### PR TITLE
[refactor] : 회원가입 API 공통 응답 구조 및 Validation 예외 상세 처리 리팩토링

### DIFF
--- a/src/main/java/com/example/basketballmatching/global/config/AppConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/AppConfig.java
@@ -1,0 +1,17 @@
+package com.example.basketballmatching.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.example.basketballmatching.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
+
+        httpSecurity
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .authorizeHttpRequests(
+                        request -> request
+                                .requestMatchers("/api/v1/**").permitAll()
+                                .anyRequest().permitAll()
+                );
+
+        return httpSecurity.build();
+    }
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/global/dto/ApiResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/dto/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(staticName = "of")
+public class ApiResponse<T> {
+
+    private final String message;
+    private final T data;
+
+}

--- a/src/main/java/com/example/basketballmatching/global/dto/CheckResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/dto/CheckResponse.java
@@ -1,0 +1,15 @@
+package com.example.basketballmatching.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class CheckResponse {
+
+    private final boolean success;
+    private final String message;
+
+
+}

--- a/src/main/java/com/example/basketballmatching/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/basketballmatching/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.example.basketballmatching.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -8,9 +8,17 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // user
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+    // validation
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
+    PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요.");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
@@ -1,14 +1,32 @@
 package com.example.basketballmatching.global.exception;
 
 import com.example.basketballmatching.global.exception.dto.ErrorResponse;
+import com.example.basketballmatching.global.exception.dto.FieldErrorDetail;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Map<String, ErrorCode> CODE_MAP = Map.of(
+            "NotBlank", INVALID_INPUT,
+            "NotNull", INVALID_INPUT,
+            "Pattern", INVALID_PATTERN,
+            "Email", INVALID_PATTERN,
+            "Past", PAST_BIRTHDAY
+    );
 
 
     @ExceptionHandler(CustomException.class)
