### PR TITLE
[feat] : 경기 참가 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -106,6 +106,10 @@ public class GameEntity extends BaseEntity {
 
     }
 
+    public void increaseParticipantCount() {
+        this.participantCount++;
+    }
+
     // 테스트용
     public void setDeletedDateTime(LocalDateTime deletedDateTime) {
         this.deletedDateTime = deletedDateTime;

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -1,0 +1,68 @@
+package com.example.basketballmatching.gameCreator.entity;
+
+
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ParticipantGameEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long participantGameId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipantGameStatus participantGameStatus;
+
+    private LocalDateTime acceptDateTime;
+
+    private LocalDateTime rejectDateTime;
+
+    private LocalDateTime canceledDateTime;
+
+    private LocalDateTime withDrawDateTime;
+
+    private LocalDateTime kickoutDateTime;
+
+    private LocalDateTime deletedDateTime;
+
+
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private GameEntity gameEntity;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private UserEntity userEntity;
+
+    public ParticipantGameEntity toGameCreatorEntity(
+            GameEntity gameEntity, UserEntity userEntity
+    ) {
+
+        return ParticipantGameEntity.builder()
+                .participantGameStatus(ParticipantGameStatus.ACCEPT)
+                .gameEntity(gameEntity)
+                .userEntity(userEntity)
+                .build();
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -1,0 +1,15 @@
+package com.example.basketballmatching.gameCreator.repository;
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
+
+    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long gameId, Long UserId);
+
+    int countByParticipantGameStatusAndGameEntity_GameId(
+            ParticipantGameStatus participantGameStatus, Long gameId
+    );
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -12,6 +12,8 @@ import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class GameServiceImpl implements GameService {
     private final UserRepository userRepository;
     private final GameRepository gameRepository;
     private final GameQueryRepository gameQueryRepository;
+    private final ParticipantGameRepository participantGameRepository;
 
     @Override
     @Transactional
@@ -50,6 +53,11 @@ public class GameServiceImpl implements GameService {
         GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
 
         gameRepository.save(gameEntity);
+
+        ParticipantGameEntity participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, userEntity);
+
+        participantGameRepository.save(participantGameEntity);
+
 
         log.info("[경기 생성 완료] gameId = {}", gameEntity.getGameId());
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
@@ -2,6 +2,6 @@ package com.example.basketballmatching.gameCreator.type;
 
 public enum MatchGenderType {
 
-    MAIL_ONLY, FEMALE_ONLY, MIXED
+    MALE_ONLY, FEMALE_ONLY, MIXED
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
@@ -1,0 +1,13 @@
+package com.example.basketballmatching.gameCreator.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public enum ParticipantGameStatus {
+
+    APPLY, ACCEPT, REJECT, CANCEL, WITHDRAW, KICKOUT, DELETE
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -1,0 +1,34 @@
+package com.example.basketballmatching.gameUsers.controller;
+
+
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/game/participant")
+public class GameUserController {
+
+    private final GameUserService gameUserService;
+
+    @PostMapping("/apply")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<ApplyGameUserDto>> applyGame(
+            @RequestParam Long gameId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(applyGame);
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/ApplyGameUserDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/ApplyGameUserDto.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApplyGameUserDto {
+
+
+    private Long userId;
+
+    private Long gameId;
+
+    private String gameAddress;
+
+    private ParticipantGameStatus participantGameStatus;
+
+    private LocalDateTime createdDateTime;
+
+    public static ApplyGameUserDto fromEntity(ParticipantGameEntity participantGameEntity) {
+        return ApplyGameUserDto.builder()
+                .userId(participantGameEntity.getUserEntity().getUserId())
+                .gameId(participantGameEntity.getGameEntity().getGameId())
+                .participantGameStatus(participantGameEntity.getParticipantGameStatus())
+                .gameAddress(participantGameEntity.getGameEntity().getAddress())
+                .createdDateTime(participantGameEntity.getCreatedAt())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,0 +1,11 @@
+package com.example.basketballmatching.gameUsers.service;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+
+public interface GameUserService {
+
+
+    ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameUserServiceImpl implements GameUserService {
+
+    private final ParticipantGameRepository participantGameRepository;
+
+    private final UserRepository userRepository;
+
+    private final GameRepository gameRepository;
+
+    @Override
+    @Transactional
+    public ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
+        log.info("[경기 참가 신청 시작] gameId : {} userId : {}", gameId, userId);
+
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        validateParticipantInfo(userEntity, gameEntity);
+
+        ParticipantGameEntity entity = ParticipantGameEntity.builder()
+                .participantGameStatus(ParticipantGameStatus.APPLY)
+                .gameEntity(gameEntity)
+                .userEntity(userEntity)
+                .build();
+
+        participantGameRepository.save(entity);
+
+        ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(entity);
+
+
+        log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, entity.getParticipantGameId());
+
+        return ApiResponse.of("경기 신청이 완료되었습니다.", participantDto);
+    }
+
+    private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
+            throw new CustomException(ALREADY_APPLY_GAME_USER);
+        }
+
+        if (participantGameRepository.countByParticipantGameStatusAndGameEntity_GameId(
+                ParticipantGameStatus.APPLY, gameEntity.getGameId()
+        ) >= gameEntity.getHeadCount()) {
+            throw new CustomException(FULL_HEADCOUNT_GAME);
+        }
+
+        if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
+            throw new CustomException(NOT_ALLOWED_TO_JOIN);
+        }
+
+        if (gameEntity.getMatchGenderType().equals(MatchGenderType.FEMALE_ONLY) &&
+        userEntity.getGenderType().equals(GenderType.MALE)) {
+            throw new CustomException(ONLY_FEMALE_GAME);
+        }
+
+
+        if (gameEntity.getMatchGenderType().equals(MatchGenderType.MALE_ONLY) &&
+                userEntity.getGenderType().equals(GenderType.FEMALE)) {
+            throw new CustomException(ONLY_MALE_GAME);
+        }
+
+
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -52,7 +52,12 @@ public enum ErrorCode {
     NOT_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자가 아닙니다."),
     UPDATE_GAME_HEAD_COUNT(HttpStatus.BAD_REQUEST, "경기 인원 수를 변경해주세요.")
 
-
+    // participant
+    , ALREADY_APPLY_GAME_USER(HttpStatus.BAD_REQUEST, "이미 참가 신청한 유저입니다."),
+    FULL_HEADCOUNT_GAME(HttpStatus.BAD_REQUEST, "남은 신청 자리가 없습니다."),
+    NOT_ALLOWED_TO_JOIN(HttpStatus.BAD_REQUEST, "경기 참가를 요청할 수 없습니다."),
+    ONLY_FEMALE_GAME(HttpStatus.BAD_REQUEST, "여성 유저만 신청가능합니다."),
+    ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다.")
     ;
 
 

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -1,0 +1,224 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.type.FieldStatus;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import static com.example.basketballmatching.global.exception.ErrorCode.GAME_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class GameUserServiceImplTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private GameUserService gameUserService;
+
+    @BeforeEach
+    void setUp() {
+        // given: 테스트용 유저 데이터 삽입
+        UserEntity creator = UserEntity.builder()
+                .email("test2@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("name")
+                .nickname("name")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        UserEntity gameUser = UserEntity.builder()
+                .email("test3@example.com")
+                .password(passwordEncoder.encode("Test@1234"))
+                .name("name")
+                .nickname("name2")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소2")
+                .phone("010-1111-1112")
+                .position(Position.GUARD)
+                .genderType(GenderType.FEMALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+
+        creator.setEmailAuth();
+        gameUser.setEmailAuth();
+
+        userRepository.save(creator);
+        userRepository.save(gameUser);
+
+        CreateGameDto.Request request = CreateGameDto.Request.builder()
+                .title("테스트 게임")
+                .content("테스트 게임 본문")
+                .headCount(9)
+                .fieldStatus(FieldStatus.OUTDOOR)
+                .matchGenderType(MatchGenderType.FEMALE_ONLY)
+                .startDateTime(LocalDateTime.now().plusHours(2L))
+                .endDateTime(LocalDateTime.now().plusHours(3L))
+                .placeName("테스트 게임 장소")
+                .address("인천광역시 테스트 게임 주소")
+                .matchFormat(MatchFormat.THREE_ON_THREE)
+                .build();
+
+        GameEntity gameEntity = CreateGameDto.Request.toEntity(request, creator);
+
+        gameRepository.save(gameEntity);
+    }
+
+    @Test
+    @DisplayName("경기 신청 테스트")
+    void applyGameTest() {
+        // given
+
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        // when
+
+        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+
+        // then
+        assertEquals("경기 신청이 완료되었습니다.", applyGame.getMessage());
+
+        assertEquals(userEntity.getUserId(), applyGame.getData().getUserId());
+
+
+    }
+
+    @Test
+    @DisplayName("경기 신청 실패 - 여성만 참여가능 -> 남성 참가자가 신청 시")
+    void applyGameTest_Fail_FEMALE_ONLY() {
+        // given
+        UserEntity gameUser = UserEntity.builder()
+                .email("test4@example.com")
+                .password(passwordEncoder.encode("Test@1234!"))
+                .name("name3")
+                .nickname("name3")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소23")
+                .phone("010-1111-1112")
+                .position(Position.GUARD)
+                // 남성 유저
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        userRepository.save(gameUser);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameEntity.getGameId(), gameUser.getUserId()));
+        // then
+
+        assertEquals(ErrorCode.ONLY_FEMALE_GAME, exception.getErrorCode());
+
+
+    }
+
+    @Test
+    @DisplayName("경기 신청 실패 테스트 - 경기 인원 초과")
+    void applyGameTest_Fail_Full_HeadCount() {
+        // given
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        int headCount = gameEntity.getHeadCount();
+
+        for (int i = 0; i < headCount; i++) {
+            UserEntity extraUser = UserEntity.builder()
+                    .email("extra" + i + "@example.com")
+                    .password(passwordEncoder.encode("Test@1234!"))
+                    .name("참가자" + i)
+                    .nickname("참가자" + i)
+                    .birth(LocalDate.of(1998, 1, 1))
+                    .address("인천시 테스트주소" + i)
+                    .phone("010-9999-99" + i)
+                    .position(Position.GUARD)
+                    .genderType(GenderType.FEMALE)
+                    .loginProvider(LoginProvider.LOCAL)
+                    .userType(UserType.USER)
+                    .build();
+
+            userRepository.save(extraUser);
+
+            // 이미 참가된 상태를 DB에 반영 (status = APPLY)
+            gameUserService.applyGame(gameEntity.getGameId(), extraUser.getUserId());
+        }
+
+        UserEntity user = UserEntity.builder()
+                .email("overUser@example.com")
+                .password(passwordEncoder.encode("Test@1234!"))
+                .name("초과유저")
+                .nickname("overUser")
+                .birth(LocalDate.of(1999, 1, 1))
+                .address("인천시 초과주소")
+                .phone("010-8888-8888")
+                .position(Position.GUARD)
+                .genderType(GenderType.FEMALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+        userRepository.save(user);
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () ->
+                gameUserService.applyGame(gameEntity.getGameId(), user.getUserId()));
+
+        // then
+
+        assertEquals(ErrorCode.FULL_HEADCOUNT_GAME, exception.getErrorCode());
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 참가 기능 미구현

---

### 🚀 TO-BE
✅ 경기 참가 기능 구현
- 경기 참가 신청 유효성 검사
   - 중복 신청 불가
   - 경기 신청 인원이 최대 인원 수 초과 시 `FULL_HEADCOUNT_GAME` 예외 발생  
    → JPA 쿼리 메서드 `countByParticipantGameStatusAndGameEntity_GameId` 활용
   - 경기 시작 30분 전에는 경기 신청 불가
   - 남성 및 여성만 참여하는 기능 성별이 다를 시 경기 신청 불가

✅ 테스트 코드 작성
- 정상 신청 성공 테스트
- 실패 테스트
  - 성별 불일치 시 `CustomException` 검증
  - 최대 인원 초과 시 `CustomException` 검증


---

## ✅ 체크리스트
- [x] 경기 참가 신청 구현
- [x] 테스트 코드 작성
- [x] API테스트 
---
