### PR TITLE
[feat] : 경기 거절,취소,강퇴 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.gameCreator.controller;
 
 
+import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
 import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
 import com.example.basketballmatching.global.dto.ApiResponse;
@@ -23,7 +24,7 @@ public class ParticipantGameController {
 
     private final ParticipantGameService participantGameService;
 
-    @GetMapping("/apply-user")
+    @GetMapping("/search/apply")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<ApiResponse<List<ApplyGameUserListDto>>> getApplyParticipantList (
             @RequestParam Long gameId,
@@ -42,7 +43,24 @@ public class ParticipantGameController {
         return ResponseEntity.ok(participantList);
     }
 
-    @PatchMapping("/accept-user")
+    @GetMapping("/search/accept")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<AcceptGameUserListDto>>> getAcceptParticipantList(
+            @RequestParam Long gameId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC, "createdAt");
+
+        ApiResponse<List<AcceptGameUserListDto>> acceptParticipantList = participantGameService.getAcceptParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+        return ResponseEntity.ok(acceptParticipantList);
+    }
+
+
+    @PatchMapping("/accept")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> acceptGameUser (
             @RequestParam Long gameId,
@@ -51,6 +69,46 @@ public class ParticipantGameController {
     ) {
 
         CheckResponse checkResponse = participantGameService.acceptGameUser(participantId, userInfoDetails.getUserEntity().getUserId(), gameId);
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+    @PatchMapping("/reject")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> rejectGameUser (
+            @RequestParam Long gameId,
+            @RequestParam Long participantId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        CheckResponse checkResponse = participantGameService.rejectGameUser(participantId, userInfoDetails.getUserEntity().getUserId(), gameId);
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+    @PatchMapping("/kickout")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> kickoutGameUser (
+            @RequestParam Long gameId,
+            @RequestParam Long participantId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        CheckResponse checkResponse = participantGameService.kickOutGameUser(participantId, userInfoDetails.getUserEntity().getUserId(), gameId);
+
+        return ResponseEntity.ok(checkResponse);
+
+    }
+
+    @PatchMapping("/delete")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> deleteGame (
+            @RequestParam Long gameId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        CheckResponse checkResponse = participantGameService.deleteGame(userInfoDetails.getUserEntity().getUserId(), gameId);
+
 
         return ResponseEntity.ok(checkResponse);
     }

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/AcceptGameUserListDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/AcceptGameUserListDto.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AcceptGameUserListDto {
+
+
+    private Long participantId;
+
+    private String nickname;
+
+    private GenderType genderType;
+
+    private Position position;
+
+    private LocalDate birth;
+
+    public static AcceptGameUserListDto fromEntity(ParticipantGameEntity participantGameEntity) {
+        return AcceptGameUserListDto.builder()
+                .participantId(participantGameEntity.getParticipantGameId())
+                .nickname(participantGameEntity.getUserEntity().getNickname())
+                .genderType(participantGameEntity.getUserEntity().getGenderType())
+                .position(participantGameEntity.getUserEntity().getPosition())
+                .birth(participantGameEntity.getUserEntity().getBirth())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -110,6 +110,10 @@ public class GameEntity extends BaseEntity {
         this.participantCount++;
     }
 
+    public void decreaseParticipantCount() {
+        this.participantCount--;
+    }
+
     // 테스트용
     public void setDeletedDateTime(LocalDateTime deletedDateTime) {
         this.deletedDateTime = deletedDateTime;

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -66,7 +66,25 @@ public class ParticipantGameEntity extends BaseEntity {
     }
 
 
+    public void setParticipantGameStatusAndRejectDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime rejectDateTime) {
+        this.participantGameStatus = participantGameStatus;
+        this.rejectDateTime = rejectDateTime;
+    }
 
+    public void setParticipantGameStatusAndCanceledDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime canceledDateTime) {
+        this.participantGameStatus = participantGameStatus;
+        this.canceledDateTime = canceledDateTime;
+    }
+
+    public void setParticipantGameStatusAndKickoutDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime kickoutDateTime) {
+        this.participantGameStatus = participantGameStatus;
+        this.kickoutDateTime = kickoutDateTime;
+    }
+
+    public void setParticipantGameStatusAndDeletedDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime deletedDateTime) {
+        this.participantGameStatus = participantGameStatus;
+        this.deletedDateTime = deletedDateTime;
+    }
 
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.QGameEntity;
 import com.example.basketballmatching.gameCreator.type.*;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -60,11 +61,15 @@ public class GameQueryRepository {
         return new PageImpl<>(searchGames, pageable, total);
     }
 
+
+
     private static void validationSearch(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, BooleanBuilder builder, QGameEntity qGameEntity) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
         builder.and(qGameEntity.startDateTime.between(startOfDay, endOfDay));
+
+        builder.and(qGameEntity.deletedDateTime.isNull());
 
         if (cityName != null) {
             builder.and(qGameEntity.cityName.eq(cityName));

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
 
     boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long gameId, Long UserId);
@@ -15,6 +18,10 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
     );
 
     Page<ParticipantGameEntity> findByParticipantGameStatusAndGameEntity_GameId(ParticipantGameStatus status, Long gameId, Pageable pageable);
+
+    List<ParticipantGameEntity> findByParticipantGameStatusInAndGameEntity_GameId(List<ParticipantGameStatus> statuses, Long gameId);
+
+    Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
 
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.gameCreator.service;
 
+import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
 import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
@@ -13,7 +14,16 @@ public interface ParticipantGameService {
 
     ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable);
 
+    ApiResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable);
 
-    CheckResponse acceptGameUser(Long participantId, Long userId, Long GameId);
+    CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId);
+
+
+    CheckResponse rejectGameUser(Long participantId, Long userId, Long gameId);
+
+    CheckResponse kickOutGameUser(Long participantId, Long userId, Long gameId);
+
+    CheckResponse deleteGame(Long userId, Long gameId);
+
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -39,6 +39,9 @@ public class GameServiceImpl implements GameService {
     private final GameQueryRepository gameQueryRepository;
     private final ParticipantGameRepository participantGameRepository;
 
+    /**
+     * 경기 생성
+     */
     @Override
     @Transactional
     public ApiResponse<CreateGameDto.Response> createGame(Long userId, CreateGameDto.Request request) {
@@ -65,9 +68,14 @@ public class GameServiceImpl implements GameService {
         return ApiResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
     }
 
+    /**
+     * 경기 상세조회
+     */
     @Override
     @Transactional(readOnly = true)
     public ApiResponse<GameDto> detailGame(Long gameId) {
+
+        log.info("[경기 상세 조회 시작] gameId : {}", gameId);
 
         GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
@@ -75,12 +83,19 @@ public class GameServiceImpl implements GameService {
 
         GameDto gameDto = GameDto.fromEntity(gameEntity);
 
+        log.info("[경기 상세조회 완료] gameId : {}", gameId);
+
         return ApiResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
     }
 
+    /**
+     * 경기 검색 정렬
+     */
     @Override
     @Transactional(readOnly = true)
     public ApiResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable) {
+
+        log.info("[경기 검색 정렬 시작] date : {}", date);
 
         Page<SearchGameDto> responses = gameQueryRepository.searchByKeyword(date, cityName, matchFormat, fieldStatus,matchGenderType, gameStatus, pageable);
 
@@ -89,9 +104,14 @@ public class GameServiceImpl implements GameService {
             return ApiResponse.of("경기 검색결과가 없습니다.", responses);
         }
 
+        log.info("[경기 검색 정렬 완료] date : {}", date);
+
         return ApiResponse.of("경기 검색이 완료되었습니다.", responses);
     }
 
+    /**
+     * 경기 수정
+     */
     @Override
     @Transactional
     public ApiResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId) {

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.gameCreator.service.impl;
 
+import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
 import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
@@ -13,6 +14,7 @@ import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,12 +24,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
-import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.ACCEPT;
-import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.APPLY;
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ParticipantGameServiceImpl implements ParticipantGameService {
 
     private final ParticipantGameRepository participantGameRepository;
@@ -36,10 +38,15 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
     private final UserRepository userRepository;
 
+
+    /**
+     * 경기 참가 신청자 조회
+     */
     @Override
     @Transactional(readOnly = true)
     public ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable) {
 
+        log.info("[경기 참가 신청자 조회 시작] gameId : {}, userId : {}", gameId, userId);
 
         GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
@@ -48,23 +55,32 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
         // 지원자 목록 조회 (엔티티 기준)
-        Page<ParticipantGameEntity> pages = participantGameRepository.
-                findByParticipantGameStatusAndGameEntity_GameId(APPLY, gameEntity.getGameId(), pageable);
+        Page<ParticipantGameEntity> pages = getParticipantGameList(pageable, gameEntity, APPLY);
 
 
         // DTO 변환
         List<ApplyGameUserListDto> participantGameList = pages.stream().map(ApplyGameUserListDto::fromEntity).toList();
 
+        log.info("[경기 참가 신청자 조회 완료] gameId : {}, userId : {}", gameId, userId);
+
         return ApiResponse.of("경기 신청자 조회가 완료되었습니다.", participantGameList);
     }
 
+
+    /**
+     * 경기 참가 수락자 조회
+     */
     @Override
-    @Transactional
-    public CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId) {
+    @Transactional(readOnly = true)
+    public ApiResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable) {
+
+        log.info("[경기 참가 수락자 조회 시작] gameId : {}, userId : {}", gameId, userId);
+
 
         GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
@@ -73,6 +89,46 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+        // 지원자 목록 조회 (엔티티 기준)
+        Page<ParticipantGameEntity> pages = getParticipantGameList(pageable, gameEntity, ACCEPT);
+
+
+        // DTO 변환
+        List<AcceptGameUserListDto> participantGameList = pages.stream().map(AcceptGameUserListDto::fromEntity).toList();
+
+        log.info("[경기 참가 수락자 조회 완료] gameId : {}, userId : {}", gameId, userId);
+
+
+        return ApiResponse.of("경기 참가자 조회가 완료되었습니다.", participantGameList);
+    }
+
+    private Page<ParticipantGameEntity> getParticipantGameList(Pageable pageable, GameEntity gameEntity, ParticipantGameStatus participantGameStatus) {
+        Page<ParticipantGameEntity> pages = participantGameRepository.
+                findByParticipantGameStatusAndGameEntity_GameId(participantGameStatus, gameEntity.getGameId(), pageable);
+        return pages;
+    }
+
+    /**
+     * 경기 수락
+     */
+    @Override
+    @Transactional
+    public CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId) {
+
+        log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantId, gameId);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
@@ -109,7 +165,159 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
+        log.info("[참가자 경기 수락 완료] participantId : {}, gameId : {}", participantId, gameId);
 
         return CheckResponse.of(true, "경기 수락이 완료되었습니다.");
     }
