### PR TITLE
[feat] : 유저 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -1,0 +1,45 @@
+package com.example.basketballmatching.auth.controller;
+
+
+import com.example.basketballmatching.auth.dto.LoginDto;
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.user.dto.UserDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/user")
+@RequiredArgsConstructor
+public class AuthController {
+
+
+
+    private final AuthService authService;
+
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenDto>> loginUser(
+            @RequestBody @Valid LoginDto.Request request
+    ) {
+
+        TokenDto token = authService.loginUser(request.getEmail(), request.getPassword());
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.of("로그인에 성공하였습니다.", token));
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
@@ -1,0 +1,36 @@
+package com.example.basketballmatching.auth.dto;
+
+import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class LoginDto {
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class Request {
+
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식으로 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
+                message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+        private String password;
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/dto/TokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.auth.dto;
+
+
+import com.example.basketballmatching.user.dto.UserDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenDto {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private UserDto userDto;
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.example.basketballmatching.auth.service;
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+
+public interface AuthService {
+
+    TokenDto loginUser(String email, String password);
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,58 @@
+package com.example.basketballmatching.auth.service.impl;
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.security.TokenProvider;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.PASSWORD_NOT_MATCH;
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final TokenProvider tokenProvider;
+
+
+    @Override
+    @Transactional
+    public TokenDto loginUser(String email, String password) {
+
+        log.info("유저 로그인 시작: {}", email);
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(password, userEntity.getPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+
+        String accessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+        log.info("accessToken 생성 완료.");
+
+        String refreshToken = tokenProvider.createRefreshToken(userDto.getEmail());
+        log.info("refreshToken 생성 완료");
+
+
+        return new TokenDto(accessToken, refreshToken, userDto);
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.global.config;
 
+import com.example.basketballmatching.global.security.AuthentificationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,11 +9,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+
+    private final AuthentificationFilter authentificationFilter;
 
     @Bean
     protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
@@ -22,9 +27,18 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer::disable)
                 .authorizeHttpRequests(
                         request -> request
-                                .requestMatchers("/api/v1/**").permitAll()
-                                .anyRequest().permitAll()
-                );
+                                .requestMatchers(
+                                        "/api/v1/user/signup",
+                                        "/api/v1/user/check-email",
+                                        "/api/v1/user/check-nickname",
+                                        "/api/v1/user/send-mail",
+                                        "/api/v1/user/verify-mail",
+                                        "/api/v1/user/login"
+
+                                ).permitAll()
+                                .anyRequest().authenticated()
+                )
+                .addFilterBefore(authentificationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -8,6 +8,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // jwt
+    // JWT
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 갱신해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
 

--- a/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
+++ b/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
@@ -1,0 +1,103 @@
+package com.example.basketballmatching.global.security;
+
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthentificationFilter  extends OncePerRequestFilter {
+
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolvedTokenRequest(request);
+
+        try {
+
+            if (token == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            if (tokenProvider.validateToken(token)) {
+
+                Authentication authentication = tokenProvider.getAuthentication(token);
+
+                log.info("인증 객체 principal: {}", authentication.getPrincipal());
+
+                if (authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+
+
+                filterChain.doFilter(request, response);
+
+            }
+
+        } catch (CustomException e) {
+            log.warn("JWT 검증 실패: {}", e.getErrorCode().getErrorMessage());
+            setErrorResponse(response, e.getErrorCode());
+            return;
+
+        } catch (Exception e) {
+            log.error("INTERNAL SERVER ERROR 발생: {}", e.getMessage());
+            setErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+
+
+    }
+
+    private String resolvedTokenRequest(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length()).trim();
+        }
+
+
+        return null;
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(errorCode.getStatusCode());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String errorMessage = objectMapper.writeValueAsString(
+                Map.of("statusCode", errorCode.getStatusCode(),
+                        "errorCode", errorCode.name(), "errorMessage", errorCode.getErrorMessage()
+                )
+        );
+
+        response.getWriter().write(errorMessage);
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -1,0 +1,172 @@
+package com.example.basketballmatching.global.security;
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.type.UserType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @Value("${spring.jwt.access-token-expiration}")
+    private Long access_token_expire;
+
+    @Value("${spring.jwt.refresh-token-expiration}")
+    private Long refresh_token_expire;
+
+
+    private final UserInfoDetailsService userInfoDetailsService;
+
+    private final RedisService redisService;
+
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Decoders.BASE64.decode(secretKey);
+
+        this.key = Keys.hmacShaKeyFor(bytes);
+    }
+
+
+    public String createAccessToken(String email, String name, UserType userType) {
+
+        log.info("accessToken 생성 시작");
+
+        String accessToken = generateAccessToken(email, name, userType, access_token_expire);
+
+        return accessToken;
+
+
+    }
+
+    public String createRefreshToken(String email) {
+
+        log.info("refreshToken 생성 시작");
+
+        String refreshToken = generateRefreshToken(email, refresh_token_expire);
+
+
+
+        redisService.setDataExpireMillis("refreshToken:" + email, refreshToken, refresh_token_expire);
+
+        return refreshToken;
+
+
+    }
+
+    public Claims parseToken(String token) {
+
+        try {
+
+            log.info("토큰 파싱 시작");
+
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            log.error("토큰 파싱 오류 : {}", e.getMessage());
+
+            return e.getClaims();
+        }
+
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        UserDetails userDetails = userInfoDetailsService.loadUserByUsername(getEmailFromToken(token));
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities()
+        );
+    }
+
+    public boolean validateToken(String token) {
+
+        try {
+
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            return !claims.getBody().getExpiration().before(new Date());
+
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw new CustomException(UNSUPPORTED_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(EXPIRED_TOKEN);
+        } catch (JwtException e) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+    }
+
+    public String getEmailFromToken(String token) {
+        return parseToken(token).getSubject();
+    }
+
+
+
+    private String generateAccessToken(String email, String name, UserType userType, long access_token_expire) {
+
+        Claims claims = Jwts.claims().setSubject(email);
+
+        claims.put("name", name);
+        claims.put("userType", String.valueOf(userType));
+
+
+        return returnToken(claims, access_token_expire);
+
+    }
+
+    private String generateRefreshToken(String email, long refresh_token_expire) {
+
+        Claims claims = Jwts.claims().setSubject(email);
+
+
+        return returnToken(claims, refresh_token_expire);
+
+    }
+
+    private String returnToken(Claims claims, long expireTime) {
+
+        var now = new Date();
+
+        var expireDate = new Date(now.getTime() + expireTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(key)
+                .compact();
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/global/security/UserInfoDetails.java
+++ b/src/main/java/com/example/basketballmatching/global/security/UserInfoDetails.java
@@ -1,0 +1,54 @@
+package com.example.basketballmatching.global.security;
+
+import com.example.basketballmatching.user.entity.UserEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class UserInfoDetails implements UserDetails {
+
+    private final UserEntity userEntity;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(this.userEntity.getUserType().getDescription()));
+    }
+
+    @Override
+    public String getPassword() {
+        return this.userEntity.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return this.userEntity.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.userEntity.isEmailAuth();
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
+++ b/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
@@ -1,0 +1,31 @@
+package com.example.basketballmatching.global.security;
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@Getter
+@RequiredArgsConstructor
+public class UserInfoDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        return new UserInfoDetails(userEntity);
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/service/RedisService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/RedisService.java
@@ -19,6 +19,14 @@ public class RedisService {
         valueOperations.set(key, value, Duration.ofMinutes(expiredTime));
     }
 
+    public void setDataExpireMillis(String key, String value, Long expiredTime) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        valueOperations.set(key, value, Duration.ofMillis(expiredTime));
+
+    }
+
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
     }
 
-    @PostMapping("send-mail")
+    @PostMapping("/send-mail")
     public ResponseEntity<CheckResponse> sendMailAuth(
             @RequestParam String email
     ) {
@@ -63,7 +63,7 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
     }
 
-    @PostMapping("verify-mail")
+    @PostMapping("/verify-mail")
     public ResponseEntity<CheckResponse> verifyEmailAuth(
             @RequestBody VerifyEmailDto request
             ) {

--- a/src/main/java/com/example/basketballmatching/user/type/UserType.java
+++ b/src/main/java/com/example/basketballmatching/user/type/UserType.java
@@ -1,7 +1,14 @@
 package com.example.basketballmatching.user.type;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum UserType {
 
-    USER, ADMIN
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
 
+    private final String description;
 }

--- a/src/test/java/com/example/basketballmatching/BasketballMatchingApplicationTests.java
+++ b/src/test/java/com/example/basketballmatching/BasketballMatchingApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class BasketballMatchingApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+//        @Test
+//        void contextLoads() {
+//        }
 
 }

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.example.basketballmatching.auth.service.impl;
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AuthServiceImplTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        // given: 테스트용 유저 데이터 삽입
+        UserEntity user = UserEntity.builder()
+                .email("test@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("name")
+                .nickname("name")
+                .birth(LocalDate.of(1997,7,24))
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    void loginUser_Success() {
+        // given
+
+        TokenDto tokenDto = authService.loginUser("test@example.com", "Test1234!");
+
+        // when
+
+        // then
+
+        assertThat(tokenDto.getAccessToken()).isNotBlank();
+        assertThat(tokenDto.getRefreshToken()).isNotBlank();
+        assertThat(tokenDto.getUserDto().getEmail()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 테스트")
+    void loginUser_PasswordNotMatch() {
+        // given
+
+        // when
+
+        // then
+
+        CustomException exception = assertThrows(CustomException.class, () ->
+                authService.loginUser("test@example.com", "Test@123111!"));
+
+
+        assertEquals(ErrorCode.PASSWORD_NOT_MATCH, exception.getErrorCode());
+
+    }
+
+
+}

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -1,11 +1,16 @@
 package com.example.basketballmatching.user.service.impl;
 
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.MailService;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.SignUpDto;
-import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.service.UserService;
+import com.example.basketballmatching.user.type.Position;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 
 
 @SpringBootTest
@@ -28,6 +36,15 @@ class UserServiceImplTest {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private MailService mailService;
+
+    @Autowired
+    private RedisService redisService;
+
+
+
     @Test
     @DisplayName("회원가입 테스트")
     void signUpTest() {
@@ -37,20 +54,122 @@ class UserServiceImplTest {
                 .email("test@test.com")
                 .password("Test@123")
                 .checkPassword("Test@123")
+                .nickname("JI")
                 .name("test")
                 .phone("010-1111-1111")
                 .birth(LocalDate.now())
-                .position("GUARD")
+                .position(Position.GUARD)
                 .build();
         // when
 
-        SignUpDto.Response response = userService.signUp(request);
-
-        UserEntity userEntity = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        ApiResponse<SignUpDto.Response> response = userService.signUp(request);
         // then
 
-        assertEquals(response.getEmail(), userEntity.getEmail());
+        assertEquals("회원가입에 성공하였습니다.", response.getMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("중복 이메일 확인")
+    void NotValidEmail() {
+        // given
+        SignUpDto.Request request1 = SignUpDto.Request.builder()
+                .email("test@naver.com")
+                .password("Test@123")
+                .checkPassword("Test@123")
+                .nickname("JI")
+                .name("test")
+                .phone("010-1111-1111")
+                .birth(LocalDate.now())
+                .position(Position.GUARD)
+                .build();
+
+        SignUpDto.Request request2 = SignUpDto.Request.builder()
+                .email("test@naver.com")
+                .password("Test@123")
+                .checkPassword("Test@123")
+                .nickname("JI1234")
+                .name("test4")
+                .phone("010-1111-2222")
+                .birth(LocalDate.now())
+                .position(Position.GUARD)
+                .build();
+
+        userService.signUp(request1);
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            userService.signUp(request2);
+        });
+
+
+        // then
+
+        assertEquals(ErrorCode.ALREADY_EXIST_EMAIL, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("이메일 전송 확인 테스트")
+    void sendMailTest() {
+        // given
+
+        mailService.sendAuthMail("rwg1279@naver.com");
+
+        String data = redisService.getData("email:auth:" + "rwg1279@naver.com");
+
+
+        // when
+
+        CheckResponse checkResponse = mailService.verifyEmailAuth("rwg1279@naver.com", data);
+
+        SignUpDto.Request request1 = SignUpDto.Request.builder()
+                .email("rwg1279@naver.com")
+                .password("Test@123")
+                .checkPassword("Test@123")
+                .nickname("JI")
+                .name("test")
+                .phone("010-1111-1111")
+                .birth(LocalDate.now())
+                .position(Position.GUARD)
+                .build();
+
+        userService.signUp(request1);
+
+        // then
+
+        assertEquals("이메일 인증에 성공하였습니다.", checkResponse.getMessage());
+
+        assertEquals(null, redisService.getData("email:auth:verified:" + request1.getEmail()));
+
+    }
+
+    @Test
+    @DisplayName("이메일 인증 없이 회원가입 시도 시 예외 발생")
+    void signUpWithoutEmailVerification() {
+        // given
+
+        SignUpDto.Request request1 = SignUpDto.Request.builder()
+                .email("rwg1279@naver.com")
+                .password("Test@123")
+                .checkPassword("Test@123")
+                .nickname("JI")
+                .name("test")
+                .phone("010-1111-1111")
+                .birth(LocalDate.now())
+                .position(Position.GUARD)
+                .build();
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.signUp(request1));
+
+        // then
+
+        assertEquals(ErrorCode.EMAIL_NOT_VERIFIED, exception.getErrorCode());
 
     }
 


### PR DESCRIPTION
## ✨ 변경 사항 

### 📌 AS-IS  
- 로그인 API 미구현  
- 인증 구조 및 토큰 발급 로직 부재  
- 유저 검증 시 비밀번호 일치 여부 확인 불가  

---

### 🚀 TO-BE  
#### ✅ JWT 기반 로그인 API 구현  
- AuthController / AuthServiceImpl 추가
   - 이메일, 비밀번호 검증 후 Access/Refresh Token 생성  
   - 로그인 성공 시 `Authorization` 헤더에 AccessToken 포함  
   - 응답 바디에 `accessToken`, `refreshToken`, `userDto` 반환  

- TokenProvider 구현
   - AccessToken: 이메일, 이름, 권한(UserType) Claims 포함  
   - RefreshToken: Redis 저장소에 `refreshToken:{email}` 키로 저장  
   - AccessToken 유효시간 30분, RefreshToken 유효시간 14일  

- AuthentificationFilter 추가
   - 매 요청마다 JWT 검증 및 SecurityContext 등록  
   - 토큰 유효성 검증 실패 시 CustomException 처리  

- SecurityConfig 수정
   - `/api/v1/user/login`, `/signup`, `/check-email`, `/verify-mail` 등 `permitAll` 처리  
   - `AuthentificationFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 등록  

---
## ✅ 체크리스트
- [x] API 테스트
- [x] AccessToken/RefreshToken 정상 생성 
- [x] RefreshToken Redis에 저장 확인
- [x] JWT 필터 정상 작동 및 인증 객체 등록 확인
