### PR TITLE
[feat] : 경기 참가자 실력 평가 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -119,7 +119,14 @@ public class GameEntity extends BaseEntity {
         this.deletedDateTime = deletedDateTime;
     }
 
+    public void setStartDateTime(LocalDateTime startDateTime) {
+        this.startDateTime = startDateTime;
+    }
 
+
+    public void setEndDateTime(LocalDateTime endDateTime) {
+        this.endDateTime = endDateTime;
+    }
 
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -3,11 +3,13 @@ package com.example.basketballmatching.gameUsers.controller;
 
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
 import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
 import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -81,4 +83,19 @@ public class GameUserController {
 
         return ResponseEntity.ok(myCurrentGameList);
     }
+
+    @PostMapping("/user/evaluate/{gameId}")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> evaluatePlayer(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @PathVariable Long gameId,
+            @RequestBody @Valid EvaluatePlayerDto request
+            ) {
+
+        CheckResponse checkResponse = gameUserService.evaluatePlayer(gameId, userInfoDetails.getUserEntity().getUserId(), request);
+
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/EvaluatePlayerDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/EvaluatePlayerDto.java
@@ -1,0 +1,40 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameUsers.entity.LevelEntity;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EvaluatePlayerDto {
+
+    @NotNull
+    private Long receiverId;
+
+    @NotNull
+    @Min(1)
+    @Max(5)
+    private int score;
+
+    public static LevelEntity toEntity( UserEntity evaluator, UserEntity receiver, GameEntity gameEntity, int score) {
+
+
+        return LevelEntity.builder()
+                .evaluator(evaluator)
+                .receiver(receiver)
+                .gameEntity(gameEntity)
+                .score(score)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/entity/LevelEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/entity/LevelEntity.java
@@ -1,0 +1,41 @@
+package com.example.basketballmatching.gameUsers.entity;
+
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class LevelEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long levelId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluator_id")
+    private UserEntity evaluator;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private UserEntity receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private GameEntity gameEntity;
+
+    private int score;
+
+    private LocalDateTime evaluateDateTime;
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/repository/LevelRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/repository/LevelRepository.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.gameUsers.repository;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameUsers.entity.LevelEntity;
+import com.example.basketballmatching.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LevelRepository extends JpaRepository<LevelEntity, Long> {
+
+    boolean existsByGameEntity_GameIdAndEvaluator_UserIdAndReceiver_UserId(
+            Long gameId, Long evaluatorId, Long receiverId
+    );
+
+    List<LevelEntity> findByReceiverAndGameEntity(UserEntity receiver, GameEntity gameEntity);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -21,6 +21,6 @@ public interface GameUserService {
 
     ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable);
 
-//    CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request);
+    CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -24,12 +24,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Optionals;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -49,6 +52,9 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final GameRepository gameRepository;
 
+    /**
+     * 경기 참가 신청
+     */
     @Override
     @Transactional
     public ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
@@ -79,6 +85,9 @@ public class GameUserServiceImpl implements GameUserService {
         return ApiResponse.of("경기 신청이 완료되었습니다.", participantDto);
     }
 
+    /**
+     * 경기 참가 취소
+     */
     @Override
     @Transactional
     public CheckResponse cancelGame(Long userId, Long gameId) {
@@ -86,7 +95,7 @@ public class GameUserServiceImpl implements GameUserService {
         GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, userId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
 
@@ -119,6 +128,9 @@ public class GameUserServiceImpl implements GameUserService {
         return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
     }
 
+    /**
+     * 현재 예정 경기 조회
+     */
     @Override
     @Transactional(readOnly = true)
     public ApiResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
@@ -132,6 +144,9 @@ public class GameUserServiceImpl implements GameUserService {
         return ApiResponse.of("현재 예정된 게임 조회가 완료되었습니다.", currentGameList);
     }
 
+    /**
+     * 지난 경기 조회
+     */
     @Override
     @Transactional(readOnly = true)
     public ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
@@ -147,6 +162,102 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
+    /**
+     * 경기 참가자 평가
+     */
+    @Override
+    @Transactional
+    public CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request) {
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        if (gameEntity.getEndDateTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(NOT_GAME_ENDED);
+        }
+
+        ParticipantGameEntity evaluator = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), evaluatorId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        ParticipantGameEntity receiver = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, request.getReceiverId())
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        if (evaluator.getParticipantGameId().equals(receiver.getParticipantGameId())) {
+            throw new CustomException(CANNOT_EVALUATE_SELF);
+        }
+
+        boolean exists = levelRepository.existsByGameEntity_GameIdAndEvaluator_UserIdAndReceiver_UserId(gameId, evaluator.getUserEntity().getUserId(), receiver.getUserEntity().getUserId());
+
+        if (exists) {
+            throw new CustomException(ALREADY_EVALUATED);
+        }
+
+        if (request.getScore()< 1 || request.getScore() > 5) {
+            throw new CustomException(INVALID_LEVEL_SCORE);
+        }
+
+        LevelEntity levelEntity = EvaluatePlayerDto.toEntity(evaluator.getUserEntity(), receiver.getUserEntity(), gameEntity, request.getScore());
+
+
+        levelRepository.save(levelEntity);
+
+        updatePlayerLevel(receiver.getUserEntity());
+
+        userRepository.save(receiver.getUserEntity());
+
+        return CheckResponse.of(true, "경기 참가자 평가를 완료하였습니다.");
+    }
+
+    // 최근 10경기 평균으로 Level측정
+    private void updatePlayerLevel(UserEntity receiver) {
+
+        List<GameEntity> recent10GamesByUser = gameQueryRepository.findRecent10GamesByUser(receiver);
+
+        if (recent10GamesByUser.size() < 10) {
+            receiver.updateLevel(GameUserLevel.NONE);
+            return;
+        }
+
+        List<Double> gameAverages = new ArrayList<>();
+
+        for (GameEntity gameEntity : recent10GamesByUser) {
+
+            List<LevelEntity> evaluations = levelRepository.findByReceiverAndGameEntity(receiver, gameEntity);
+
+            if (evaluations.isEmpty()) {
+                continue;
+            }
+
+            double gameAverage = evaluations.stream()
+                    .mapToInt(LevelEntity::getScore)
+                    .average()
+                    .orElse(0.0);
+
+
+            gameAverages.add(gameAverage);
+        }
+
+        // 10경기 이상의 경기 후 평가를 받은 경기가 5개 미만일시 Level -> NONE
+        if (gameAverages.size() < 5) {
+            receiver.updateLevel(GameUserLevel.NONE);
+            return;
+        }
+
+        double average = gameAverages.stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0.0);
+
+
+        GameUserLevel newLevel = GameUserLevel.fromScore(average);
+
+
+        receiver.updateLevel(newLevel);
+
+    }
+
+
+
 
 
 
@@ -154,6 +265,11 @@ public class GameUserServiceImpl implements GameUserService {
     private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
 
         LocalDateTime now = LocalDateTime.now();
+
+        if (Objects.equals(userEntity.getUserId(), gameEntity.getUserEntity().getUserId())) {
+            throw new CustomException(NOT_APPLY_GAME_CREATOR);
+
+        }
 
         if (participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);

--- a/src/main/java/com/example/basketballmatching/gameUsers/type/GameUserLevel.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/type/GameUserLevel.java
@@ -1,0 +1,37 @@
+package com.example.basketballmatching.gameUsers.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GameUserLevel {
+
+    NONE("경기 부족"),
+    BEGINNER("초보자"),
+    AMATEUR("아마추어"),
+    SEMI_PRO("세미프로"),
+    PRO("프로");
+
+    private final String description;
+
+    public static GameUserLevel fromScore(double score) {
+
+        if (score < 2.5) {
+            return BEGINNER;
+        }
+
+        if (score < 3.5) {
+            return AMATEUR;
+        }
+
+        if (score < 4.5) {
+            return SEMI_PRO;
+        }
+
+        return PRO;
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -69,7 +69,15 @@ public enum ErrorCode {
     ALREADY_CANCELED_USER(HttpStatus.BAD_REQUEST, "이미 취소한 참가자입니다."),
     NOT_KICKOUT_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 강퇴할 수 없습니다."),
     ALREADY_KICKOUT_USER(HttpStatus.BAD_REQUEST, "이미 강퇴한 참가자입니다."),
-    NOT_DELETE_GAME(HttpStatus.BAD_REQUEST, "경기를 삭제할 수 없습니다.")
+    NOT_DELETE_GAME(HttpStatus.BAD_REQUEST, "경기를 삭제할 수 없습니다."),
+    NOT_APPLY_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 참가신청을 할 수 없습니다."),
+
+
+    // level
+    NOT_GAME_ENDED(HttpStatus.BAD_REQUEST, "아직 경기가 종료되지 않았습니다."),
+    CANNOT_EVALUATE_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 평가할 수 없습니다."),
+    ALREADY_EVALUATED(HttpStatus.BAD_REQUEST, "이미 평가한 참가자입니다."),
+    INVALID_LEVEL_SCORE(HttpStatus.BAD_REQUEST, "평가점수는 1 ~ 5점만 입력가능합니다.")
     ;
 
 

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -2,13 +2,19 @@ package com.example.basketballmatching.gameUsers.service.impl;
 
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.entity.UserEntity;
@@ -22,17 +28,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-
-import static com.example.basketballmatching.global.exception.ErrorCode.GAME_NOT_FOUND;
-import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
@@ -49,6 +56,9 @@ class GameUserServiceImplTest {
 
     @Autowired
     private GameUserService gameUserService;
+
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
 
     @BeforeEach
     void setUp() {
@@ -94,8 +104,8 @@ class GameUserServiceImplTest {
                 .headCount(9)
                 .fieldStatus(FieldStatus.OUTDOOR)
                 .matchGenderType(MatchGenderType.FEMALE_ONLY)
-                .startDateTime(LocalDateTime.now().plusHours(2L))
-                .endDateTime(LocalDateTime.now().plusHours(3L))
+                .startDateTime(LocalDateTime.now().plusHours(1L))
+                .endDateTime(LocalDateTime.now().plusHours(2L))
                 .placeName("테스트 게임 장소")
                 .address("인천광역시 테스트 게임 주소")
                 .matchFormat(MatchFormat.THREE_ON_THREE)
@@ -218,6 +228,150 @@ class GameUserServiceImplTest {
         // then
 
         assertEquals(ErrorCode.FULL_HEADCOUNT_GAME, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 테스트")
+    void CancelGameTest() {
+        // given
+
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
+
+        participantGameRepository.save(participantGameEntity);
+
+        // when
+
+        CheckResponse checkResponse = gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId());
+
+        // then
+
+        assertEquals(ParticipantGameStatus.CANCEL, participantGameEntity.getParticipantGameStatus());
+        assertEquals("경기 취소가 완료되었습니다.", checkResponse.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 실패 테스트 - 수락되지 않은 유저 접근")
+    void cancelGameFailTest_Apply_User() {
+        // given
+
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId()));
+
+        // then
+
+        assertEquals(NOT_ACCEPT_USER, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 실패테스트 - 경기시작 30분전 취소 불가")
+    void cancelGameFailTest_NOT_ALLOWED_CANCEL() {
+        // given
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
+
+        participantGameRepository.save(participantGameEntity);
+
+        gameEntity.setStartDateTime(LocalDateTime.now().minusMinutes(40));
+        gameEntity.setEndDateTime(LocalDateTime.now().minusMinutes(40));
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId()));
+
+        // then
+
+        assertEquals(NOT_ALLOWED_CANCEL, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("현재 예정 경기 조회 테스트")
+    void getCurrentGameListTest() {
+        // given
+
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+        // when
+        ApiResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+
+        // then
+
+        assertEquals(gameEntity.getGameId(), myCurrentGameList.getData().get(0).getGameId());
+        assertEquals("현재 예정된 게임 조회가 완료되었습니다.", myCurrentGameList.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("지난 경기 조회 테스트")
+    void getLastGameListTest() {
+        // given
+        UserEntity userEntity = userRepository.findById(2L)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
+
+        participantGameRepository.save(participantGameEntity);
+
+        gameEntity.setStartDateTime(LocalDateTime.now().minusHours(2L));
+        gameEntity.setEndDateTime(LocalDateTime.now().minusHours(2L));
+
+        gameRepository.save(gameEntity);
+        // when
+
+        ApiResponse<List<LastGameListDto>> myLastGameList = gameUserService.getMyLastGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+
+        // then
+
+        assertEquals(gameEntity.getGameId(), myLastGameList.getData().get(0).getGameId());
+        assertEquals("지난 게임 조회가 완료되었습니다.", myLastGameList.getMessage());
 
     }
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 참가자 실력 평가 기능 미구현
- 경기 취소 테스트 코드 미작성
- 현재 예정 경기 / 지난 경기 조회 테스트 코드 미작성

### 🚀 TO-BE
✅ 경기 참가자 실력 평가 기능 구현
- 종료된 경기만 평가 가능
- 동일 경기 동일 유저 반복 평가 불가
- 자기 자신 평가 불가
- 평가 점수 범위(1~5점)

✅ 최근 10경기 기반 Level 자동 업데이트
- receiver 기준 최근 10경기 조회 -> 10경기 미만이라면 Level -> NONE
- 각 경기별 평균 점수  계산 후 전체 평균 산정
- 평가받은 경기가 5개 미만이면 Level -> NONE
- 최종 평가 값 기준 GameUserLevel 자동 갱신

✅ 테스트 코드 작성
- 현재 예정 경기 조회 성공 테스트
- 지난 경기 조회 성공 테스트
- 경기 취소 성공 테스트
- 경기 취소 실패 테스트
   - 경기 시작 30분전 취소 불가 테스트
   - ACCEPT 유저만 취소 가능 테스트

---

## ✅ 체크리스트
- [x] API 테스트
- [x] 경기 참가자 실력 평가 기능 구현
- [x] 경기 조회 및 취소 기능 테스트코드 작성
---
