### PR TITLE
[refactor] : 이메일 인증번호 전송 비동기 처리

### DIFF
--- a/src/main/java/com/example/basketballmatching/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.example.basketballmatching.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean
+    public Executor takeExecutor() {
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(500);
+        executor.setThreadGroupName("EmailThread-");
+        executor.initialize();
+
+
+        return executor;
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/service/MailService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/MailService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +36,9 @@ public class MailService {
     private static final String EMAIL_PREFIX = "email:auth:";
 
 
+    @Async
     @Transactional
-    public CheckResponse sendAuthMail(String email) {
+    public void sendAuthMail(String email) {
 
         String code = createRandomCode();
 
@@ -78,12 +80,13 @@ public class MailService {
             throw new CustomException(INTERNAL_SERVER_ERROR);
         }
 
-        return CheckResponse.of(true, "이메일 인증번호가 전송되었습니다.");
+
 
     }
 
+    @Async
     @Transactional
-    public CheckResponse sendPasswordAuthCode(String email) {
+    public void sendPasswordAuthCode(String email) {
 
         UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -128,7 +131,7 @@ public class MailService {
             throw new CustomException(INTERNAL_SERVER_ERROR);
         }
 
-        return CheckResponse.of(true, "인증번호가 전송되었습니다.");
+
 
     }
 

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -60,9 +60,9 @@ public class UserController {
     public ResponseEntity<CheckResponse> sendMailAuth(
             @RequestParam String email
     ) {
-        CheckResponse checkResponse = mailService.sendAuthMail(email);
+        mailService.sendAuthMail(email);
 
-        return ResponseEntity.ok(checkResponse);
+        return ResponseEntity.ok(CheckResponse.of(true, "이메일 인증번호가 전송되었습니다."));
     }
 
     @PostMapping("/verify-mail")
@@ -103,9 +103,9 @@ public class UserController {
             @RequestParam String email
     ) {
 
-        CheckResponse checkResponse = mailService.sendPasswordAuthCode(email);
+        mailService.sendPasswordAuthCode(email);
 
-        return ResponseEntity.ok(checkResponse);
+        return ResponseEntity.ok(CheckResponse.of(true, "인증번호가 전송되었습니다."));
 
     }
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- Postman으로 API요청시 4초의 지연시간 발생

---

### 🚀 TO-BE
✅ 이메일 인증번호 전송 비동기 처리
- '@EnableAsync'  및 @Async 기반 비동기 처리
- MailService의 sendAuthMail(), sendPasswordAuthCode()에 비동기 처리 적용
- API 요청시 즉시 응답 확인

---

## ✅ 체크리스트
- [ ] 이메일 인증 비동기 전송
- [ ] API 테스트


---
