### PR TITLE
[feat] : 경기 생성 API 및 검증 로직 추가

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -8,7 +8,6 @@ import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
-import com.example.basketballmatching.user.dto.UserDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -7,6 +7,8 @@ public interface AuthService {
 
     TokenDto loginUser(String email, String password);
 
+    TokenDto kakaoLogin(String email);
+
     TokenDto reissue(String email, String refreshToken);
 
     CheckResponse logoutUser(String email, String token);

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.LoginProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static com.example.basketballmatching.user.type.LoginProvider.*;
 
 @Service
 @RequiredArgsConstructor
@@ -40,9 +42,16 @@ public class AuthServiceImpl implements AuthService {
         UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(password, userEntity.getPassword())) {
-            throw new CustomException(PASSWORD_NOT_MATCH);
+        if (userEntity.getLoginProvider().equals(KAKAO)) {
+            throw new CustomException(PROVIDER_NOT_MATCH);
         }
+
+        if (!passwordEncoder.matches(password, userEntity.getPassword()) || password == null) {
+                throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+
+
 
         UserDto userDto = UserDto.fromEntity(userEntity);
 
@@ -53,6 +62,32 @@ public class AuthServiceImpl implements AuthService {
         String refreshToken = tokenProvider.createRefreshToken(userDto.getEmail());
         log.info("refreshToken 생성 완료");
 
+        log.info("[유저 로그인 완료] email : {}", userDto.getEmail());
+
+        return new TokenDto(accessToken, refreshToken, userDto);
+    }
+
+    @Override
+    @Transactional
+    public TokenDto kakaoLogin(String email) {
+
+        log.info("[카카오 로그인 검증 시작] email : {}", email);
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (userEntity.getLoginProvider().equals(LOCAL)) {
+            throw new CustomException(PROVIDER_NOT_MATCH);
+        }
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        String accessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+
+        String refreshToken = tokenProvider.createRefreshToken(userDto.getEmail());
+
+
+        log.info("[카카오 로그인 완료] email : {}", userDto.getEmail());
 
         return new TokenDto(accessToken, refreshToken, userDto);
     }

--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
@@ -1,22 +1,27 @@
 package com.example.basketballmatching.gameCreator.controller;
 
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.dto.EditGameDto;
+import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.service.GameService;
+import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
-import com.example.basketballmatching.global.security.UserInfoDetailsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
-@RequestMapping("/api/game")
+@RequestMapping("/api/v1/game")
 @RequiredArgsConstructor
 public class GameController {
 
@@ -35,6 +40,51 @@ public class GameController {
         return ResponseEntity.ok(game);
 
     }
+
+    @GetMapping("/details")
+    public ResponseEntity<ApiResponse<GameDto>> detailGame(
+            @RequestParam Long gameId
+    ) {
+
+        ApiResponse<GameDto> gameDto = gameService.detailGame(gameId);
+
+        return ResponseEntity.ok(gameDto);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Page<SearchGameDto>>> searchGame(
+            @RequestParam @Valid LocalDate date,
+            @RequestParam(required = false) CityName cityName,
+            @RequestParam(required = false) MatchFormat matchFormat,
+            @RequestParam(required = false) FieldStatus fieldStatus,
+            @RequestParam(required = false) MatchGenderType matchGenderType,
+            @RequestParam(required = false) GameStatus gameStatus,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ApiResponse<Page<SearchGameDto>> searchGame = gameService.searchGame(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageRequest);
+
+        return ResponseEntity.ok(searchGame);
+    }
+
+    @PatchMapping("/edit")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<GameDto>> editGame(
+            @RequestBody @Valid EditGameDto request,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam Long gameId
+    ) {
+
+        ApiResponse<GameDto> editGame = gameService.editGame(request, gameId, userInfoDetails.getUserEntity().getUserId());
+
+
+        return ResponseEntity.ok(editGame);
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameCreator.controller;
+
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.service.GameService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import com.example.basketballmatching.global.security.UserInfoDetailsService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+public class GameController {
+
+    private final GameService gameService;
+
+    @PostMapping("/create")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<CreateGameDto.Response>> createGame(
+            @RequestBody @Valid CreateGameDto.Request request,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        ApiResponse<CreateGameDto.Response> game = gameService.createGame(userInfoDetails.getUserEntity().getUserId(), request);
+
+
+        return ResponseEntity.ok(game);
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
@@ -1,0 +1,150 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.type.*;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class CreateGameDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Request {
+
+
+        @NotBlank(message = "제목을 입력해주세요.")
+        private String title;
+
+        @NotBlank(message = "내용을 입력해주세요.")
+        private String content;
+
+        @NotNull(message = "인원수를 입력해주세요.")
+        @Min(value = 6, message = "최소 6명이상입니다.")
+        private Integer headCount;
+
+        @NotNull(message = "실내외를 입력해주세요.")
+        private FieldStatus fieldStatus;
+
+        @NotNull(message = "경기형식을 입력해주세요.")
+        private MatchFormat matchFormat;
+
+        @NotNull(message = "시작 날짜를 입력해주세요.")
+        @Future(message = "시작 시간은 현재 시각 이후여야 합니다.")
+        private LocalDateTime startDateTime;
+
+        @NotNull(message = "종료 날짜를 입력해주세요.")
+        @Future(message = "종료 시간은 현재 시각 이후여야 합니다.")
+        private LocalDateTime endDateTime;
+
+        @NotBlank(message = "장소 이름을 입력해주세요.")
+        private String placeName;
+
+        @NotBlank(message = "주소를 입력해주세요.")
+        private String address;
+
+        private Double latitude;
+
+        private Double longitude;
+
+        @NotNull(message = "성별을 입력해주세요.")
+        private MatchGenderType matchGenderType;
+
+        public static GameEntity toEntity(CreateGameDto.Request request, UserEntity userEntity) {
+
+            return GameEntity.builder()
+                    .title(request.getTitle())
+                    .content(request.getContent())
+                    .headCount(request.getHeadCount())
+                    .fieldStatus(request.getFieldStatus())
+                    .matchGenderType(request.getMatchGenderType())
+                    .startDateTime(request.getStartDateTime())
+                    .endDateTime(request.getEndDateTime())
+                    .placeName(request.getPlaceName())
+                    .address(request.getAddress())
+                    .latitude(request.getLatitude())
+                    .longitude(request.getLongitude())
+                    .cityName(CityName.getCityName(request.getAddress()))
+                    .matchFormat(request.getMatchFormat())
+                    .gameStatus(GameStatus.RECRUITING)
+                    .userEntity(userEntity)
+                    .build();
+
+
+        }
+
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Response {
+        private Long gameId;
+
+        private String title;
+
+        private String content;
+
+        private int headCount;
+
+        private FieldStatus fieldStatus;
+
+        private MatchFormat matchFormat;
+
+        private GameStatus gameStatus;
+
+        private LocalDateTime startDateTime;
+
+        private String placeName;
+
+        private String address;
+
+        private Double latitude;
+
+        private Double longitude;
+
+        private CityName cityName;
+
+        private MatchGenderType matchGenderType;
+
+        private Long creatorId;
+
+        private String creatorNickname;
+
+        public static Response fromDto(GameDto gameDto) {
+
+            return Response.builder()
+                    .gameId(gameDto.getGameId())
+                    .title(gameDto.getTitle())
+                    .content(gameDto.getContent())
+                    .headCount(gameDto.getHeadCount())
+                    .fieldStatus(gameDto.getFieldStatus())
+                    .matchFormat(gameDto.getMatchFormat())
+                    .gameStatus(gameDto.getGameStatus())
+                    .startDateTime(gameDto.getStartDateTime())
+                    .placeName(gameDto.getPlaceName())
+                    .address(gameDto.getAddress())
+                    .latitude(gameDto.getLatitude())
+                    .longitude(gameDto.getLongitude())
+                    .cityName(gameDto.getCityName())
+                    .matchGenderType(gameDto.getMatchGenderType())
+                    .creatorId(gameDto.getCreatorId())
+                    .creatorNickname(gameDto.getCreatorNickname())
+                    .build();
+
+        }
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
@@ -99,6 +99,8 @@ public class CreateGameDto {
 
         private int headCount;
 
+        private int participantCount;
+
         private FieldStatus fieldStatus;
 
         private MatchFormat matchFormat;
@@ -130,6 +132,7 @@ public class CreateGameDto {
                     .title(gameDto.getTitle())
                     .content(gameDto.getContent())
                     .headCount(gameDto.getHeadCount())
+                    .participantCount(gameDto.getParticipantCount())
                     .fieldStatus(gameDto.getFieldStatus())
                     .matchFormat(gameDto.getMatchFormat())
                     .gameStatus(gameDto.getGameStatus())

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/EditGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/EditGameDto.java
@@ -1,0 +1,21 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+@Getter
+@AllArgsConstructor
+@Builder
+public class EditGameDto {
+
+        private String title;
+
+        private String content;
+
+        private int headCount;
+
+        private MatchFormat matchFormat;
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
@@ -1,0 +1,86 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.type.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class GameDto {
+
+    private Long gameId;
+
+    private String title;
+
+    private String content;
+
+    private int headCount;
+
+    private FieldStatus fieldStatus;
+
+    private MatchFormat matchFormat;
+
+    private GameStatus gameStatus;
+
+    private LocalDateTime startDateTime;
+
+    private LocalDateTime endDateTime;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedDateTime;
+
+    private String placeName;
+
+    private String address;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private CityName cityName;
+
+    private MatchGenderType matchGenderType;
+
+    private Long creatorId;
+
+    private String creatorNickname;
+
+
+
+    public static GameDto fromEntity(GameEntity gameEntity) {
+
+        return GameDto.builder()
+                .gameId(gameEntity.getGameId())
+                .title(gameEntity.getTitle())
+                .content(gameEntity.getContent())
+                .headCount(gameEntity.getHeadCount())
+                .fieldStatus(gameEntity.getFieldStatus())
+                .matchFormat(gameEntity.getMatchFormat())
+                .gameStatus(gameEntity.getGameStatus())
+                .startDateTime(gameEntity.getStartDateTime())
+                .endDateTime(gameEntity.getEndDateTime())
+                .createdAt(gameEntity.getCreatedAt())
+                .updatedAt(gameEntity.getUpdatedAt())
+                .deletedDateTime(gameEntity.getDeletedDateTime())
+                .placeName(gameEntity.getPlaceName())
+                .address(gameEntity.getAddress())
+                .latitude(gameEntity.getLatitude())
+                .longitude(gameEntity.getLongitude())
+                .cityName(gameEntity.getCityName())
+                .matchGenderType(gameEntity.getMatchGenderType())
+                .creatorId(gameEntity.getUserEntity().getUserId())
+                .creatorNickname(gameEntity.getUserEntity().getNickname())
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
@@ -23,6 +23,8 @@ public class GameDto {
 
     private int headCount;
 
+    private int participantCount;
+
     private FieldStatus fieldStatus;
 
     private MatchFormat matchFormat;
@@ -64,6 +66,7 @@ public class GameDto {
                 .title(gameEntity.getTitle())
                 .content(gameEntity.getContent())
                 .headCount(gameEntity.getHeadCount())
+                .participantCount(gameEntity.getParticipantCount())
                 .fieldStatus(gameEntity.getFieldStatus())
                 .matchFormat(gameEntity.getMatchFormat())
                 .gameStatus(gameEntity.getGameStatus())

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/SearchGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/SearchGameDto.java
@@ -1,0 +1,49 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.type.GameStatus;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+@Builder
+@AllArgsConstructor
+@Getter
+public class SearchGameDto {
+
+        private Long gameId;
+
+        private String title;
+
+        private String address;
+
+        private LocalDateTime startDateTime;
+
+        private MatchGenderType matchGenderType;
+
+        private MatchFormat matchFormat;
+
+        private GameStatus gameStatus;
+
+        public static SearchGameDto fromEntity(GameEntity gameEntity) {
+
+            return SearchGameDto.builder()
+                    .gameId(gameEntity.getGameId())
+                    .title(gameEntity.getTitle())
+                    .address(gameEntity.getAddress())
+                    .startDateTime(gameEntity.getStartDateTime())
+                    .matchGenderType(gameEntity.getMatchGenderType())
+                    .matchFormat(gameEntity.getMatchFormat())
+                    .gameStatus(gameEntity.getGameStatus())
+                    .build();
+
+        }
+
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -1,17 +1,15 @@
 package com.example.basketballmatching.gameCreator.entity;
 
 
-import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.dto.EditGameDto;
 import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.entity.BaseEntity;
-import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -34,6 +32,10 @@ public class GameEntity extends BaseEntity {
 
     @Column(nullable = false)
     private int headCount;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private int participantCount = 1;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -79,6 +81,30 @@ public class GameEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private UserEntity userEntity;
+
+    public void editGameInfo(EditGameDto editGameDto) {
+
+        if (editGameDto.getTitle() != null) {
+            this.title = editGameDto.getTitle();
+        }
+
+        if (editGameDto.getContent() != null) {
+            this.content = editGameDto.getContent();
+        }
+
+        if (editGameDto.getHeadCount() > 0) {
+            this.headCount = editGameDto.getHeadCount();
+        }
+
+        if (editGameDto.getMatchFormat() != null) {
+            this.matchFormat = editGameDto.getMatchFormat();
+        }
+
+
+
+
+
+    }
 
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -1,0 +1,86 @@
+package com.example.basketballmatching.gameCreator.entity;
+
+
+import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.type.*;
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GameEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long gameId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int headCount;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private FieldStatus fieldStatus;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MatchGenderType matchGenderType;
+
+    @Column(nullable = false)
+    private LocalDateTime startDateTime;
+
+    @Column
+    private LocalDateTime endDateTime;
+
+
+    private LocalDateTime deletedDateTime;
+
+    @Column(nullable = false)
+    private String placeName;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = true)
+    private Double latitude;
+
+    @Column(nullable = true)
+    private Double longitude;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CityName cityName;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MatchFormat matchFormat;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GameStatus gameStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private UserEntity userEntity;
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
@@ -1,0 +1,92 @@
+package com.example.basketballmatching.gameCreator.repository;
+
+import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.QGameEntity;
+import com.example.basketballmatching.gameCreator.type.*;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class GameQueryRepository {
+
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    public Page<SearchGameDto> searchByKeyword(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable) {
+
+
+        QGameEntity qGameEntity = QGameEntity.gameEntity;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        validationSearch(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, builder, qGameEntity);
+
+        List<GameEntity> gameEntities = jpaQueryFactory
+                .select(qGameEntity)
+                .from(qGameEntity)
+                .where(builder)
+                .orderBy(qGameEntity.startDateTime.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<SearchGameDto> searchGames = gameEntities.stream()
+                .map(SearchGameDto::fromEntity)
+                .toList();
+
+        Long total = Optional.ofNullable(
+                jpaQueryFactory
+                        .select(qGameEntity.count())
+                        .from(qGameEntity)
+                        .where(builder)
+                        .fetchOne()
+        ).orElse(0L);
+
+
+        return new PageImpl<>(searchGames, pageable, total);
+    }
+
+    private static void validationSearch(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, BooleanBuilder builder, QGameEntity qGameEntity) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        builder.and(qGameEntity.startDateTime.between(startOfDay, endOfDay));
+
+        if (cityName != null) {
+            builder.and(qGameEntity.cityName.eq(cityName));
+        }
+
+        if (gameStatus != null) {
+            builder.and(qGameEntity.gameStatus.eq(gameStatus));
+        }
+
+        if (fieldStatus != null) {
+            builder.and(qGameEntity.fieldStatus.eq(fieldStatus));
+        }
+
+        if (matchFormat != null) {
+            builder.and(qGameEntity.matchFormat.eq(matchFormat));
+        }
+
+        if (matchGenderType != null) {
+            builder.and(qGameEntity.matchGenderType.eq(matchGenderType));
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
@@ -1,0 +1,27 @@
+package com.example.basketballmatching.gameCreator.repository;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface GameRepository extends JpaRepository<GameEntity, Long> {
+
+
+    @Query ("""
+        select count(g) > 0
+        from GameEntity g
+        where g.deletedDateTime IS NULL 
+        and g.placeName = :placeName
+        and g.address = :address
+        and g.startDateTime < :endDateTime
+        and g.endDateTime > :startDateTime
+""")
+    boolean existsBySamePlaceAtSameTime(@Param("placeName") String placeName,
+                                        @Param("address") String address,
+                                        @Param("startDateTime") LocalDateTime startDateTime,
+                                        @Param("endDateTime") LocalDateTime endDateTime);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface GameRepository extends JpaRepository<GameEntity, Long> {
 
@@ -23,5 +24,7 @@ public interface GameRepository extends JpaRepository<GameEntity, Long> {
                                         @Param("address") String address,
                                         @Param("startDateTime") LocalDateTime startDateTime,
                                         @Param("endDateTime") LocalDateTime endDateTime);
+
+    Optional<GameEntity> findByGameIdAndDeletedDateTimeIsNull(Long gameId);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
@@ -1,10 +1,24 @@
 package com.example.basketballmatching.gameCreator.service;
 
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.dto.EditGameDto;
+import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
+import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
 
 public interface GameService {
 
     ApiResponse<CreateGameDto.Response> createGame(Long UserId, CreateGameDto.Request request);
+
+    ApiResponse<GameDto> detailGame(Long gameId);
+
+    ApiResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable);
+
+    ApiResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
@@ -1,0 +1,10 @@
+package com.example.basketballmatching.gameCreator.service;
+
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.global.dto.ApiResponse;
+
+public interface GameService {
+
+    ApiResponse<CreateGameDto.Response> createGame(Long UserId, CreateGameDto.Request request);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -2,21 +2,27 @@ package com.example.basketballmatching.gameCreator.service.impl;
 
 
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.dto.EditGameDto;
 import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.service.GameService;
+import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -28,6 +34,7 @@ public class GameServiceImpl implements GameService {
 
     private final UserRepository userRepository;
     private final GameRepository gameRepository;
+    private final GameQueryRepository gameQueryRepository;
 
     @Override
     @Transactional
@@ -48,6 +55,89 @@ public class GameServiceImpl implements GameService {
 
 
         return ApiResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<GameDto> detailGame(Long gameId) {
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+
+        GameDto gameDto = GameDto.fromEntity(gameEntity);
+
+        return ApiResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable) {
+
+        Page<SearchGameDto> responses = gameQueryRepository.searchByKeyword(date, cityName, matchFormat, fieldStatus,matchGenderType, gameStatus, pageable);
+
+
+        if (responses.isEmpty()) {
+            return ApiResponse.of("경기 검색결과가 없습니다.", responses);
+        }
+
+        return ApiResponse.of("경기 검색이 완료되었습니다.", responses);
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId) {
+
+        log.info("[경기 수정 시작] loginId : {}, gameId : {}", userId, gameId);
+
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!gameEntity.getUserEntity().getUserId().equals(userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+
+
+        if (request.getHeadCount() > 0) {
+
+            if (request.getHeadCount() < gameEntity.getParticipantCount()) {
+                throw new CustomException(INVALID_HEADCOUNT);
+            }
+
+            if (request.getMatchFormat() != null) {
+                switch (request.getMatchFormat()) {
+                    case THREE_ON_THREE -> {
+
+                        if (request.getHeadCount() < 6 || request.getHeadCount() > 9) {
+                            throw new CustomException(INVALID_HEADCOUNT);
+                        }
+
+                    }
+                    case FIVE_ON_FIVE -> {
+                        if (request.getHeadCount() < 10 || request.getHeadCount() > 15) {
+                            throw new CustomException(INVALID_HEADCOUNT);
+                        }
+                    }
+
+                }
+
+            }
+        }
+
+
+
+        gameEntity.editGameInfo(request);
+
+        gameRepository.save(gameEntity);
+
+        log.info("[경기 수정 완료] gameId : {}", gameId);
+
+        return ApiResponse.of("경기 수정이 완료되었습니다.", GameDto.fromEntity(gameEntity));
     }
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.dto.GameDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.service.GameService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class GameServiceImpl implements GameService {
+
+    private final UserRepository userRepository;
+    private final GameRepository gameRepository;
+
+    @Override
+    @Transactional
+    public ApiResponse<CreateGameDto.Response> createGame(Long userId, CreateGameDto.Request request) {
+
+        log.info("[경기 생성 시작] userId = {} title = {}", userId, request.getTitle());
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        validateCreateGame(request);
+
+        GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
+
+        gameRepository.save(gameEntity);
+
+        log.info("[경기 생성 완료] gameId = {}", gameEntity.getGameId());
+
+
+        return ApiResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
+    }
+
+
+    private void validateCreateGame(CreateGameDto.Request request) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (request.getStartDateTime().isBefore(now)) {
+            throw new CustomException(INVALID_GAME_TIME);
+        }
+
+        if (!request.getEndDateTime().isAfter(request.getStartDateTime())) {
+            throw new CustomException(INVALID_GAME_TIME);
+        }
+
+        long between = Duration.between(request.getStartDateTime(), request.getEndDateTime()).toMinutes();
+
+        if (between < 60 || between > 120) {
+            throw new CustomException(INVALID_GAME_TIME);
+        }
+
+        switch (request.getMatchFormat()) {
+            case THREE_ON_THREE -> {
+                if (request.getHeadCount() < 6 || request.getHeadCount() > 9) {
+                    throw new CustomException(INVALID_HEADCOUNT);
+                }
+            }
+            case FIVE_ON_FIVE -> {
+                if (request.getHeadCount() < 10 || request.getHeadCount() > 15) {
+                    throw new CustomException(INVALID_HEADCOUNT);
+                }
+
+            }
+        }
+
+        boolean exists = gameRepository.existsBySamePlaceAtSameTime(
+                request.getPlaceName(),
+                request.getAddress(),
+                request.getStartDateTime(),
+                request.getEndDateTime()
+        );
+
+        if (exists) {
+            throw new CustomException(PLACE_SCHEDULE_OVERLAP);
+        }
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/CityName.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/CityName.java
@@ -1,0 +1,49 @@
+package com.example.basketballmatching.gameCreator.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CityName {
+
+    SEOUL("서울특별시"),
+    GYEONGGI("경기도"),
+    INCHEON("인천광역시"),
+    GANGWON("강원특별자치도"),
+    DAEJEON("대전광역시"),
+    SEJONG("세종특별자치시"),
+    CHUNGNAM("충청남도"),
+    CHUNGBUK("충청북도"),
+    DAEGU("대구광역시"),
+    GYEONGBUK("경상북도"),
+    GYEONGNAM("경상남도"),
+    BUSAN("부산광역시"),
+    ULSAN("울산광역시"),
+    GWANGJU("광주광역시"),
+    JEONNAM("전남특별자치도"),
+    JEONBUK("전북특별자치도"),
+    JEJU("제주특별자치도");
+
+    private String cityName;
+
+
+    public static CityName getCityName(String address) {
+
+        String[] parts = address.split(" ");
+
+        String cityName = parts[0];
+
+        for (CityName cityNames : CityName.values()) {
+
+            if (cityNames.getCityName().equals(cityName)) {
+                return cityNames;
+            }
+
+        }
+
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/FieldStatus.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/FieldStatus.java
@@ -1,0 +1,7 @@
+package com.example.basketballmatching.gameCreator.type;
+
+public enum FieldStatus {
+
+    INDOOR, OUTDOOR
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/GameStatus.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/GameStatus.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.gameCreator.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GameStatus {
+
+    RECRUITING("모집 중"),
+    CLOSED("마감");
+
+
+    private final String description;
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/MatchFormat.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/MatchFormat.java
@@ -1,0 +1,13 @@
+package com.example.basketballmatching.gameCreator.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MatchFormat {
+
+
+    FIVE_ON_FIVE, THREE_ON_THREE
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
@@ -1,0 +1,7 @@
+package com.example.basketballmatching.gameCreator.type;
+
+public enum MatchGenderType {
+
+    MAIL_ONLY, FEMALE_ONLY, MIXED
+
+}

--- a/src/main/java/com/example/basketballmatching/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/QueryDslConfig.java
@@ -1,0 +1,24 @@
+package com.example.basketballmatching.global.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -37,7 +37,9 @@ public class SecurityConfig {
                                         "/api/v1/user/verify-mail",
                                         "/api/v1/user/login",
                                         "/api/v1/user/reissue",
-                                        "/api/oauth2/**"
+                                        "/api/oauth2/**",
+                                        "/api/v1/game/details",
+                                        "api/v1/game/search"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -47,7 +47,10 @@ public enum ErrorCode {
     INVALID_GAME_TIME(HttpStatus.BAD_REQUEST, "시작/종료 시간이 유효하지 않습니다."),
     GAME_TIME_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "경기시간은 1시간 이상 2시간 이하입니다."),
     PLACE_SCHEDULE_OVERLAP(HttpStatus.BAD_REQUEST, "해당 장소에 겹치는 경기가 존재합니다."),
-    INVALID_HEADCOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 인원수입니다.")
+    INVALID_HEADCOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 인원수입니다."),
+    GAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "경기를 찾을 수 없습니다."),
+    NOT_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자가 아닙니다."),
+
 
     ;
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -28,10 +28,28 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해주세요."),
     INVALID_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
     LOGOUT_USER(HttpStatus.BAD_REQUEST, "로그아웃 유저입니다"),
+    PROVIDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "로그인 방식이 일치하지 않습니다."),
     // validation
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
-    PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요.");
+    PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요."),
+    FUTURE_DATE(HttpStatus.BAD_REQUEST, "현재 시각 이후로 입력해주세요."),
+
+    // OAuth2
+    OAUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "OAUTH2 토큰이 존재하지 않습니다."),
+    OAUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, "요청 검증 상태가 유효하지 않습니다."),
+    OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 토큰 발급에 실패하였습니다."),
+    OAUTH_USERINFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 요청에 실패하였습니다."),
+    OAUTH_USERINFO_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 응답 파싱에 실패하였습니다."),
+
+    // game
+
+    INVALID_GAME_TIME(HttpStatus.BAD_REQUEST, "시작/종료 시간이 유효하지 않습니다."),
+    GAME_TIME_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "경기시간은 1시간 이상 2시간 이하입니다."),
+    PLACE_SCHEDULE_OVERLAP(HttpStatus.BAD_REQUEST, "해당 장소에 겹치는 경기가 존재합니다."),
+    INVALID_HEADCOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 인원수입니다.")
+
+    ;
 
 
 

--- a/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
@@ -25,7 +25,8 @@ public class GlobalExceptionHandler {
             "NotNull", INVALID_INPUT,
             "Pattern", INVALID_PATTERN,
             "Email", INVALID_PATTERN,
-            "Past", PAST_BIRTHDAY
+            "Past", PAST_BIRTHDAY,
+            "Future", FUTURE_DATE
     );
 
 

--- a/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.user.dto;
 
+import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -21,6 +22,8 @@ public class EditUserDto {
     private String phone;
 
     private String address;
+
+    private GenderType genderType;
 
     private Position position;
 }

--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -1,6 +1,8 @@
 package com.example.basketballmatching.user.dto;
 
 import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -59,6 +61,11 @@ public class SignUpDto {
         @NotNull(message = "포지션을 입력해주세요.")
         private Position position;
 
+        @NotNull(message = "성별을 입력해주세요.")
+        private GenderType genderType;
+
+        private LoginProvider loginProvider;
+
         public static UserEntity toEntity(SignUpDto.Request request) {
 
             return UserEntity.builder()
@@ -71,6 +78,8 @@ public class SignUpDto {
                     .address(request.getAddress())
                     .position(request.getPosition())
                     .userType(UserType.USER)
+                    .genderType(request.genderType)
+                    .loginProvider(LoginProvider.LOCAL)
                     .build();
         }
 
@@ -98,6 +107,8 @@ public class SignUpDto {
 
         private Position position;
 
+        private GenderType genderType;
+
         private UserType userType;
 
         private LocalDateTime createdAt;
@@ -112,6 +123,7 @@ public class SignUpDto {
                     .phone(userDto.getPhone())
                     .position(userDto.getPosition())
                     .userType(userDto.getUserType())
+                    .genderType(userDto.getGenderType())
                     .createdAt(userDto.getCreatedAt())
                     .build();
         }

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.user.dto;
 
 import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import lombok.AllArgsConstructor;
@@ -19,8 +20,6 @@ public class UserDto {
 
     private String email;
 
-    private String password;
-
     private String nickname;
 
     private String name;
@@ -32,6 +31,8 @@ public class UserDto {
     private String address;
 
     private Position position;
+
+    private GenderType genderType;
 
     private UserType userType;
 
@@ -45,7 +46,6 @@ public class UserDto {
         return UserDto.builder()
                 .userId(userEntity.getUserId())
                 .email(userEntity.getEmail())
-                .password(userEntity.getPassword())
                 .nickname(userEntity.getNickname())
                 .name(userEntity.getName())
                 .birth(userEntity.getBirth())
@@ -53,6 +53,7 @@ public class UserDto {
                 .address(userEntity.getAddress())
                 .position(userEntity.getPosition())
                 .userType(userEntity.getUserType())
+                .genderType(userEntity.getGenderType())
                 .createdAt(userEntity.getCreatedAt())
                 .updatedAt(userEntity.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -2,6 +2,8 @@ package com.example.basketballmatching.user.entity;
 
 import com.example.basketballmatching.global.entity.BaseEntity;
 import com.example.basketballmatching.user.dto.EditUserDto;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.*;
@@ -26,7 +28,7 @@ public class UserEntity extends BaseEntity {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Column(nullable = false, unique = true)
@@ -52,6 +54,14 @@ public class UserEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserType userType;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GenderType genderType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LoginProvider loginProvider;
+
     @Builder.Default
     private boolean emailAuth = false;
 
@@ -76,6 +86,10 @@ public class UserEntity extends BaseEntity {
 
         if (editUserDto.getPosition() != null) {
             this.position = editUserDto.getPosition();
+        }
+
+        if (editUserDto.getGenderType() != null) {
+            this.genderType = editUserDto.getGenderType();
         }
 
     }

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoDto.java
@@ -3,6 +3,8 @@ package com.example.basketballmatching.user.oauth2.dto;
 import com.example.basketballmatching.user.dto.SignUpDto;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.validation.constraints.Email;
@@ -45,8 +47,11 @@ public class KakaoDto {
                     .birth(LocalDate.now())
                     .phone("010-0000-0000")
                     .address("DEFAULT_ADDRESS")
+                    .loginProvider(LoginProvider.KAKAO)
                     .position(Position.NONE)
                     .userType(UserType.USER)
+                    .genderType(GenderType.NONE)
+                    .emailAuth(true)
                     .build();
         }
 

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoLoginDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoLoginDto.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class KakaoLoginDto {
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/service/impl/OAuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/service/impl/OAuthServiceImpl.java
@@ -1,11 +1,11 @@
 package com.example.basketballmatching.user.oauth2.service.impl;
 
-import com.example.basketballmatching.auth.dto.LoginDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
-import com.example.basketballmatching.global.dto.ApiResponse;
-import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.oauth2.dto.KakaoDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoLoginDto;
 import com.example.basketballmatching.user.oauth2.dto.KakaoOAuthTokenDto;
 import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto;
 import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto.KakaoAccount;
@@ -15,6 +15,7 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -24,10 +25,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OAuthServiceImpl implements OAuthService {
@@ -54,8 +56,12 @@ public class OAuthServiceImpl implements OAuthService {
 
     @Override
     public String responseUrl() {
-        return authorizationUri + "?response_type=code" + "&client_id=" + clientId
-                + "&redirect_uri=" + redirectUri;
+        return UriComponentsBuilder.fromUriString(authorizationUri)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .build()
+                .toString();
     }
 
 
@@ -64,39 +70,76 @@ public class OAuthServiceImpl implements OAuthService {
     @Transactional
     public TokenDto kakaoLogin(String code) throws JsonProcessingException {
 
+        if (code == null || code.isBlank()) {
+            throw new CustomException(ErrorCode.OAUTH_CODE_NOT_FOUND);
+        }
+
+
+        log.info("[카카오 유저 정보 발급]");
         KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(code);
         Properties properties = kakaoUserInfo.getProperties();
         KakaoAccount kakaoAccount = kakaoUserInfo.getKakao_account();
 
 
-        if (!userRepository.existsByEmail(kakaoAccount.getEmail())) {
+        log.info("[카카오 로그인 시작]");
 
+        if (!userRepository.existsByEmail(kakaoAccount.getEmail())) {
+            log.info("[카카오 유저 회원가입 시작] nickname : {}", properties.getNickname());
             KakaoDto.Request request = KakaoDto.Request.builder()
                     .email(kakaoAccount.getEmail())
                     .name(properties.getNickname())
                     .nickname(properties.getNickname())
                     .build();
 
+            log.info("[카카오 유저 회원가입 완료] nickname : {}", properties.getNickname());
             userRepository.save(KakaoDto.Request.toEntity(request));
 
         }
 
 
-        LoginDto.Request loginDto = kakaoUserLogin(kakaoAccount.getEmail());
+        KakaoLoginDto loginDto = kakaoUserLogin(kakaoAccount.getEmail());
 
-
-        return authService.loginUser(loginDto.getEmail(), loginDto.getPassword());
+        log.info("[카카오 로그인 완료] nickname : {}", properties.getNickname());
+        return authService.kakaoLogin(loginDto.getEmail());
     }
 
 
-    private KakaoUserInfoDto getKakaoUserInfo(String code) throws JsonProcessingException {
+    private KakaoUserInfoDto getKakaoUserInfo(String code){
 
-        ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
-        KakaoOAuthTokenDto accessToken = getAccessToken(accessTokenResponse);
-        ResponseEntity<String> userinfo = requestUserinfo(accessToken);
+        try {
 
 
-        return getUserInfo(userinfo);
+
+            ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+
+            if (accessTokenResponse.getBody() == null) {
+                log.warn("[카카오 토큰 발급 실패] state : {}", accessTokenResponse.getStatusCode());
+                throw new CustomException(ErrorCode.OAUTH_TOKEN_REQUEST_FAILED);
+            }
+
+
+            KakaoOAuthTokenDto accessToken = getAccessToken(accessTokenResponse);
+            ResponseEntity<String> userinfo = requestUserinfo(accessToken);
+
+            if (userinfo.getBody() == null) {
+                log.warn("[카카오 사용자 정보 요청 실패] state : {}", userinfo.getStatusCode());
+                throw new CustomException(ErrorCode.OAUTH_USERINFO_REQUEST_FAILED);
+            }
+
+            log.info("[카카오 토큰 발급 성공]");
+
+            return getUserInfo(userinfo);
+
+        } catch (HttpStatusCodeException e) {
+            log.warn("[카카오 토큰 요청 오류] status : {}", e.getStatusCode());
+            throw new CustomException(ErrorCode.OAUTH_USERINFO_REQUEST_FAILED);
+        } catch (JsonProcessingException e) {
+            log.warn("[카카오 토큰 응답 파싱 실패]");
+            throw new CustomException(ErrorCode.OAUTH_USERINFO_RESPONSE_PARSE_ERROR);
+        } catch (Exception e) {
+            log.info("[내부 서버 오류] : {}", e.getMessage());
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
 
     }
 
@@ -155,10 +198,9 @@ public class OAuthServiceImpl implements OAuthService {
         return objectMapper.readValue(response.getBody(), KakaoUserInfoDto.class);
     }
 
-    public LoginDto.Request kakaoUserLogin(String email) {
-        return LoginDto.Request.builder()
+    public KakaoLoginDto kakaoUserLogin(String email) {
+        return KakaoLoginDto.builder()
                 .email(email)
-                .password("kakao")
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/user/type/GenderType.java
+++ b/src/main/java/com/example/basketballmatching/user/type/GenderType.java
@@ -1,0 +1,6 @@
+package com.example.basketballmatching.user.type;
+
+public enum GenderType {
+
+    MALE, FEMALE, NONE
+}

--- a/src/main/java/com/example/basketballmatching/user/type/LoginProvider.java
+++ b/src/main/java/com/example/basketballmatching/user/type/LoginProvider.java
@@ -1,0 +1,7 @@
+package com.example.basketballmatching.user.type;
+
+public enum LoginProvider {
+
+
+    LOCAL, KAKAO
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=basketball-matching


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 생성기능 미구현

---

### 🚀 TO-BE
✅ 경기 생성 기능 구현
- 경기 생성 조건 검증
   - 경기 시작 시간이 현재 시간보다 이전이거나
종료 시간이 시작 시간보다 이전인 경우 → INVALID_GAME_TIME 예외 발생
   - 경기 시간은 최소 60분 ~ 최대 120분 사이로 제한
   - 3대3 경기 → 최소 6명 / 최대 9명
   - 5대5 경기 → 최소 10명 / 최대 15명
   - JPQL을 이용해 동일 시간 + 동일 장소 중복 경기 존재 시 → PLACE_SCHEDULE_OVERLAP 예외 발생
- 검증 통과 시 GameEntity 생성 및 저장
- 응답으로 ApiResponse<GameDto> 형태의 공통응답 포맷 적용


---

## ✅ 체크리스트
- [x] API테스트
- [x] 유효성 검증 로직 정상 작동


---