@@ -20,6 +38,33 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(ErrorResponse.of(e.getErrorCode()), e.getErrorCode().getHttpStatus());
 
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        log.warn("MethodArgumentNotValidException 발생 : {}", e.getMessage());
+
+        List<FieldErrorDetail> details = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> FieldErrorDetail.of(
+                        error.getField(),
+                        error.getCode(),
+                        error.getDefaultMessage()
+                )).toList();
+
+        String firstCode = Optional.ofNullable(e.getBindingResult().getFieldErrors().get(0).getCode())
+                .orElse("NotBlank");
+
+        ErrorCode errorCode = map(firstCode);
+
+
+        return new ResponseEntity<>(ErrorResponse.of(errorCode, details), errorCode.getHttpStatus());
+    }
+
+    private static ErrorCode map(String validationCode) {
+        return CODE_MAP.getOrDefault(validationCode, INVALID_INPUT);
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/dto/ErrorResponse.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -14,6 +16,7 @@ public class ErrorResponse {
     private int statusCode;
     private String errorCode;
     private String errorMessage;
+    private List<FieldErrorDetail> details;
 
     public static ErrorResponse of(ErrorCode errorCode) {
 
@@ -21,6 +24,17 @@ public class ErrorResponse {
                 .statusCode(errorCode.getStatusCode())
                 .errorCode(errorCode.name())
                 .errorMessage(errorCode.getErrorMessage())
+                .build();
+
+    }
+
+    public static ErrorResponse of (ErrorCode errorCode, List<FieldErrorDetail> details) {
+
+        return ErrorResponse.builder()
+                .statusCode(errorCode.getStatusCode())
+                .errorCode(errorCode.name())
+                .errorMessage(errorCode.getErrorMessage())
+                .details(details)
                 .build();
 
     }

--- a/src/main/java/com/example/basketballmatching/global/exception/dto/FieldErrorDetail.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/dto/FieldErrorDetail.java
@@ -1,0 +1,13 @@
+package com.example.basketballmatching.global.exception.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class FieldErrorDetail {
+
+    private final String field;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.example.basketballmatching.user.controller;
 
 
+import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.user.dto.SignUpDto;
 import com.example.basketballmatching.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -12,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -21,11 +23,11 @@ public class UserController {
 
 
     @PostMapping("/signup")
-    public ResponseEntity<SignUpDto.Response> signup(
-            @RequestBody @Validated SignUpDto.Request request
+    public ResponseEntity<ApiResponse<SignUpDto.Response>> signup(
+            @RequestBody @Valid SignUpDto.Request request
             ) {
 
-        SignUpDto.Response response = userService.signUp(request);
+        ApiResponse<SignUpDto.Response> response = userService.signUp(request);
 
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -6,10 +6,9 @@ import com.example.basketballmatching.user.type.UserType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,7 +17,9 @@ public class SignUpDto {
 
 
     @Getter
+    @Setter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     public static class Request {
 
@@ -27,22 +28,24 @@ public class SignUpDto {
         private String email;
 
         @NotBlank(message = "비밀번호를 입력해주세요.")
-        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$",
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
                 message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
         private String password;
 
         @NotBlank(message = "비밀번호 확인을 입력해주세요.")
-        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$",
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
                 message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
         private String checkPassword;
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        private String nickname;
 
         @NotBlank(message = "이름을 입력해주세요.")
         private String name;
 
         @JsonFormat(
             shape = JsonFormat.Shape.STRING,
-                pattern = "yyyy-MM-dd",
-                timezone = "Asia/Seoul"
+                pattern = "yyyy-MM-dd"
         )
         private LocalDate birth;
 
@@ -50,21 +53,20 @@ public class SignUpDto {
         @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
         private String phone;
 
-        @NotBlank(message = "포지션을 입력해주세요.")
-        private String position;
+        @NotNull(message = "포지션을 입력해주세요.")
+        private Position position;
 
         public static UserEntity toEntity(SignUpDto.Request request) {
 
             return UserEntity.builder()
                     .email(request.getEmail())
                     .password(request.getPassword())
+                    .nickname(request.getNickname())
                     .name(request.getName())
                     .birth(request.getBirth())
                     .phone(request.getPhone())
-                    .position(Position.valueOf(request.getPosition()))
+                    .position(request.getPosition())
                     .userType(UserType.USER)
-                    .createdAt(LocalDateTime.now())
-                    .updatedAt(LocalDateTime.now())
                     .build();
         }
 
@@ -74,10 +76,13 @@ public class SignUpDto {
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     public static class Response {
 
         private String email;
+
+        private String nickname;
 
         private String name;
 
@@ -85,9 +90,9 @@ public class SignUpDto {
 
         private String phone;
 
-        private String position;
+        private Position position;
 
-        private String userType;
+        private UserType userType;
 
         private LocalDateTime createdAt;
 
@@ -96,6 +101,7 @@ public class SignUpDto {
             return Response.builder()
                     .email(userDto.getEmail())
                     .name(userDto.getName())
+                    .nickname(userDto.getNickname())
                     .birth(userDto.getBirth())
                     .phone(userDto.getPhone())
                     .position(userDto.getPosition())

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -1,6 +1,8 @@
 package com.example.basketballmatching.user.dto;
 
 import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,15 +21,17 @@ public class UserDto {
 
     private String password;
 
+    private String nickname;
+
     private String name;
 
     private LocalDate birth;
 
     private String phone;
 
-    private String position;
+    private Position position;
 
-    private String userType;
+    private UserType userType;
 
     private LocalDateTime createdAt;
 
@@ -40,11 +44,12 @@ public class UserDto {
                 .userId(userEntity.getUserId())
                 .email(userEntity.getEmail())
                 .password(userEntity.getPassword())
+                .nickname(userEntity.getNickname())
                 .name(userEntity.getName())
                 .birth(userEntity.getBirth())
                 .phone(userEntity.getPhone())
-                .position(String.valueOf(userEntity.getPosition()))
-                .userType(String.valueOf(userEntity.getUserType()))
+                .position(userEntity.getPosition())
+                .userType(userEntity.getUserType())
                 .createdAt(userEntity.getCreatedAt())
                 .updatedAt(userEntity.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -1,25 +1,22 @@
 package com.example.basketballmatching.user.entity;
 
+import com.example.basketballmatching.global.entity.BaseEntity;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class UserEntity {
+public class UserEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,6 +27,9 @@ public class UserEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
 
     @Column(nullable = false)
     private String name;
@@ -48,12 +48,14 @@ public class UserEntity {
     @Enumerated(EnumType.STRING)
     private UserType userType;
 
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+    @Builder.Default
+    private boolean emailAuth = false;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    public void setEmailAuth() {
+        this.emailAuth = true;
+    }
+
+
+
 
 }

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -9,6 +9,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByNickname(String nickname);
+
     Optional<UserEntity> findByEmail(String email);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/service/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.example.basketballmatching.user.service;
 
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.user.dto.SignUpDto;
 
 public interface UserService {
 
 
-    SignUpDto.Response signUp(SignUpDto.Request request);
+    ApiResponse<SignUpDto.Response> signUp(SignUpDto.Request request);
+
+
+    CheckResponse checkEmail(String email);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.basketballmatching.user.service.impl;
 
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.dto.SignUpDto;
@@ -8,37 +10,72 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.ALREADY_EXIST_EMAIL;
-import static com.example.basketballmatching.global.exception.ErrorCode.PASSWORD_NOT_MATCH;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserServiceImpl implements UserService {
+
+    private final PasswordEncoder passwordEncoder;
 
     private final UserRepository userRepository;
 
 
     @Override
     @Transactional
-    public SignUpDto.Response signUp(SignUpDto.Request request) {
+    public ApiResponse<SignUpDto.Response> signUp(SignUpDto.Request request) {
 
-        boolean exists = userRepository.existsByEmail(request.getEmail());
+        log.info("유저 회원가입 시작 : {}", request.getEmail());
 
-        if (exists) {
-            throw new CustomException(ALREADY_EXIST_EMAIL);
-        }
+        boolean existsByEmail = userRepository.existsByEmail(request.getEmail());
 
-        if (!request.getPassword().equals(request.getCheckPassword())) {
-            throw new CustomException(PASSWORD_NOT_MATCH);
-        }
+        boolean existsByNickname = userRepository.existsByNickname(request.getNickname());
+
+        validationByUser(request, existsByEmail, existsByNickname);
+
+        request.setPassword(passwordEncoder.encode(request.getPassword()));
 
         UserEntity userEntity = SignUpDto.Request.toEntity(request);
 
         userRepository.save(userEntity);
 
-        return SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity));
+        log.info("유저 회원가입 완료");
+
+        return ApiResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity)));
+    }
+
+    @Override
+    public CheckResponse checkEmail(String email) {
+
+        boolean exists = userRepository.existsByEmail(email);
+
+        if (exists) {
+            throw new CustomException(ALREADY_EXIST_EMAIL);
+        }
+
+        return CheckResponse.of(true, "사용가능한 이메일입니다.");
+    }
+
+
+
+
+    private static void validationByUser(SignUpDto.Request request, boolean existsByEmail, boolean existsByNickname) {
+        if (existsByEmail) {
+            throw new CustomException(ALREADY_EXIST_EMAIL);
+        }
+
+        if (existsByNickname) {
+            throw new CustomException(ALREADY_EXIST_NICKNAME);
+        }
+
+        if (!request.getPassword().equals(request.getCheckPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 회원가입 API 응답이 서비스마다 각각 DTO로 직접 반환
- Validation 예외 발생시 400에러 및 응답 Body가 출력되지 않음
- 각 엔티티에서 'cratedAt', 'updatedAt' 필드를 개별 정의하여 중복 발생

### 🚀 TO-BE

#### ✅ 공통 응답 구조 통일 ('ApiResponse' 적용)
- 모든 API 응답을 ApiResponse<T> 제네릭 구조로 통일
- Controller에서도 ApiResponse기반으로 응답 통일

#### ✅ Validation 예외 상세 정보 추가(FieldErrorDetail)
- @Valid, @Validated 검증 실패시 ExceptionHandler에서 MethodArgumentNotValidException 처리
- 예외 발생 시 상태코드와 함께 필드별 오류를 담은 리스트 형태로 응답

#### ✅ 공통 엔티티 기반 클래스 추가
- createdAt, updatedAt 필드를 BaseEntity로 통합 관리
- JpaAuditing 적용
- 모든 엔티티 BaseEntity를 상속받아 중복코드 제거 예정

---

## ✅ 체크리스트
- [x] UserService -> ApiRespose 적용
- [x] Validation 예외처리 ExceptionHandler에 추가
- [x] BaseEntity 구현


---
