### PR TITLE
[feat] : 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -6,15 +6,17 @@ import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.user.dto.UserDto;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/user")
@@ -57,6 +59,24 @@ public class AuthController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
+
+    }
+
+    @PatchMapping("/logout")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> logoutUser(
+            HttpServletRequest request, @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        String accessToken = request.getHeader("Authorization");
+
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+
+        CheckResponse checkResponse = authService.logoutUser(userInfoDetails.getUsername(), accessToken);
+
+        return ResponseEntity.ok(checkResponse);
 
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.controller;
 
 
 import com.example.basketballmatching.auth.dto.LoginDto;
+import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
@@ -39,6 +40,23 @@ public class AuthController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(ApiResponse.of("로그인에 성공하였습니다.", token));
+
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenDto>> reissue(
+            @RequestBody @Valid ReIssueTokenDto request
+            ) {
+
+        TokenDto reissueToken = authService.reissue(request.getEmail(), request.getRefreshToken());
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + reissueToken.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
 
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReIssueTokenDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -6,4 +6,6 @@ public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
+    TokenDto reissue(String email, String refreshToken);
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -1,11 +1,14 @@
 package com.example.basketballmatching.auth.service;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.global.dto.CheckResponse;
 
 public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
     TokenDto reissue(String email, String refreshToken);
+
+    CheckResponse logoutUser(String email, String token);
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
@@ -13,8 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.PASSWORD_NOT_MATCH;
-import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,8 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
 
     private final TokenProvider tokenProvider;
+
+    private final RedisService redisService;
 
 
     @Override
@@ -52,6 +54,42 @@ public class AuthServiceImpl implements AuthService {
 
 
         return new TokenDto(accessToken, refreshToken, userDto);
+    }
+
+    @Override
+    public TokenDto reissue(String email, String refreshToken) {
+
+        log.info("토큰 재발급 시작: {}", email);
+
+        String redisToken = redisService.getData("refreshToken:" + email);
+
+
+        if (redisToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        if (!redisToken.equals(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
+
+        if (!userEmail.equals(email)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // refreshToken 검증
+        tokenProvider.validateRefreshToken(refreshToken);
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        String reissuedAccessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+
+
+        return new TokenDto(reissuedAccessToken, redisToken, userDto);
     }
 
 

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.service.impl;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
 import com.example.basketballmatching.global.service.RedisService;
@@ -34,7 +35,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenDto loginUser(String email, String password) {
 
-        log.info("유저 로그인 시작: {}", email);
+        log.info("[유저 로그인 시작]: {}", email);
 
         UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -59,7 +60,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public TokenDto reissue(String email, String refreshToken) {
 
-        log.info("토큰 재발급 시작: {}", email);
+        log.info("[토큰 재발급 시작]: {}", email);
 
         String redisToken = redisService.getData("refreshToken:" + email);
 
@@ -90,6 +91,25 @@ public class AuthServiceImpl implements AuthService {
 
 
         return new TokenDto(reissuedAccessToken, redisToken, userDto);
+    }
+
+    @Override
+    public CheckResponse logoutUser(String email, String token) {
+
+        log.info("[유저 로그아웃 시작] : {}", email);
+
+        if (token == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        redisService.setDataExpireMillis("logout:access:" + token, "LOGOUT",tokenProvider.getRemainingTime(token));
+
+        redisService.deleteData("refreshToken:" + email);
+
+
+        log.info("[유저 로그아웃 완료] : {}", email);
+
+        return CheckResponse.of(true, "로그아웃 완료되었습니다.");
     }
 
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.global.security.AuthentificationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                                         "/api/v1/user/check-nickname",
                                         "/api/v1/user/send-mail",
                                         "/api/v1/user/verify-mail",
-                                        "/api/v1/user/login"
+                                        "/api/v1/user/login",
+                                        "/api/v1/user/reissue"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해주세요."),
     INVALID_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
+    LOGOUT_USER(HttpStatus.BAD_REQUEST, "로그아웃 유저입니다"),
     // validation
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),

--- a/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
+++ b/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
@@ -21,6 +21,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -29,22 +31,41 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
     public static final String TOKEN_HEADER = "Authorization";
     public static final String TOKEN_PREFIX = "Bearer ";
 
+
     private final TokenProvider tokenProvider;
 
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String token = resolvedTokenRequest(request);
 
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = tokenProvider.parseToken(token).getSubject();
+
+
+
+
         try {
 
-            if (token == null) {
-                filterChain.doFilter(request, response);
-                return;
-            }
+
 
             if (tokenProvider.validateToken(token)) {
+
+                String logoutToken = redisService.getData("logout:access:" + token);
+
+
+                if (logoutToken != null) {
+                    log.warn("[로그아웃 유저 접근]: {}", email );
+
+                    setErrorResponse(response, LOGOUT_USER);
+                    return;
+                }
 
                 Authentication authentication = tokenProvider.getAuthentication(token);
 
@@ -63,14 +84,13 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
             log.warn("JWT 검증 실패: {}", e.getErrorCode().getErrorMessage());
             setErrorResponse(response, e.getErrorCode());
             return;
-
         } catch (Exception e) {
             log.error("INTERNAL SERVER ERROR 발생: {}", e.getMessage());
-            setErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR);
+            setErrorResponse(response, INTERNAL_SERVER_ERROR);
             return;
         }
 
-        filterChain.doFilter(request, response);
+
 
 
     }

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -183,6 +183,12 @@ public class TokenProvider {
     }
 
 
+    public long getRemainingTime(String token) {
+
+        return parseToken(token).getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -168,5 +168,21 @@ public class TokenProvider {
                 .compact();
     }
 
+    public void validateRefreshToken(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        Claims claims = parseToken(refreshToken);
+
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(EXPIRED_TOKEN);
+        }
+
+    }
+
+
+
 
 }

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.service.impl;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.global.service.RedisService;
@@ -141,6 +142,26 @@ class AuthServiceImplTest {
                 () -> authService.reissue(email, null));
         // then
         assertEquals(ErrorCode.NOT_FOUND_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 테스트")
+    void logoutTest() {
+        // given
+
+        String email = "test@example.com";
+
+        TokenDto tokenDto = authService.loginUser(email, "Test1234!");
+
+        // when
+
+        CheckResponse checkResponse = authService.logoutUser(email, tokenDto.getAccessToken());
+
+        // then
+
+        assertEquals("로그아웃 완료되었습니다.", checkResponse.getMessage());
+
+
     }
 
 

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -4,11 +4,11 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
@@ -36,6 +37,9 @@ class AuthServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private RedisService redisService;
+
     @BeforeEach
     void setUp() {
         // given: 테스트용 유저 데이터 삽입
@@ -49,6 +53,8 @@ class AuthServiceImplTest {
                 .position(Position.GUARD)
                 .userType(UserType.USER)
                 .build();
+
+        user.setEmailAuth();
 
         userRepository.save(user);
     }
@@ -84,6 +90,57 @@ class AuthServiceImplTest {
 
         assertEquals(ErrorCode.PASSWORD_NOT_MATCH, exception.getErrorCode());
 
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 테스트")
+    void reissueTokenTest() {
+        // given
+
+        authService.loginUser("test@example.com", "Test1234!");
+
+
+        // when
+        String email = "test@example.com";
+
+        TokenDto reissue = authService.reissue(email, redisService.getData("refreshToken:" + email));
+
+
+        // then
+
+        assertThat(reissue.getAccessToken()).isNotBlank();
+        assertThat(reissue.getRefreshToken()).isNotBlank();
+        assertEquals(email, reissue.getUserDto().getEmail());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - 토큰 불일치")
+    void reissueToken_Invalid_Token() {
+        // given
+
+        String email = "test@example.com";
+
+        authService.loginUser(email, "Test1234!");
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> authService.reissue(email, "awdwadwadwadwadwadwadasfdsgdfgfdgfd"));
+
+        // then
+
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - Redis에 토큰이 없는 경우")
+    void reissueToken_NOT_FOUND_TOKEN() {
+        // given
+        String email = "tes@example.com";
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.reissue(email, null));
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_TOKEN, exception.getErrorCode());
     }
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 유저 로그아웃 기능 미구현

### 🚀 TO-BE
✅ 로그아웃 기능 구현
- AccessToken 무효화 처리
   - Redis에 logout:access:{token} 형태로 현재 사용중인 AccessToken 저장
   - 토큰을 이용하여 접근 시 AuthentificationFilter에서 Redis에 logout:access 존재하면 접근 차단
   - LOGOUT_USER 에러코드 응답

---

## ✅ 체크리스트
- [x] 로그아웃 API 구현
- [x] 인증 필터에서 로그아웃 유저 차단 로직 추가
- [x] 테스트 코드 작성
- [x] API 테스트 완료

---
