### PR TITLE
[fix] : 경기 참가 신청 시 deadLock 발생 문제 해결 및 비관적 락 적용

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -129,4 +129,7 @@ public class GameEntity extends BaseEntity {
     }
 
 
+    public void setParticipantCount(int participantCount) {
+        this.participantCount = participantCount;
+    }
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
@@ -2,7 +2,10 @@ package com.example.basketballmatching.gameCreator.repository;
 
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
@@ -24,6 +27,17 @@ public interface GameRepository extends JpaRepository<GameEntity, Long> {
                                         @Param("address") String address,
                                         @Param("startDateTime") LocalDateTime startDateTime,
                                         @Param("endDateTime") LocalDateTime endDateTime);
+    @Modifying
+    @Query("update GameEntity g " +
+            "set g.participantCount = g.participantCount + 1 " +
+            "where g.gameId = :gameId")
+    int increaseParticipantCount(@Param("gameId") Long gameId);
+
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from GameEntity g where g.gameId = :gameId and g.deletedDateTime is NULL ")
+    Optional<GameEntity> findByGameIdWithLock(@Param("gameId") Long gameId);
+
 
     Optional<GameEntity> findByGameIdAndDeletedDateTimeIsNull(Long gameId);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -158,9 +158,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, now);
 
-        gameEntity.increaseParticipantCount();
-
-        gameRepository.save(gameEntity);
         participantGameRepository.save(participantGameEntity);
 
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -1,10 +1,7 @@
 package com.example.basketballmatching.gameUsers.controller;
 
 
