### PR TITLE
[feat] : 회원 정보 조회, 수정 및 비밀번호 변경/재설정 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -6,15 +6,17 @@ import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.user.dto.UserDto;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/user")
@@ -57,6 +59,24 @@ public class AuthController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
+
+    }
+
+    @PatchMapping("/logout")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> logoutUser(
+            HttpServletRequest request, @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        String accessToken = request.getHeader("Authorization");
+
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+
+        CheckResponse checkResponse = authService.logoutUser(userInfoDetails.getUsername(), accessToken);
+
+        return ResponseEntity.ok(checkResponse);
 
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.controller;
 
 
 import com.example.basketballmatching.auth.dto.LoginDto;
+import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
@@ -39,6 +40,23 @@ public class AuthController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(ApiResponse.of("로그인에 성공하였습니다.", token));
+
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenDto>> reissue(
+            @RequestBody @Valid ReIssueTokenDto request
+            ) {
+
+        TokenDto reissueToken = authService.reissue(request.getEmail(), request.getRefreshToken());
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + reissueToken.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
 
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReIssueTokenDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -6,4 +6,6 @@ public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
+    TokenDto reissue(String email, String refreshToken);
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -1,11 +1,14 @@
 package com.example.basketballmatching.auth.service;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.global.dto.CheckResponse;
 
 public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
     TokenDto reissue(String email, String refreshToken);
+
+    CheckResponse logoutUser(String email, String token);
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
@@ -13,8 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.PASSWORD_NOT_MATCH;
-import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,8 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
 
     private final TokenProvider tokenProvider;
+
+    private final RedisService redisService;
 
 
     @Override
@@ -52,6 +54,42 @@ public class AuthServiceImpl implements AuthService {
 
 
         return new TokenDto(accessToken, refreshToken, userDto);
+    }
+
+    @Override
+    public TokenDto reissue(String email, String refreshToken) {
+
+        log.info("토큰 재발급 시작: {}", email);
+
+        String redisToken = redisService.getData("refreshToken:" + email);
+
+
+        if (redisToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        if (!redisToken.equals(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
+
+        if (!userEmail.equals(email)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // refreshToken 검증
+        tokenProvider.validateRefreshToken(refreshToken);
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        String reissuedAccessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+
+
+        return new TokenDto(reissuedAccessToken, redisToken, userDto);
     }
 
 

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.service.impl;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
 import com.example.basketballmatching.global.service.RedisService;
@@ -34,7 +35,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenDto loginUser(String email, String password) {
 
-        log.info("유저 로그인 시작: {}", email);
+        log.info("[유저 로그인 시작]: {}", email);
 
         UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -59,7 +60,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public TokenDto reissue(String email, String refreshToken) {
 
-        log.info("토큰 재발급 시작: {}", email);
+        log.info("[토큰 재발급 시작]: {}", email);
 
         String redisToken = redisService.getData("refreshToken:" + email);
 
@@ -90,6 +91,25 @@ public class AuthServiceImpl implements AuthService {
 
 
         return new TokenDto(reissuedAccessToken, redisToken, userDto);
+    }
+
+    @Override
+    public CheckResponse logoutUser(String email, String token) {
+
+        log.info("[유저 로그아웃 시작] : {}", email);
+
+        if (token == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        redisService.setDataExpireMillis("logout:access:" + token, "LOGOUT",tokenProvider.getRemainingTime(token));
+
+        redisService.deleteData("refreshToken:" + email);
+
+
+        log.info("[유저 로그아웃 완료] : {}", email);
+
+        return CheckResponse.of(true, "로그아웃 완료되었습니다.");
     }
 
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.global.security.AuthentificationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                                         "/api/v1/user/check-nickname",
                                         "/api/v1/user/send-mail",
                                         "/api/v1/user/verify-mail",
-                                        "/api/v1/user/login"
+                                        "/api/v1/user/login",
+                                        "/api/v1/user/reissue"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해주세요."),
     INVALID_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
+    LOGOUT_USER(HttpStatus.BAD_REQUEST, "로그아웃 유저입니다"),
     // validation
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),

--- a/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
+++ b/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
@@ -21,6 +21,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -29,22 +31,41 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
     public static final String TOKEN_HEADER = "Authorization";
     public static final String TOKEN_PREFIX = "Bearer ";
 
+
     private final TokenProvider tokenProvider;
 
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String token = resolvedTokenRequest(request);
 
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = tokenProvider.parseToken(token).getSubject();
+
+
+
+
         try {
 
-            if (token == null) {
-                filterChain.doFilter(request, response);
-                return;
-            }
+
 
             if (tokenProvider.validateToken(token)) {
+
+                String logoutToken = redisService.getData("logout:access:" + token);
+
+
+                if (logoutToken != null) {
+                    log.warn("[로그아웃 유저 접근]: {}", email );
+
+                    setErrorResponse(response, LOGOUT_USER);
+                    return;
+                }
 
                 Authentication authentication = tokenProvider.getAuthentication(token);
 
@@ -63,14 +84,13 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
             log.warn("JWT 검증 실패: {}", e.getErrorCode().getErrorMessage());
             setErrorResponse(response, e.getErrorCode());
             return;
-
         } catch (Exception e) {
             log.error("INTERNAL SERVER ERROR 발생: {}", e.getMessage());
-            setErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR);
+            setErrorResponse(response, INTERNAL_SERVER_ERROR);
             return;
         }
 
-        filterChain.doFilter(request, response);
+
 
 
     }

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -183,6 +183,12 @@ public class TokenProvider {
     }
 
 
+    public long getRemainingTime(String token) {
+
+        return parseToken(token).getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -168,5 +168,21 @@ public class TokenProvider {
                 .compact();
     }
 
+    public void validateRefreshToken(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        Claims claims = parseToken(refreshToken);
+
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(EXPIRED_TOKEN);
+        }
+
+    }
+
+
+
 
 }

--- a/src/main/java/com/example/basketballmatching/global/service/MailService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/MailService.java
@@ -2,6 +2,8 @@ package com.example.basketballmatching.global.service;
 
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,8 @@ public class MailService {
     private final JavaMailSender javaMailSender;
 
     private final RedisService redisService;
+
+    private final UserRepository userRepository;
 
     private static final Long EMAIL_TOKEN_EXPIRE = 3L;
 
@@ -75,6 +79,56 @@ public class MailService {
         }
 
         return CheckResponse.of(true, "이메일 인증번호가 전송되었습니다.");
+
+    }
+
+    @Transactional
+    public CheckResponse sendPasswordAuthCode(String email) {
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String code = createRandomCode();
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
+
+
+        try {
+            log.info("이메일 인증번호 전송 시작 : {}", userEntity.getEmail());
+
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("비밀번호 찾기 인증번호입니다.");
+
+            String msg = "<div style='margin:20px'>" +
+                    "<h1> 안녕하세요 농구 매칭 서비스입니다. </h1>" +
+                    "<br/>" +
+                    "<p>아래 코드를 입력해주세요.</p>" +
+                    "<br/>" +
+                    "<div align='center' style='border:1px solid black; font-family:verdana';>" +
+                    "<h3 style='color:blue;'>회원가입 인증번호입니다.</h3>" +
+                    "<div style='font-size:130%'>" +
+                    "CODE : <strong>" + code + "</strong></div>" +
+                    "<br/>" +
+                    "</div>";
+
+            mimeMessageHelper.setText(msg, true);
+
+            javaMailSender.send(mimeMessage);
+
+            redisService.setDataExpireMinutes("password:auth:" + email, code, EMAIL_TOKEN_EXPIRE);
+
+
+
+            log.info("이메일 인증번호 전송완료.");
+
+        } catch (MessagingException e) {
+            log.error("이메일 전송 오류 : {}", e.getMessage());
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
+        return CheckResponse.of(true, "인증번호가 전송되었습니다.");
 
     }
 

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -4,13 +4,15 @@ package com.example.basketballmatching.user.controller;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.VerifyEmailDto;
+import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.global.service.MailService;
-import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.dto.*;
 import com.example.basketballmatching.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -73,5 +75,73 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
 
     }
+
+    @GetMapping("/user-info")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<UserDto>> getUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails) {
+
+        ApiResponse<UserDto> userInfo = userService.getUserInfo(userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(userInfo);
+
+    }
+
+    @PatchMapping("/edit-info")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<UserDto>> editUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails, @RequestBody @Valid EditUserDto editUserDto) {
+
+        Long userId = userInfoDetails.getUserEntity().getUserId();
+
+        ApiResponse<UserDto> response = userService.editUserInfo(userId, editUserDto);
+
+        return ResponseEntity.ok(response);
+
+    }
+
+    @PostMapping("/password/send-auth")
+    public ResponseEntity<CheckResponse> sendPasswordAuthCode(
+            @RequestParam String email
+    ) {
+
+        CheckResponse checkResponse = mailService.sendPasswordAuthCode(email);
+
+        return ResponseEntity.ok(checkResponse);
+
+    }
+
+    @PostMapping("/password/verify-code")
+    public ResponseEntity<CheckResponse> verifyPasswordCode(
+            @RequestBody VerifyEmailDto request
+    ) {
+
+        CheckResponse checkResponse = userService.verifyPasswordCode(request.getEmail(), request.getCode());
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+    @PatchMapping("/password/reset")
+    public ResponseEntity<CheckResponse> resetPassword(
+            @RequestBody @Valid ResetPasswordDto request
+            ) {
+
+        CheckResponse checkResponse = userService.resetPassword(request.getEmail(), request.getPassword(), request.getCheckPassword());
+
+
+        return ResponseEntity.ok(checkResponse);
+
+    }
+
+    @PreAuthorize("hasAnyRole('USER')")
+    @PatchMapping("/password/change")
+    public ResponseEntity<CheckResponse> changePassword(
+            @RequestBody @Valid ChangePasswordDto request, @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        CheckResponse checkResponse = userService.changePassword(userInfoDetails.getUserEntity().getUserId(), request);
+
+        return ResponseEntity.ok(checkResponse);
+
+    }
+
 
 }

--- a/src/main/java/com/example/basketballmatching/user/dto/ChangePasswordDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/ChangePasswordDto.java
@@ -1,0 +1,27 @@
+package com.example.basketballmatching.user.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChangePasswordDto {
+
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
+            message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+    private String currentPassword;
+
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
+            message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+    private String newPassword;
+
+    private String newCheckPassword;
+
+}

--- a/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
@@ -1,0 +1,24 @@
+package com.example.basketballmatching.user.dto;
+
+import com.example.basketballmatching.user.type.Position;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EditUserDto {
+
+
+    private String nickname;
+
+
+    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    private String address;
+
+    private Position position;
+}

--- a/src/main/java/com/example/basketballmatching/user/dto/ResetPasswordDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/ResetPasswordDto.java
@@ -1,0 +1,24 @@
+package com.example.basketballmatching.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResetPasswordDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
+            message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+    private String checkPassword;
+}

--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -53,6 +53,9 @@ public class SignUpDto {
         @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
         private String phone;
 
+        @NotBlank(message = "주소를 입력해주세요.")
+        private String address;
+
         @NotNull(message = "포지션을 입력해주세요.")
         private Position position;
 
@@ -65,6 +68,7 @@ public class SignUpDto {
                     .name(request.getName())
                     .birth(request.getBirth())
                     .phone(request.getPhone())
+                    .address(request.getAddress())
                     .position(request.getPosition())
                     .userType(UserType.USER)
                     .build();
@@ -89,6 +93,8 @@ public class SignUpDto {
         private LocalDate birth;
 
         private String phone;
+
+        private String address;
 
         private Position position;
 

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -29,6 +29,8 @@ public class UserDto {
 
     private String phone;
 
+    private String address;
+
     private Position position;
 
     private UserType userType;
@@ -48,6 +50,7 @@ public class UserDto {
                 .name(userEntity.getName())
                 .birth(userEntity.getBirth())
                 .phone(userEntity.getPhone())
+                .address(userEntity.getAddress())
                 .position(userEntity.getPosition())
                 .userType(userEntity.getUserType())
                 .createdAt(userEntity.getCreatedAt())

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.user.entity;
 
 import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.user.dto.EditUserDto;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.*;
@@ -41,6 +42,9 @@ public class UserEntity extends BaseEntity {
     private String phone;
 
     @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Position position;
 
@@ -53,6 +57,33 @@ public class UserEntity extends BaseEntity {
 
     public void setEmailAuth() {
         this.emailAuth = true;
+    }
+
+
+    public void editUserInfo(EditUserDto editUserDto) {
+
+        if (editUserDto.getNickname() != null) {
+            this.nickname = editUserDto.getNickname();
+        }
+
+        if (editUserDto.getPhone() != null) {
+            this.phone = editUserDto.getPhone();
+        }
+
+        if (editUserDto.getAddress() != null) {
+            this.address = editUserDto.getAddress();
+        }
+
+        if (editUserDto.getPosition() != null) {
+            this.position = editUserDto.getPosition();
+        }
+
+    }
+
+    public void setPassword(String password) {
+
+        this.password = password;
+
     }
 
 

--- a/src/main/java/com/example/basketballmatching/user/service/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/UserService.java
@@ -2,7 +2,10 @@ package com.example.basketballmatching.user.service;
 
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.user.dto.ChangePasswordDto;
+import com.example.basketballmatching.user.dto.EditUserDto;
 import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.dto.UserDto;
 
 public interface UserService {
 
@@ -12,5 +15,15 @@ public interface UserService {
 
     CheckResponse checkEmail(String email);
     CheckResponse checkNickname(String nickname);
+    ApiResponse<UserDto> getUserInfo(Long userId);
+
+    ApiResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto);
+
+    CheckResponse verifyPasswordCode(String email, String code);
+
+
+    CheckResponse resetPassword(String email, String newPassword, String checkNewPassword);
+
+    CheckResponse changePassword(Long userId, ChangePasswordDto request);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.dto.ChangePasswordDto;
+import com.example.basketballmatching.user.dto.EditUserDto;
 import com.example.basketballmatching.user.dto.SignUpDto;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
@@ -29,8 +31,9 @@ public class UserServiceImpl implements UserService {
     private final RedisService redisService;
 
 
-
-
+    /**
+     * 유저 회원가입
+     */
     @Override
     @Transactional
     public ApiResponse<SignUpDto.Response> signUp(SignUpDto.Request request) {
@@ -65,6 +68,10 @@ public class UserServiceImpl implements UserService {
         return ApiResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity)));
     }
 
+    /**
+     * 이메일 중복 확인
+     */
+
     @Override
     public CheckResponse checkEmail(String email) {
 
@@ -76,6 +83,10 @@ public class UserServiceImpl implements UserService {
 
         return CheckResponse.of(true, "사용가능한 이메일입니다.");
     }
+
+    /**
+     * 닉네입 중복 확인
+     */
 
     @Override
     public CheckResponse checkNickname(String nickname) {
@@ -90,7 +101,136 @@ public class UserServiceImpl implements UserService {
 
     }
 
+    /**
+     * 회원 정보 조회
+     */
+    @Override
+    public ApiResponse<UserDto> getUserInfo(Long userId) {
 
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+
+        return ApiResponse.of("회원정보 조회에 성공하였습니다.", userDto);
+    }
+
+
+    /**
+     * 회원 정보 수정
+     */
+    @Override
+    @Transactional
+    public ApiResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto) {
+
+        log.info("[유저 회원정보 수정 시작 : {}]", userId);
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        boolean exists = userRepository.existsByNickname(editUserDto.getNickname());
+
+        if (editUserDto.getNickname() != null && exists) {
+            throw new CustomException(ALREADY_EXIST_NICKNAME);
+        }
+
+        userEntity.editUserInfo(editUserDto);
+
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        log.info("[유저 회원정보 수정 완료 : {}]", true);
+
+        return ApiResponse.of("회원정보 수정이 완료되었습니다.", userDto);
+    }
+
+
+    /**
+     * 비밀번호 찾기 인증번호 확인
+     */
+    @Override
+    public CheckResponse verifyPasswordCode(String email, String code) {
+
+
+        userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String data = redisService.getData("password:auth:" + email);
+
+        if (data == null || !data.equals(code)) {
+            throw new CustomException(EMAIL_NOT_VERIFIED);
+        }
+
+        // 인증 확인 후 레디스에 비밀번호 변경 가능 저장
+
+        redisService.setDataExpireMinutes("password:change:" + email, code, 10L);
+
+
+
+
+        return CheckResponse.of(true, "비밀번호를 변경해주세요.");
+    }
+
+    /**
+     * 검증 후 비밀번호 찾기
+     */
+    @Override
+    @Transactional
+    public CheckResponse resetPassword(String email, String newPassword, String checkNewPassword) {
+
+        log.info("[검증 후 비밀번호 변경 시작] email : {}", email);
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String data = redisService.getData("password:change:" + email);
+
+        if (data == null) {
+            throw new CustomException(EMAIL_NOT_VERIFIED);
+        }
+
+        if (!newPassword.equals(checkNewPassword)) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+
+        userEntity.setPassword(passwordEncoder.encode(newPassword));
+
+        userRepository.save(userEntity);
+
+        redisService.deleteData("password:change:" + email);
+
+        return CheckResponse.of(true, "비밀번호 변경을 완료하였습니다.");
+    }
+
+    @Override
+    @Transactional
+    public CheckResponse changePassword(Long userId, ChangePasswordDto request) {
+
+        log.info("[비밀번호 변경 시작] userId : {}", userId);
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), userEntity.getPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+        if (!request.getNewPassword().equals(request.getNewCheckPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+
+        userEntity.setPassword(passwordEncoder.encode(request.getNewPassword()));
+
+        userRepository.save(userEntity);
+
+        log.info("[비밀번호 변경 완료] userId : {}", userId);
+
+
+        return CheckResponse.of(true, "비밀번호 변경을 완료하였습니다.");
+    }
 
 
     private static void validationByUser(SignUpDto.Request request, boolean existsByEmail, boolean existsByNickname) {

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.auth.service.impl;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.global.service.RedisService;
@@ -141,6 +142,26 @@ class AuthServiceImplTest {
                 () -> authService.reissue(email, null));
         // then
         assertEquals(ErrorCode.NOT_FOUND_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 테스트")
+    void logoutTest() {
+        // given
+
+        String email = "test@example.com";
+
+        TokenDto tokenDto = authService.loginUser(email, "Test1234!");
+
+        // when
+
+        CheckResponse checkResponse = authService.logoutUser(email, tokenDto.getAccessToken());
+
+        // then
+
+        assertEquals("로그아웃 완료되었습니다.", checkResponse.getMessage());
+
+
     }
 
 

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -4,11 +4,11 @@ import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
@@ -36,6 +37,9 @@ class AuthServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private RedisService redisService;
+
     @BeforeEach
     void setUp() {
         // given: 테스트용 유저 데이터 삽입
@@ -49,6 +53,8 @@ class AuthServiceImplTest {
                 .position(Position.GUARD)
                 .userType(UserType.USER)
                 .build();
+
+        user.setEmailAuth();
 
         userRepository.save(user);
     }
@@ -84,6 +90,57 @@ class AuthServiceImplTest {
 
         assertEquals(ErrorCode.PASSWORD_NOT_MATCH, exception.getErrorCode());
 
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 테스트")
+    void reissueTokenTest() {
+        // given
+
+        authService.loginUser("test@example.com", "Test1234!");
+
+
+        // when
+        String email = "test@example.com";
+
+        TokenDto reissue = authService.reissue(email, redisService.getData("refreshToken:" + email));
+
+
+        // then
+
+        assertThat(reissue.getAccessToken()).isNotBlank();
+        assertThat(reissue.getRefreshToken()).isNotBlank();
+        assertEquals(email, reissue.getUserDto().getEmail());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - 토큰 불일치")
+    void reissueToken_Invalid_Token() {
+        // given
+
+        String email = "test@example.com";
+
+        authService.loginUser(email, "Test1234!");
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> authService.reissue(email, "awdwadwadwadwadwadwadasfdsgdfgfdgfd"));
+
+        // then
+
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 테스트 - Redis에 토큰이 없는 경우")
+    void reissueToken_NOT_FOUND_TOKEN() {
+        // given
+        String email = "tes@example.com";
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.reissue(email, null));
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_TOKEN, exception.getErrorCode());
     }
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 회원 정보 조회, 수정 기능 미구현
- 로그인 유저 비밀번호 변경 미구현
- 유저 검증 후 비밀번호 변경 미구현

---

### 🚀 TO-BE
✅ 회원 정보 조회 및 수정
- 로그인된 유저 정보 조회 구현
- @AuthenticationPrincipal을 통해 현재 인증된 사용자 정보 조회
- 닉네임, 전화번호, 주소, 포지션 등을 수정 기능 구현

✅ 비밀번호 변경(로그인 상태)
- 로그인 상태의 유저 @AuthenticationPrincipal로 조회
- 기존 비밀번호 확인 후 새 비밀번호로 변경 기능 구현
- 성공 시 암호화하여 저장

✅ 비밀번호 찾기(비밀번호 변경)
- 이메일로 인증번호 전송 후 검증
- 검증 후 Redis에 인증번호 확인 2차 검증
- 검증 완료 후 비밀번호 암호화하여 저장.

---

## ✅ 체크리스트
- [x] 회원 정보 조회 및 수정
- [x] 비밀번호 변경(로그인 상태)
- [x] 비밀번호 찾기(비밀번호 변경)
- [x] API테스트

---
