### PR TITLE
[feat] : 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.controller;
 
 
 import com.example.basketballmatching.auth.dto.LoginDto;
+import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
@@ -39,6 +40,23 @@ public class AuthController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(ApiResponse.of("로그인에 성공하였습니다.", token));
+
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenDto>> reissue(
+            @RequestBody @Valid ReIssueTokenDto request
+            ) {
+
+        TokenDto reissueToken = authService.reissue(request.getEmail(), request.getRefreshToken());
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + reissueToken.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
 
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReIssueTokenDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -6,4 +6,6 @@ public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
+    TokenDto reissue(String email, String refreshToken);
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
@@ -13,8 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.PASSWORD_NOT_MATCH;
-import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,8 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
 
     private final TokenProvider tokenProvider;
+
+    private final RedisService redisService;
 
 
     @Override
@@ -52,6 +54,42 @@ public class AuthServiceImpl implements AuthService {
 
 
         return new TokenDto(accessToken, refreshToken, userDto);
+    }
+
+    @Override
+    public TokenDto reissue(String email, String refreshToken) {
+
+        log.info("토큰 재발급 시작: {}", email);
+
+        String redisToken = redisService.getData("refreshToken:" + email);
+
+
+        if (redisToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        if (!redisToken.equals(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
+
+        if (!userEmail.equals(email)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // refreshToken 검증
+        tokenProvider.validateRefreshToken(refreshToken);
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        String reissuedAccessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+
+
+        return new TokenDto(reissuedAccessToken, redisToken, userDto);
     }
 
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                                         "/api/v1/user/check-nickname",
                                         "/api/v1/user/send-mail",
                                         "/api/v1/user/verify-mail",
-                                        "/api/v1/user/login"
+                                        "/api/v1/user/login",
+                                        "/api/v1/user/reissue"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -168,5 +168,21 @@ public class TokenProvider {
                 .compact();
     }
 
+    public void validateRefreshToken(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        Claims claims = parseToken(refreshToken);
+
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(EXPIRED_TOKEN);
+        }
+
+    }
+
+
+
 
 }

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -4,11 +4,11 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
@@ -36,6 +37,9 @@ class AuthServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private RedisService redisService;
+
     @BeforeEach
     void setUp() {
         // given: 테스트용 유저 데이터 삽입
@@ -49,6 +53,8 @@ class AuthServiceImplTest {
                 .position(Position.GUARD)
                 .userType(UserType.USER)
                 .build();
+
+        user.setEmailAuth();
 
         userRepository.save(user);
     }
@@ -84,6 +90,57 @@ class AuthServiceImplTest {
 
         assertEquals(ErrorCode.PASSWORD_NOT_MATCH, exception.getErrorCode());
 
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 테스트")
+    void reissueTokenTest() {
+        // given
+
+        authService.loginUser("test@example.com", "Test1234!");
+
+
+        // when
+        String email = "test@example.com";
+
+        TokenDto reissue = authService.reissue(email, redisService.getData("refreshToken:" + email));
+
+
+        // then
+
+        assertThat(reissue.getAccessToken()).isNotBlank();
+        assertThat(reissue.getRefreshToken()).isNotBlank();
+        assertEquals(email, reissue.getUserDto().getEmail());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - 토큰 불일치")
+    void reissueToken_Invalid_Token() {
+        // given
+
+        String email = "test@example.com";
+
+        authService.loginUser(email, "Test1234!");
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> authService.reissue(email, "awdwadwadwadwadwadwadasfdsgdfgfdgfd"));
+
+        // then
+
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - Redis에 토큰이 없는 경우")
+    void reissueToken_NOT_FOUND_TOKEN() {
+        // given
+        String email = "tes@example.com";
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.reissue(email, null));
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_TOKEN, exception.getErrorCode());
     }
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- AccessToken 만료 시 RefreshToken을 이용해 재발급 로직 미구현

### 🚀 TO-BE
✅ 토큰 재발급 로직 구현
- Redis에 저장된 'refreshToken' 기반으로 AccessToken을 재발급 하도록 구현
- 요청으로 전달받은 'refreshToken'과 redis 저장값 비교 후 재발급 진해
- RefreshToken은 재발급하지 않고 기존값을 그대로 반환.

---

## ✅ 체크리스트
- [x] AccessToken / RefreshToken 재발급 기능 구현 완료
- [x] Redis 기반 토큰 검증 로직 추가
- [x] 테스트 코드 작성


---