-import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
-import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
-import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
-import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
@@ -96,6 +93,17 @@ public class GameUserController {
 
 
         return ResponseEntity.ok(checkResponse);
+    }
+
+    @GetMapping("/user/rank")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<GameUserLevelDto>> getMyGameUserLevel(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        ApiResponse<GameUserLevelDto> myGameUserLevel = gameUserService.getMyGameUserLevel(userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(myGameUserLevel);
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/GameUserLevelDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/GameUserLevelDto.java
@@ -1,0 +1,28 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import com.example.basketballmatching.gameUsers.type.GameUserLevel;
+import com.example.basketballmatching.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class GameUserLevelDto {
+
+    private Long userId;
+
+    private String nickname;
+
+    private GameUserLevel gameUserLevel;
+
+    public static GameUserLevelDto fromEntity(UserEntity userEntity) {
+        return GameUserLevelDto.builder()
+                .userId(userEntity.getUserId())
+                .nickname(userEntity.getNickname())
+                .gameUserLevel(userEntity.getGameUserLevel())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,9 +1,6 @@
 package com.example.basketballmatching.gameUsers.service;
 
-import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
-import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
-import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
-import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import org.springframework.data.domain.Pageable;
@@ -23,4 +20,5 @@ public interface GameUserService {
 
     CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request);
 
+    ApiResponse<GameUserLevelDto> getMyGameUserLevel(Long userId);
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -1,30 +1,25 @@
 package com.example.basketballmatching.gameUsers.service.impl;
 
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
-import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
-import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
-import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.gameUsers.entity.LevelEntity;
 import com.example.basketballmatching.gameUsers.repository.LevelRepository;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.gameUsers.type.GameUserLevel;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
-import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
-import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
-import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.util.Optionals;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +27,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -52,6 +46,7 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final GameRepository gameRepository;
 
+
     /**
      * 경기 참가 신청
      */
@@ -64,10 +59,12 @@ public class GameUserServiceImpl implements GameUserService {
         UserEntity userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+        GameEntity gameEntity = gameRepository.findByGameIdWithLock(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
 
         validateParticipantInfo(userEntity, gameEntity);
+
+
 
         ParticipantGameEntity entity = ParticipantGameEntity.builder()
                 .participantGameStatus(APPLY)
@@ -76,6 +73,15 @@ public class GameUserServiceImpl implements GameUserService {
                 .build();
 
         participantGameRepository.save(entity);
+
+
+
+        gameEntity.increaseParticipantCount();
+        gameRepository.save(gameEntity);
+
+
+
+
 
         ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(entity);
 
@@ -208,6 +214,19 @@ public class GameUserServiceImpl implements GameUserService {
         return CheckResponse.of(true, "경기 참가자 평가를 완료하였습니다.");
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public ApiResponse<GameUserLevelDto> getMyGameUserLevel(Long userId) {
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        GameUserLevelDto gameUserLevelDto = GameUserLevelDto.fromEntity(userEntity);
+
+
+        return ApiResponse.of("유저 랭크 조회를 완료하였습니다.", gameUserLevelDto);
+    }
+
     // 최근 10경기 평균으로 Level측정
     private void updatePlayerLevel(UserEntity receiver) {
 
@@ -275,9 +294,7 @@ public class GameUserServiceImpl implements GameUserService {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 
-        if (participantGameRepository.countByParticipantGameStatusAndGameEntity_GameId(
-                ACCEPT, gameEntity.getGameId()
-        ) >= gameEntity.getHeadCount()) {
+        if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
             throw new CustomException(FULL_HEADCOUNT_GAME);
         }
 

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -23,6 +23,8 @@ import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,19 +32,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Rollback(value = false)
 @ActiveProfiles("test")
-@Transactional
 class GameUserServiceImplTest {
 
     @Autowired
@@ -60,6 +70,9 @@ class GameUserServiceImplTest {
     @Autowired
     private ParticipantGameRepository participantGameRepository;
 
+    @Autowired
+    private EntityManager em;
+
     @BeforeEach
     void setUp() {
         // given: 테스트용 유저 데이터 삽입
@@ -72,7 +85,7 @@ class GameUserServiceImplTest {
                 .address("테스트용주소")
                 .phone("010-1111-1111")
                 .position(Position.GUARD)
-                .genderType(GenderType.MALE)
+                .genderType(GenderType.NONE)
                 .loginProvider(LoginProvider.LOCAL)
                 .userType(UserType.USER)
                 .build();
@@ -101,7 +114,7 @@ class GameUserServiceImplTest {
         CreateGameDto.Request request = CreateGameDto.Request.builder()
                 .title("테스트 게임")
                 .content("테스트 게임 본문")
-                .headCount(9)
+                .headCount(6)
                 .fieldStatus(FieldStatus.OUTDOOR)
                 .matchGenderType(MatchGenderType.FEMALE_ONLY)
                 .startDateTime(LocalDateTime.now().plusHours(1L))
@@ -374,5 +387,115 @@ class GameUserServiceImplTest {
         assertEquals("지난 게임 조회가 완료되었습니다.", myLastGameList.getMessage());
 
     }
+
+
+    @Test
+    @DisplayName("경기 참가 신청 - 동시성 이슈 테스트")
+    void applyGameTest_Concurrency_Issue() throws Exception {
+        // given
+
+        for (int i = 0; i < 4; i++) {
+            UserEntity gameUser = UserEntity.builder()
+                    .email("testa@"+ i + "example.com")
+                    .password(passwordEncoder.encode("Test@1234"))
+                    .name("namea" + i)
+                    .nickname("namea" + i)
+                    .birth(LocalDate.of(1997,7,24))
+                    .address("테스트용주소a" + i)
+                    .phone("010-1111-1112")
+                    .position(Position.GUARD)
+                    .genderType(GenderType.FEMALE)
+                    .loginProvider(LoginProvider.LOCAL)
+                    .userType(UserType.USER)
+                    .build();
+
+            userRepository.save(gameUser);
+
+            gameUserService.applyGame(1L, gameUser.getUserId());
+
+
+        }
+
+        // when
+
+        int threadCount = 5;
+
+        List<Long> userIds = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+
+            UserEntity gameUser = UserEntity.builder()
+                    .email("tests@"+ i + "example.com")
+                    .password(passwordEncoder.encode("Test@1234"))
+                    .name("names" + i)
+                    .nickname("names" + i)
+                    .birth(LocalDate.of(1997,7,24))
+                    .address("테스트용주소s" + i)
+                    .phone("010-1111-1112")
+                    .position(Position.GUARD)
+                    .genderType(GenderType.FEMALE)
+                    .loginProvider(LoginProvider.LOCAL)
+                    .userType(UserType.USER)
+                    .build();
+
+            userRepository.save(gameUser);
+            userIds.add(gameUser.getUserId());
+
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger fullHeadCountErrorCount = new AtomicInteger(0);
+
+        // then
+        for (Long userId : userIds) {
+
+            executorService.submit(() -> {
+
+                try {
+                    startLatch.await();
+                    gameUserService.applyGame(1L, userId);
+                    successCount.incrementAndGet();
+                } catch (CustomException e) {
+                    if (e.getErrorCode() == FULL_HEADCOUNT_GAME) {
+                        fullHeadCountErrorCount.incrementAndGet();
+                    } else {
+                        e.printStackTrace();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    doneLatch.countDown();
+                }
+
+            });
+
+        }
+        GameEntity before = gameRepository.findById(1L).orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        System.out.println("Before concurrency - headCount=" + before.getHeadCount()
+                + ", participantCount=" + before.getParticipantCount()
+                + ", startDateTime=" + before.getStartDateTime());
+
+        startLatch.countDown();
+
+        doneLatch.await();
+
+        executorService.shutdown();
+
+        GameEntity gameEntity = gameRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+
+
+        assertEquals(6, gameEntity.getParticipantCount());
+
+
+    }
+
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 참가 로직에서 다수의 사용자가 동시에 신청할 경우 participantCount 증가가 중복 반영될 위험 존재
- 동시성 테스트 수행 중 DeadLock 발생
- participantCount를 JPA update 방식으로 변경한 경우
   - 값이 동시에 읽혀 2명 이상 참가 성공(Lost Update) 문제 확인

### 🚀 TO-BE
✅ 비관적 락(PESSIMISTIC_WRITE) 적용
- findByGameIdWithLock() 메서드에 비관적 락 적용하여
동일 게임 row 접근 시 단일 트랜잭션만 처리하도록 직렬화
- 비관적 락
   - DeadLock 해결
   - Lost Update 방지


---

## ✅ 체크리스트
- [x] 동시성 이슈 테스트
- [x] 비관적 락 적용
- [x] LostUpdate 해결
- [x] DeadLock 발생 해결
---