+
+
+    /**
+     * 경기 거절
+     */
+    @Override
+    @Transactional
+    public CheckResponse rejectGameUser(Long participantId, Long userId, Long gameId) {
+
+        log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantId, gameId);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+
+        // 경기 생성자는 거절할 수 없음.
+        if (participantGameEntity.getUserEntity().getUserId().equals(gameEntity.getUserEntity().getUserId())) {
+            throw new CustomException(NOT_REJECT_CREATOR);
+        }
+
+        if (participantGameEntity.getParticipantGameStatus().equals(REJECT)) {
+            throw new CustomException(ALREADY_REJECT_USER);
+        }
+
+        if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
+            throw new CustomException(ALREADY_ACCEPT_USER);
+        }
+
+        if (gameEntity.getStartDateTime().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ALREADY_START_GAME);
+        }
+
+        participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, LocalDateTime.now());
+
+        participantGameRepository.save(participantGameEntity);
+
+        log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantId, gameId);
+
+        return CheckResponse.of(true, "경기 거절을 완료하였습니다.");
+    }
+
+
+    /**
+     * 경기 강퇴
+     */
+    @Override
+    @Transactional
+    public CheckResponse kickOutGameUser(Long participantId, Long userId, Long gameId) {
+
+        log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantId, gameId);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
+            throw new CustomException(NOT_KICKOUT_CREATOR);
+        }
+
+        if (participantGameEntity.getParticipantGameStatus().equals(KICKOUT)) {
+            throw new CustomException(ALREADY_KICKOUT_USER);
+        }
+
+        if (!participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
+            throw new CustomException(NOT_ACCEPT_USER);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (gameEntity.getStartDateTime().isBefore(now)) {
+            throw new CustomException(ALREADY_START_GAME);
+        }
+
+        participantGameEntity.setParticipantGameStatusAndKickoutDateTime(KICKOUT, now);
+        participantGameRepository.save(participantGameEntity);
+
+        gameEntity.decreaseParticipantCount();
+        gameRepository.save(gameEntity);
+
+        log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantId, gameId);
+
+        return CheckResponse.of(true, "참가자 강퇴를 완료하였습니다.");
+
+
+    }
+
+    /**
+     * 경기 삭제
+     */
+    @Override
+    @Transactional
+    public CheckResponse deleteGame(Long userId, Long gameId) {
+
+        log.info("[경기 삭제 시작] userId : {}, gameId : {}", userId, gameId);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
+            throw new CustomException(NOT_DELETE_GAME);
+        }
+
+        List<ParticipantGameEntity> participantGameEntityList = participantGameRepository.findByParticipantGameStatusInAndGameEntity_GameId(List.of(ACCEPT, APPLY), gameId);
+
+
+        participantGameEntityList.forEach(participantGame ->
+                participantGame.setParticipantGameStatusAndDeletedDateTime(DELETE, now));
+
+        participantGameRepository.saveAll(participantGameEntityList);
+
+        gameEntity.setDeletedDateTime(now);
+
+        gameRepository.save(gameEntity);
+
+        log.info("[경기 삭제 완료] userId : {}, gameId : {}", userId, gameId);
+
+
+        return CheckResponse.of(true, "경기 삭제가 완료되었습니다.");
+    }
+
+
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/type/ParticipantGameStatus.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public enum ParticipantGameStatus {
 
-    APPLY, ACCEPT, REJECT, CANCEL, WITHDRAW, KICKOUT, DELETE
+    APPLY, ACCEPT, REJECT, CANCEL, KICKOUT, DELETE
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -2,10 +2,15 @@ package com.example.basketballmatching.gameUsers.service;
 
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.global.dto.CheckResponse;
 
 public interface GameUserService {
 
 
     ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
+
+    CheckResponse cancelGame(Long userId, Long gameId);
+
+
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
@@ -19,7 +20,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
@@ -48,7 +51,7 @@ public class GameUserServiceImpl implements GameUserService {
         validateParticipantInfo(userEntity, gameEntity);
 
         ParticipantGameEntity entity = ParticipantGameEntity.builder()
-                .participantGameStatus(ParticipantGameStatus.APPLY)
+                .participantGameStatus(APPLY)
                 .gameEntity(gameEntity)
                 .userEntity(userEntity)
                 .build();
@@ -63,6 +66,46 @@ public class GameUserServiceImpl implements GameUserService {
         return ApiResponse.of("경기 신청이 완료되었습니다.", participantDto);
     }
 
+    @Override
+    @Transactional
+    public CheckResponse cancelGame(Long userId, Long gameId) {
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
+            throw new CustomException(NOT_ALLOWED_CANCEL);
+        }
+
+        if (participantGameEntity.getParticipantGameStatus().equals(CANCEL)) {
+            throw new CustomException(ALREADY_CANCELED_USER);
+        }
+
+        if (!participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
+            throw new CustomException(NOT_ACCEPT_USER);
+        }
+
+
+
+        participantGameEntity.setParticipantGameStatusAndCanceledDateTime(CANCEL, now);
+        participantGameRepository.save(participantGameEntity);
+
+        gameEntity.decreaseParticipantCount();
+        gameRepository.save(gameEntity);
+
+
+
+
+        return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
+    }
+
     private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
 
         LocalDateTime now = LocalDateTime.now();
@@ -72,7 +115,7 @@ public class GameUserServiceImpl implements GameUserService {
         }
 
         if (participantGameRepository.countByParticipantGameStatusAndGameEntity_GameId(
-                ParticipantGameStatus.APPLY, gameEntity.getGameId()
+                APPLY, gameEntity.getGameId()
         ) >= gameEntity.getHeadCount()) {
             throw new CustomException(FULL_HEADCOUNT_GAME);
         }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -56,12 +56,20 @@ public enum ErrorCode {
     , ALREADY_APPLY_GAME_USER(HttpStatus.BAD_REQUEST, "이미 참가 신청한 유저입니다."),
     FULL_HEADCOUNT_GAME(HttpStatus.BAD_REQUEST, "남은 신청 자리가 없습니다."),
     NOT_ALLOWED_TO_JOIN(HttpStatus.BAD_REQUEST, "경기 참가를 요청할 수 없습니다."),
+    NOT_ALLOWED_CANCEL(HttpStatus.BAD_REQUEST, "경기 취소를 요청할 수 없습니다."),
     ONLY_FEMALE_GAME(HttpStatus.BAD_REQUEST, "여성 유저만 신청가능합니다."),
     ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다."),
     NOT_APPLY_USER(HttpStatus.BAD_REQUEST, "경기 참가 신청을 한 유저가 아닙니다."),
     ALREADY_START_GAME(HttpStatus.BAD_REQUEST, "이미 시작한 경기입니다."),
     PARTICIPANT_NOT_FOUND(HttpStatus.BAD_REQUEST, "경기 참가자를 찾을 수 없습니다."),
-    ALREADY_ACCEPT_USER(HttpStatus.BAD_REQUEST, "이미 수락된 참가자입니다.")
+    ALREADY_ACCEPT_USER(HttpStatus.BAD_REQUEST, "이미 수락된 참가자입니다."),
+    NOT_REJECT_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 거절할 수 없습니다."),
+    ALREADY_REJECT_USER(HttpStatus.BAD_REQUEST, "이미 거절된 참가자입니다."),
+    NOT_ACCEPT_USER(HttpStatus.BAD_REQUEST, "수락된 참가자가 아닙니다."),
+    ALREADY_CANCELED_USER(HttpStatus.BAD_REQUEST, "이미 취소한 참가자입니다."),
+    NOT_KICKOUT_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 강퇴할 수 없습니다."),
+    ALREADY_KICKOUT_USER(HttpStatus.BAD_REQUEST, "이미 강퇴한 참가자입니다."),
+    NOT_DELETE_GAME(HttpStatus.BAD_REQUEST, "경기를 삭제할 수 없습니다.")
     ;
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 거절,취소,강퇴 및 삭제 기능 미구현

---

### 🚀 TO-BE
✅ 경기 참가자 거절 기능
- 경기 생성자만 수행 가능
- 이미 걸절된 유저 및 수락된 유저 접근 -> exception발생
- 경기 시작 이후 거절 불가

✅ 경기 참가자 강퇴 기능
- 경기 생성자만 수행 가능
- 수락(ACCEPT) 유저만 강퇴 가능
- 경기 시작 이후 강퇴 불가
- 경기 생성자 자신은 강퇴 불가
- 강퇴 시 participantCount 감소 처리

✅ 경기 참가자 취소 기능
- 참가자 본인만 취소 가능
- 경기 시작 30분전까지 취소 가능
- 이미 취소된 참가자 요청 불가
- 수락(ACCEPT) 상태인 유저만 취소가능

✅ 경기 삭제 기능 구현
- 경기 생성자만 삭제 가능
- 경기 시작 30분전까지만 삭제 가능
- 삭제 시 경기 및 참가 or 신청 유저 상태 DELETE로 변경
- deletedDateTime 설정(Soft Delete)
- 검색 쿼리 조건에 deletedDateTime.isNull 추가

---

## ✅ 체크리스트
- [x] 경기 참가자 거절 기능
- [x] 경기 참가자 강퇴 기능
- [x] 경기 참가자 취소 기능
- [x] 경기 삭제 기능 구현
- [x] API 테스트

---
