### PR TITLE
[feat] : 지난 경기 조회 및 현재 참가 경기 조회 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
 
-    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long gameId, Long UserId);
+    boolean existsByParticipantGameIdAndGameEntity_GameId(Long gameId, Long UserId);
 
     int countByParticipantGameStatusAndGameEntity_GameId(
             ParticipantGameStatus participantGameStatus, Long gameId
@@ -21,8 +21,12 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
     List<ParticipantGameEntity> findByParticipantGameStatusInAndGameEntity_GameId(List<ParticipantGameStatus> statuses, Long gameId);
 
-    Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
+    Optional<ParticipantGameEntity> findByGameEntity_GameIdAndParticipantGameId(Long gameId, Long userId);
 
 
+    Page<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatusIn(Long userId, List<ParticipantGameStatus> statuses, Pageable pageable);
+
+
+    Page<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatus(Long userId, ParticipantGameStatus participantGameStatus, Pageable pageable);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -132,7 +132,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
-        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participantId, gameId);
+        boolean exists = participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(participantId, gameId);
 
         if (!exists) {
             throw new CustomException(NOT_APPLY_USER);
@@ -191,7 +191,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
 
@@ -242,7 +242,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -2,14 +2,21 @@ package com.example.basketballmatching.gameUsers.controller;
 
 
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,4 +38,47 @@ public class GameUserController {
 
     }
 
+    @PostMapping("/cancel")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> cancelGame(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam Long gameId
+    ) {
+
+        CheckResponse checkResponse = gameUserService.cancelGame(userId, gameId);
+
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+    @GetMapping("/user/current-game")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<CurrentGameListDto>>> getMyCurrentGameList (
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC,"gameEntity_startDateTime");
+
+        ApiResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+        return ResponseEntity.ok(myCurrentGameList);
+    }
+
+
+    @GetMapping("/user/last-game")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<LastGameListDto>>> getMyLastGameList (
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC,"gameEntity_startDateTime");
+
+        ApiResponse<List<LastGameListDto>> myCurrentGameList = gameUserService.getMyLastGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+        return ResponseEntity.ok(myCurrentGameList);
+    }
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/CurrentGameListDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/CurrentGameListDto.java
@@ -1,0 +1,54 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.CityName;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CurrentGameListDto {
+
+    private Long gameId;
+
+    private String title;
+
+    private String address;
+
+    private CityName cityName;
+
+    private MatchFormat matchFormat;
+
+    private MatchGenderType matchGenderType;
+
+    private LocalDateTime startDateTime;
+
+    private ParticipantGameStatus participantGameStatus;
+
+    public static CurrentGameListDto fromEntity(ParticipantGameEntity participantGameEntity) {
+
+        return CurrentGameListDto.builder()
+                .gameId(participantGameEntity.getGameEntity().getGameId())
+                .title(participantGameEntity.getGameEntity().getTitle())
+                .address(participantGameEntity.getGameEntity().getAddress())
+                .cityName(participantGameEntity.getGameEntity().getCityName())
+                .matchFormat(participantGameEntity.getGameEntity().getMatchFormat())
+                .matchGenderType(participantGameEntity.getGameEntity().getMatchGenderType())
+                .startDateTime(participantGameEntity.getGameEntity().getStartDateTime())
+                .participantGameStatus(participantGameEntity.getParticipantGameStatus())
+                .build();
+
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/LastGameListDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/LastGameListDto.java
@@ -1,0 +1,57 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.type.CityName;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LastGameListDto {
+
+    private Long gameId;
+
+    private String title;
+
+    private String address;
+
+    private CityName cityName;
+
+    private MatchFormat matchFormat;
+
+    private MatchGenderType matchGenderType;
+
+    private LocalDateTime startDateTime;
+
+    private LocalDateTime endDateTime;
+
+    private ParticipantGameStatus participantGameStatus;
+
+    public static LastGameListDto fromEntity(ParticipantGameEntity participantGameEntity) {
+
+        return LastGameListDto.builder()
+                .gameId(participantGameEntity.getGameEntity().getGameId())
+                .title(participantGameEntity.getGameEntity().getTitle())
+                .address(participantGameEntity.getGameEntity().getAddress())
+                .cityName(participantGameEntity.getGameEntity().getCityName())
+                .matchFormat(participantGameEntity.getGameEntity().getMatchFormat())
+                .matchGenderType(participantGameEntity.getGameEntity().getMatchGenderType())
+                .startDateTime(participantGameEntity.getGameEntity().getStartDateTime())
+                .endDateTime(participantGameEntity.getGameEntity().getEndDateTime())
+                .participantGameStatus(participantGameEntity.getParticipantGameStatus())
+                .build();
+
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,8 +1,13 @@
 package com.example.basketballmatching.gameUsers.service;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface GameUserService {
 
@@ -11,6 +16,7 @@ public interface GameUserService {
 
     CheckResponse cancelGame(Long userId, Long gameId);
 
+    ApiResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable);
 
-
+    ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.basketballmatching.gameUsers.service.impl;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
@@ -10,17 +12,18 @@ import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
-import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
+import java.util.List;
 
 import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -73,7 +76,7 @@ public class GameUserServiceImpl implements GameUserService {
         GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, userId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
 
@@ -106,11 +109,53 @@ public class GameUserServiceImpl implements GameUserService {
         return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Page<ParticipantGameEntity> participantGameEntities = participantGameRepository.findByUserEntity_UserIdAndParticipantGameStatusIn(userEntity.getUserId(), List.of(ACCEPT, APPLY), pageable);
+
+        List<CurrentGameListDto> gameListDtos = participantGameEntities.stream()
+                .filter(p -> p.getGameEntity().getStartDateTime().isAfter(now))
+                .map(CurrentGameListDto::fromEntity)
+                .toList();
+
+
+        return ApiResponse.of("현재 예정된 게임 조회가 완료되었습니다.", gameListDtos);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Page<ParticipantGameEntity> participantGameEntities = participantGameRepository.findByUserEntity_UserIdAndParticipantGameStatus(userEntity.getUserId(), ACCEPT, pageable);
+
+        List<LastGameListDto> gameListDtos = participantGameEntities.stream()
+                .filter(p -> p.getGameEntity().getStartDateTime().isBefore(now))
+                .map(LastGameListDto::fromEntity)
+                .toList();
+
+
+        return ApiResponse.of("지난 게임 조회가 완료되었습니다.", gameListDtos);
+    }
+
+
+
     private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
 
         LocalDateTime now = LocalDateTime.now();
 
-        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
+        if (participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 참가자 지난 경기 조회 기능 미구현
- 참가자 현재 참여 경기 조회 기능 미구현

### 🚀 TO-BE
✅ 지난 경기 조회 기능
- 현재 시간 이전 경기 중 ACCEPT인 상태 리스트 조회 기능 구현
- 페이징 처리

✅ 현재 참여 및 요청 경기 조회 기능
- 현재 시간 이후 경기 중 ACCEPT, APPLY인 상태 리스트 조회 기능 구현
- 페이징 처리

---

## ✅ 체크리스트
- [x] 지난 경기 조회 기능
- [x] 현재 참여 및 요청 경기 조회 기능
- [x] API 테스트
---
