### PR TITLE
[feat] : 경기 참가 승인 및 신청자 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
@@ -1,0 +1,58 @@
+package com.example.basketballmatching.gameCreator.controller;
+
+
+import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
+import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/game/creator")
+@RequiredArgsConstructor
+public class ParticipantGameController {
+
+    private final ParticipantGameService participantGameService;
+
+    @GetMapping("/apply-user")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<ApplyGameUserListDto>>> getApplyParticipantList (
+            @RequestParam Long gameId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+
+            ) {
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC, "createdAt");
+
+        ApiResponse<List<ApplyGameUserListDto>> participantList = participantGameService.getApplyParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+
+
+        return ResponseEntity.ok(participantList);
+    }
+
+    @PatchMapping("/accept-user")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> acceptGameUser (
+            @RequestParam Long gameId,
+            @RequestParam Long participantId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        CheckResponse checkResponse = participantGameService.acceptGameUser(participantId, userInfoDetails.getUserEntity().getUserId(), gameId);
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/ApplyGameUserListDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/ApplyGameUserListDto.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ApplyGameUserListDto {
+
+    private Long participantId;
+
+    private String nickname;
+
+    private GenderType genderType;
+
+    private Position position;
+
+    private LocalDate birth;
+
+    public static ApplyGameUserListDto fromEntity(ParticipantGameEntity participantGameEntity) {
+
+        return ApplyGameUserListDto.builder()
+                .participantId(participantGameEntity.getParticipantGameId())
+                .nickname(participantGameEntity.getUserEntity().getNickname())
+                .genderType(participantGameEntity.getUserEntity().getGenderType())
+                .position(participantGameEntity.getUserEntity().getPosition())
+                .birth(participantGameEntity.getUserEntity().getBirth())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -106,6 +106,10 @@ public class GameEntity extends BaseEntity {
 
     }
 
+    public void increaseParticipantCount() {
+        this.participantCount++;
+    }
+
     // 테스트용
     public void setDeletedDateTime(LocalDateTime deletedDateTime) {
         this.deletedDateTime = deletedDateTime;

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -60,6 +60,10 @@ public class ParticipantGameEntity extends BaseEntity {
                 .build();
     }
 
+    public void setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime acceptDateTime) {
+        this.participantGameStatus = participantGameStatus;
+        this.acceptDateTime = acceptDateTime;
+    }
 
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -1,0 +1,68 @@
+package com.example.basketballmatching.gameCreator.entity;
+
+
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ParticipantGameEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long participantGameId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipantGameStatus participantGameStatus;
+
+    private LocalDateTime acceptDateTime;
+
+    private LocalDateTime rejectDateTime;
+
+    private LocalDateTime canceledDateTime;
+
+    private LocalDateTime withDrawDateTime;
+
+    private LocalDateTime kickoutDateTime;
+
+    private LocalDateTime deletedDateTime;
+
+
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private GameEntity gameEntity;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private UserEntity userEntity;
+
+    public ParticipantGameEntity toGameCreatorEntity(
+            GameEntity gameEntity, UserEntity userEntity
+    ) {
+
+        return ParticipantGameEntity.builder()
+                .participantGameStatus(ParticipantGameStatus.ACCEPT)
+                .gameEntity(gameEntity)
+                .userEntity(userEntity)
+                .build();
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -2,6 +2,8 @@ package com.example.basketballmatching.gameCreator.repository;
 
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
@@ -11,5 +13,9 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
     int countByParticipantGameStatusAndGameEntity_GameId(
             ParticipantGameStatus participantGameStatus, Long gameId
     );
+
+    Page<ParticipantGameEntity> findByParticipantGameStatusAndGameEntity_GameId(ParticipantGameStatus status, Long gameId, Pageable pageable);
+
+
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -1,0 +1,15 @@
+package com.example.basketballmatching.gameCreator.repository;
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
+
+    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long gameId, Long UserId);
+
+    int countByParticipantGameStatusAndGameEntity_GameId(
+            ParticipantGameStatus participantGameStatus, Long gameId
+    );
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
@@ -1,0 +1,19 @@
+package com.example.basketballmatching.gameCreator.service;
+
+import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ParticipantGameService {
+
+
+
+    ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable);
+
+
+    CheckResponse acceptGameUser(Long participantId, Long userId, Long GameId);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -12,6 +12,8 @@ import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class GameServiceImpl implements GameService {
     private final UserRepository userRepository;
     private final GameRepository gameRepository;
     private final GameQueryRepository gameQueryRepository;
+    private final ParticipantGameRepository participantGameRepository;
 
     @Override
     @Transactional
@@ -50,6 +53,11 @@ public class GameServiceImpl implements GameService {
         GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
 
         gameRepository.save(gameEntity);
+
+        ParticipantGameEntity participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, userEntity);
+
+        participantGameRepository.save(participantGameEntity);
+
 
         log.info("[경기 생성 완료] gameId = {}", gameEntity.getGameId());
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -1,0 +1,115 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.ACCEPT;
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.APPLY;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantGameServiceImpl implements ParticipantGameService {
+
+    private final ParticipantGameRepository participantGameRepository;
+
+    private final GameRepository gameRepository;
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable) {
+
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+        // 지원자 목록 조회 (엔티티 기준)
+        Page<ParticipantGameEntity> pages = participantGameRepository.
+                findByParticipantGameStatusAndGameEntity_GameId(APPLY, gameEntity.getGameId(), pageable);
+
+
+        // DTO 변환
+        List<ApplyGameUserListDto> participantGameList = pages.stream().map(ApplyGameUserListDto::fromEntity).toList();
+
+        return ApiResponse.of("경기 신청자 조회가 완료되었습니다.", participantGameList);
+    }
+
+    @Override
+    @Transactional
+    public CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId) {
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participantId, gameId);
+
+        if (!exists) {
+            throw new CustomException(NOT_APPLY_USER);
+        }
+        LocalDateTime now = LocalDateTime.now();
+        if (gameEntity.getStartDateTime().isBefore(now)) {
+            throw new CustomException(ALREADY_START_GAME);
+        }
+
+        if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
+            throw new CustomException(FULL_HEADCOUNT_GAME);
+        }
+
+
+
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findById(participantId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
+            throw new CustomException(ALREADY_ACCEPT_USER);
+        }
+
+        participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, now);
+
+        gameEntity.increaseParticipantCount();
+
+        gameRepository.save(gameEntity);
+        participantGameRepository.save(participantGameEntity);
+
+
+
+
+        return CheckResponse.of(true, "경기 수락이 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/MatchGenderType.java
@@ -2,6 +2,6 @@ package com.example.basketballmatching.gameCreator.type;
 
 public enum MatchGenderType {
 
-    MAIL_ONLY, FEMALE_ONLY, MIXED
+    MALE_ONLY, FEMALE_ONLY, MIXED
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
@@ -1,0 +1,13 @@
+package com.example.basketballmatching.gameCreator.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public enum ParticipantGameStatus {
+
+    APPLY, ACCEPT, REJECT, CANCEL, WITHDRAW, KICKOUT, DELETE
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -1,0 +1,34 @@
+package com.example.basketballmatching.gameUsers.controller;
+
+
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/game/participant")
+public class GameUserController {
+
+    private final GameUserService gameUserService;
+
+    @PostMapping("/apply")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<ApplyGameUserDto>> applyGame(
+            @RequestParam Long gameId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+            ) {
+
+        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(applyGame);
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/game/participant")
+@RequestMapping("api/v1/game")
 public class GameUserController {
 
     private final GameUserService gameUserService;

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/ApplyGameUserDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/ApplyGameUserDto.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApplyGameUserDto {
+
+
+    private Long userId;
+
+    private Long gameId;
+
+    private String gameAddress;
+
+    private ParticipantGameStatus participantGameStatus;
+
+    private LocalDateTime createdDateTime;
+
+    public static ApplyGameUserDto fromEntity(ParticipantGameEntity participantGameEntity) {
+        return ApplyGameUserDto.builder()
+                .userId(participantGameEntity.getUserEntity().getUserId())
+                .gameId(participantGameEntity.getGameEntity().getGameId())
+                .participantGameStatus(participantGameEntity.getParticipantGameStatus())
+                .gameAddress(participantGameEntity.getGameEntity().getAddress())
+                .createdDateTime(participantGameEntity.getCreatedAt())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,0 +1,11 @@
+package com.example.basketballmatching.gameUsers.service;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+
+public interface GameUserService {
+
+
+    ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameUserServiceImpl implements GameUserService {
+
+    private final ParticipantGameRepository participantGameRepository;
+
+    private final UserRepository userRepository;
+
+    private final GameRepository gameRepository;
+
+    @Override
+    @Transactional
+    public ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
+        log.info("[경기 참가 신청 시작] gameId : {} userId : {}", gameId, userId);
+
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        validateParticipantInfo(userEntity, gameEntity);
+
+        ParticipantGameEntity entity = ParticipantGameEntity.builder()
+                .participantGameStatus(ParticipantGameStatus.APPLY)
+                .gameEntity(gameEntity)
+                .userEntity(userEntity)
+                .build();
+
+        participantGameRepository.save(entity);
+
+        ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(entity);
+
+
+        log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, entity.getParticipantGameId());
+
+        return ApiResponse.of("경기 신청이 완료되었습니다.", participantDto);
+    }
+
+    private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
+            throw new CustomException(ALREADY_APPLY_GAME_USER);
+        }
+
+        if (participantGameRepository.countByParticipantGameStatusAndGameEntity_GameId(
+                ParticipantGameStatus.APPLY, gameEntity.getGameId()
+        ) >= gameEntity.getHeadCount()) {
+            throw new CustomException(FULL_HEADCOUNT_GAME);
+        }
+
+        if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
+            throw new CustomException(NOT_ALLOWED_TO_JOIN);
+        }
+
+        if (gameEntity.getMatchGenderType().equals(MatchGenderType.FEMALE_ONLY) &&
+        userEntity.getGenderType().equals(GenderType.MALE)) {
+            throw new CustomException(ONLY_FEMALE_GAME);
+        }
+
+
+        if (gameEntity.getMatchGenderType().equals(MatchGenderType.MALE_ONLY) &&
+                userEntity.getGenderType().equals(GenderType.FEMALE)) {
+            throw new CustomException(ONLY_MALE_GAME);
+        }
+
+
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -57,7 +57,11 @@ public enum ErrorCode {
     FULL_HEADCOUNT_GAME(HttpStatus.BAD_REQUEST, "남은 신청 자리가 없습니다."),
     NOT_ALLOWED_TO_JOIN(HttpStatus.BAD_REQUEST, "경기 참가를 요청할 수 없습니다."),
     ONLY_FEMALE_GAME(HttpStatus.BAD_REQUEST, "여성 유저만 신청가능합니다."),
-    ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다.")
+    ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다."),
+    NOT_APPLY_USER(HttpStatus.BAD_REQUEST, "경기 참가 신청을 한 유저가 아닙니다."),
+    ALREADY_START_GAME(HttpStatus.BAD_REQUEST, "이미 시작한 경기입니다."),
+    PARTICIPANT_NOT_FOUND(HttpStatus.BAD_REQUEST, "경기 참가자를 찾을 수 없습니다."),
+    ALREADY_ACCEPT_USER(HttpStatus.BAD_REQUEST, "이미 수락된 참가자입니다.")
     ;
 
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -52,7 +52,12 @@ public enum ErrorCode {
     NOT_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자가 아닙니다."),
     UPDATE_GAME_HEAD_COUNT(HttpStatus.BAD_REQUEST, "경기 인원 수를 변경해주세요.")
 
-
+    // participant
+    , ALREADY_APPLY_GAME_USER(HttpStatus.BAD_REQUEST, "이미 참가 신청한 유저입니다."),
+    FULL_HEADCOUNT_GAME(HttpStatus.BAD_REQUEST, "남은 신청 자리가 없습니다."),
+    NOT_ALLOWED_TO_JOIN(HttpStatus.BAD_REQUEST, "경기 참가를 요청할 수 없습니다."),
+    ONLY_FEMALE_GAME(HttpStatus.BAD_REQUEST, "여성 유저만 신청가능합니다."),
+    ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다.")
     ;
 
 

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -1,0 +1,224 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.type.FieldStatus;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import static com.example.basketballmatching.global.exception.ErrorCode.GAME_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class GameUserServiceImplTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private GameUserService gameUserService;
+
+    @BeforeEach
+    void setUp() {
+        // given: 테스트용 유저 데이터 삽입
+        UserEntity creator = UserEntity.builder()
+                .email("test2@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("name")
+                .nickname("name")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        UserEntity gameUser = UserEntity.builder()
+                .email("test3@example.com")
+                .password(passwordEncoder.encode("Test@1234"))
+                .name("name")
+                .nickname("name2")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소2")
+                .phone("010-1111-1112")
+                .position(Position.GUARD)
+                .genderType(GenderType.FEMALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+
+        creator.setEmailAuth();
+        gameUser.setEmailAuth();
+
+        userRepository.save(creator);
+        userRepository.save(gameUser);
+
+        CreateGameDto.Request request = CreateGameDto.Request.builder()
+                .title("테스트 게임")
+                .content("테스트 게임 본문")
+                .headCount(9)
+                .fieldStatus(FieldStatus.OUTDOOR)
+                .matchGenderType(MatchGenderType.FEMALE_ONLY)
+                .startDateTime(LocalDateTime.now().plusHours(2L))
+                .endDateTime(LocalDateTime.now().plusHours(3L))
+                .placeName("테스트 게임 장소")
+                .address("인천광역시 테스트 게임 주소")
+                .matchFormat(MatchFormat.THREE_ON_THREE)
+                .build();
+
+        GameEntity gameEntity = CreateGameDto.Request.toEntity(request, creator);
+
+        gameRepository.save(gameEntity);
+    }
+
+    @Test
+    @DisplayName("경기 신청 테스트")
+    void applyGameTest() {
+        // given
+
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        // when
+
+        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+
+        // then
+        assertEquals("경기 신청이 완료되었습니다.", applyGame.getMessage());
+
+        assertEquals(userEntity.getUserId(), applyGame.getData().getUserId());
+
+
+    }
+
+    @Test
+    @DisplayName("경기 신청 실패 - 여성만 참여가능 -> 남성 참가자가 신청 시")
+    void applyGameTest_Fail_FEMALE_ONLY() {
+        // given
+        UserEntity gameUser = UserEntity.builder()
+                .email("test4@example.com")
+                .password(passwordEncoder.encode("Test@1234!"))
+                .name("name3")
+                .nickname("name3")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소23")
+                .phone("010-1111-1112")
+                .position(Position.GUARD)
+                // 남성 유저
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        userRepository.save(gameUser);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameEntity.getGameId(), gameUser.getUserId()));
+        // then
+
+        assertEquals(ErrorCode.ONLY_FEMALE_GAME, exception.getErrorCode());
+
+
+    }
+
+    @Test
+    @DisplayName("경기 신청 실패 테스트 - 경기 인원 초과")
+    void applyGameTest_Fail_Full_HeadCount() {
+        // given
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        int headCount = gameEntity.getHeadCount();
+
+        for (int i = 0; i < headCount; i++) {
+            UserEntity extraUser = UserEntity.builder()
+                    .email("extra" + i + "@example.com")
+                    .password(passwordEncoder.encode("Test@1234!"))
+                    .name("참가자" + i)
+                    .nickname("참가자" + i)
+                    .birth(LocalDate.of(1998, 1, 1))
+                    .address("인천시 테스트주소" + i)
+                    .phone("010-9999-99" + i)
+                    .position(Position.GUARD)
+                    .genderType(GenderType.FEMALE)
+                    .loginProvider(LoginProvider.LOCAL)
+                    .userType(UserType.USER)
+                    .build();
+
+            userRepository.save(extraUser);
+
+            // 이미 참가된 상태를 DB에 반영 (status = APPLY)
+            gameUserService.applyGame(gameEntity.getGameId(), extraUser.getUserId());
+        }
+
+        UserEntity user = UserEntity.builder()
+                .email("overUser@example.com")
+                .password(passwordEncoder.encode("Test@1234!"))
+                .name("초과유저")
+                .nickname("overUser")
+                .birth(LocalDate.of(1999, 1, 1))
+                .address("인천시 초과주소")
+                .phone("010-8888-8888")
+                .position(Position.GUARD)
+                .genderType(GenderType.FEMALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+        userRepository.save(user);
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () ->
+                gameUserService.applyGame(gameEntity.getGameId(), user.getUserId()));
+
+        // then
+
+        assertEquals(ErrorCode.FULL_HEADCOUNT_GAME, exception.getErrorCode());
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 신청 승인 및 경기 신청자 조회 기능 미구현

### 🚀 TO-BE
✅ 경기 신청자 조회 기능 구현
- 경기 신청자 유효성 검사
   - 경기 생성자만 조회 가능
   - JPA 메서드 `findByParticipantGameStatusAndGameEntity_GameId` 사용 결과를 `Page`로 조회 후 `Stream`을 통해 `List<ApplyGameUserListDto>`로 변환 및 반환 
   

✅ 경기 신청 승인 기능 구현
- 경기 신청 승인 시 유효성 검사 
   - 경기 생성자만 승인 가능 
   - `existsByUserEntity_UserIdAndGameEntity_GameId`로 신청자 여부 확인  
   - 이미 승인된 유저일 경우 예외 발생  
- 경기 승인
   - 유효성 검사 통과 후 ParticipantStatus -> ACCEPT로 변경
   - GameEntity participantCount 컬럼 증가 시킨 후 CheckResponse 반환

---

## ✅ 체크리스트
- [x] 경기 신청자 리스트 조회
- [x] 경기 신청 승인
- [x] API 테스트
---
