### PR TITLE
[feat] : 카카오 OAuth2 로그인 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
@@ -19,6 +19,7 @@ public class LoginDto {
 
     @Getter
     @AllArgsConstructor
+    @Builder
     public static class Request {
 
         @NotBlank(message = "이메일은 필수 입력값입니다.")

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -11,4 +11,6 @@ public interface AuthService {
 
     CheckResponse logoutUser(String email, String token);
 
+
+
 }

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                                         "/api/v1/user/send-mail",
                                         "/api/v1/user/verify-mail",
                                         "/api/v1/user/login",
-                                        "/api/v1/user/reissue"
+                                        "/api/v1/user/reissue",
+                                        "/api/oauth2/**"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/user/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/controller/OAuth2Controller.java
@@ -1,0 +1,57 @@
+package com.example.basketballmatching.user.oauth2.controller;
+
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.user.oauth2.dto.KakaoDto.Response;
+import com.example.basketballmatching.user.oauth2.service.OAuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+public class OAuth2Controller {
+
+    private final OAuthService oAuthService;
+
+    private final AuthService authService;
+
+    @GetMapping("/login/kakao")
+    public void getKakaoAuthUrl(HttpServletResponse response) throws IOException {
+
+        response.sendRedirect(oAuthService.responseUrl());
+
+    }
+
+
+    @GetMapping("/kakao")
+    public ResponseEntity<ApiResponse<Response>> kakaoLogin(
+            @RequestParam(name = "code") String code
+    ) throws IOException{
+
+        log.info("[카카오 API 서버] code : {}", code);
+
+        TokenDto tokenDto = oAuthService.kakaoLogin(code);
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken());
+
+
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.of("카카오 로그인에 성공하였습니다.", Response.fromDto(tokenDto.getUserDto(), tokenDto.getRefreshToken())));
+    }
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoDto.java
@@ -1,0 +1,102 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDate;
+
+public class KakaoDto {
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식으로 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        private String nickname;
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        private String name;
+
+
+        public static UserEntity toEntity(KakaoDto.Request request) {
+
+            BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+            return UserEntity.builder()
+                    .email(request.getEmail())
+                    .password(encoder.encode("kakao"))
+                    .nickname(request.getNickname())
+                    .name(request.getName())
+                    .birth(LocalDate.now())
+                    .phone("010-0000-0000")
+                    .address("DEFAULT_ADDRESS")
+                    .position(Position.NONE)
+                    .userType(UserType.USER)
+                    .build();
+        }
+
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private Long userId;
+
+        private String email;
+
+        private String name;
+
+        private String nickname;
+
+        private LocalDate birth;
+
+        private String phone;
+
+        private String address;
+
+        private Position position;
+
+        private UserType userType;
+
+        private String refreshToken;
+
+        public static Response fromDto(UserDto userDto, String refreshToken) {
+
+            return Response.builder()
+                    .userId(userDto.getUserId())
+                    .email(userDto.getEmail())
+                    .name(userDto.getName())
+                    .nickname(userDto.getNickname())
+                    .birth(userDto.getBirth())
+                    .phone(userDto.getPhone())
+                    .address(userDto.getAddress())
+                    .position(userDto.getPosition())
+                    .userType(userDto.getUserType())
+                    .refreshToken(refreshToken)
+                    .build();
+
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoOAuthTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoOAuthTokenDto.java
@@ -1,0 +1,25 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class KakaoOAuthTokenDto {
+
+    private String access_token;
+
+    private String token_type;
+
+    private String refresh_token;
+
+    private String id_token;
+
+    private Integer expires_in;
+    private String scope;
+
+    private Integer refresh_token_expires_in;
+
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoUserInfoDto.java
@@ -1,0 +1,48 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoUserInfoDto {
+
+
+    private Long id;
+    private String connected_at;
+    private Properties properties;
+    private KakaoAccount kakao_account;
+
+
+    @Data
+    public static class Properties {
+
+        private String nickname;
+    }
+
+    @Data
+    public static class KakaoAccount {
+
+        private boolean profile_nickname_needs_agreement;
+        private Profile profile;
+        private boolean has_email;
+        private boolean email_needs_agreement;
+        @JsonProperty("is_email_valid")
+        private boolean is_email_valid;
+        @JsonProperty("is_email_verified")
+        private boolean is_email_verified;
+        private String email;
+
+
+    }
+
+    @Data
+    public static class Profile {
+
+        @JsonProperty("is_default_nickname")
+        private boolean is_default_nickname;
+
+        private String nickname;
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuthService.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuthService.java
@@ -1,0 +1,14 @@
+package com.example.basketballmatching.user.oauth2.service;
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface OAuthService {
+
+    TokenDto kakaoLogin(String code) throws JsonProcessingException;
+
+    String responseUrl();
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/service/impl/OAuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/service/impl/OAuthServiceImpl.java
@@ -1,0 +1,165 @@
+package com.example.basketballmatching.user.oauth2.service.impl;
+
+import com.example.basketballmatching.auth.dto.LoginDto;
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoOAuthTokenDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto.KakaoAccount;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto.Properties;
+import com.example.basketballmatching.user.oauth2.service.OAuthService;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthServiceImpl implements OAuthService {
+
+    private final UserRepository userRepository;
+
+    private final AuthService authService;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private String authorizationUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenRequestUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+
+    @Override
+    public String responseUrl() {
+        return authorizationUri + "?response_type=code" + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri;
+    }
+
+
+
+    @Override
+    @Transactional
+    public TokenDto kakaoLogin(String code) throws JsonProcessingException {
+
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(code);
+        Properties properties = kakaoUserInfo.getProperties();
+        KakaoAccount kakaoAccount = kakaoUserInfo.getKakao_account();
+
+
+        if (!userRepository.existsByEmail(kakaoAccount.getEmail())) {
+
+            KakaoDto.Request request = KakaoDto.Request.builder()
+                    .email(kakaoAccount.getEmail())
+                    .name(properties.getNickname())
+                    .nickname(properties.getNickname())
+                    .build();
+
+            userRepository.save(KakaoDto.Request.toEntity(request));
+
+        }
+
+
+        LoginDto.Request loginDto = kakaoUserLogin(kakaoAccount.getEmail());
+
+
+        return authService.loginUser(loginDto.getEmail(), loginDto.getPassword());
+    }
+
+
+    private KakaoUserInfoDto getKakaoUserInfo(String code) throws JsonProcessingException {
+
+        ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+        KakaoOAuthTokenDto accessToken = getAccessToken(accessTokenResponse);
+        ResponseEntity<String> userinfo = requestUserinfo(accessToken);
+
+
+        return getUserInfo(userinfo);
+
+    }
+
+    private ResponseEntity<String> requestAccessToken(String code) {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-Type", "application/x-www-form-urlencoded;"
+        + "charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+
+        HttpEntity<MultiValueMap<String, String>> kakaoRequest = new HttpEntity<>(params, headers);
+
+        return restTemplate.postForEntity(tokenRequestUri, kakaoRequest, String.class);
+    }
+
+
+    private KakaoOAuthTokenDto getAccessToken(ResponseEntity<String> response) throws JsonProcessingException {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(response.getBody(), KakaoOAuthTokenDto.class);
+
+
+    }
+
+    private ResponseEntity<String> requestUserinfo(KakaoOAuthTokenDto kakaoOAuthTokenDto) {
+
+        HttpHeaders headers = new HttpHeaders();
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        headers.add("Authorization", "Bearer " +
+                kakaoOAuthTokenDto.getAccess_token());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+
+        return restTemplate.exchange("https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET, request, String.class);
+    }
+
+    public KakaoUserInfoDto getUserInfo(ResponseEntity<String> response) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(response.getBody(), KakaoUserInfoDto.class);
+    }
+
+    public LoginDto.Request kakaoUserLogin(String email) {
+        return LoginDto.Request.builder()
+                .email(email)
+                .password("kakao")
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/user/type/Position.java
+++ b/src/main/java/com/example/basketballmatching/user/type/Position.java
@@ -2,5 +2,5 @@ package com.example.basketballmatching.user.type;
 
 public enum Position {
 
-    GUARD, CENTER, FORWARD
+    NONE, GUARD, CENTER, FORWARD
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 50px;
+        }
+        h1 {
+            color: #333;
+        }
+        .login-link {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 10px 20px;
+            background-color: #FEE500;
+            color: #000;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        .login-link:hover {
+            background-color: #FFC107;
+        }
+    </style>
+</head>
+<body>
+<h1>Welcome to the Application!</h1>
+<a class="login-link" href="http://localhost:8080/api/oauth2/login/kakao">Kakao Login</a>
+</body>
+</html>


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 카카오 OAuth2 로그인 미구현

### 🚀 TO-BE
✅ 카카오 로그인 구현
- 카카오 Authorization Code -> AccessToken 발급
- 신규 카카오 유저 회원가입 처리
   - 이메일, 닉네임, 이름으로 사용자 등록
   - 누락 데이터('birth', 'phone', 'address', 'position') 기본값 지정
- 카카오 로그인 성공 시 AccessToken 헤더 반환

---

## ✅ 체크리스트
- [x] 카카오 로그인 AP테스트
- [x] 신규 유저 자동 회원가입 확인
- [x] 기존 유저 로그인 정상 동작


---
