### PR TITLE
[feat] : 경기 상태 알림 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -3,16 +3,20 @@ package com.example.basketballmatching.gameCreator.repository;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
 
-    boolean existsByParticipantGameIdAndGameEntity_GameId(Long gameId, Long UserId);
+    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long userId, Long gameId);
 
     int countByParticipantGameStatusAndGameEntity_GameId(
             ParticipantGameStatus participantGameStatus, Long gameId
@@ -32,6 +36,8 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
 
     Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
+
+
 
     List<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatus(Long userId, ParticipantGameStatus participantGameStatus);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -11,6 +11,8 @@ import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import com.example.basketballmatching.notifications.type.NotificationType;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     private final GameRepository gameRepository;
 
     private final UserRepository userRepository;
+
+    private final NotificationService notificationService;
 
 
     /**
@@ -132,7 +136,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
-        boolean exists = participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(participantId, gameId);
+        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participantId, gameId);
 
         if (!exists) {
             throw new CustomException(NOT_APPLY_USER);
@@ -149,7 +153,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findById(participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
@@ -159,6 +163,10 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, now);
 
         participantGameRepository.save(participantGameEntity);
+
+
+        notificationService.send(NotificationType.ACCEPT_GAME, participantGameEntity.getUserEntity(),
+                participantGameEntity.getGameEntity().getTitle() + "에 참가가 수락되었습니다.");
 
 
 
@@ -188,7 +196,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
 
@@ -212,6 +220,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, LocalDateTime.now());
 
         participantGameRepository.save(participantGameEntity);
+
+        notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
         log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantId, gameId);
 
@@ -239,7 +249,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
@@ -265,6 +275,10 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         gameEntity.decreaseParticipantCount();
         gameRepository.save(gameEntity);
+
+        notificationService.send(NotificationType.KICKED_OUT, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에서 강퇴당하였습니다.");
+
+
 
         log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantId, gameId);
 
@@ -303,6 +317,16 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         participantGameEntityList.forEach(participantGame ->
                 participantGame.setParticipantGameStatusAndDeletedDateTime(DELETE, now));
+
+        participantGameEntityList
+                .stream()
+                .filter(participantGameEntity -> !Objects.equals(participantGameEntity.getUserEntity().getUserId(), userEntity.getUserId()))
+                .forEach(
+
+                participantGame ->
+                    notificationService.send(NotificationType.DELETE_GAME, participantGame.getUserEntity(), participantGame.getGameEntity().getTitle() + "의 게임이 삭제되었습니다.")
+
+        );
 
         participantGameRepository.saveAll(participantGameEntityList);
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -98,7 +98,7 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional
     public CheckResponse cancelGame(Long userId, Long gameId) {
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+        GameEntity gameEntity = gameRepository.findByGameIdWithLock(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
 
         ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
@@ -290,7 +290,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         }
 
-        if (participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(gameEntity.getGameId(),userEntity.getUserId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 

--- a/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
+++ b/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
@@ -1,0 +1,57 @@
+package com.example.basketballmatching.notifications.controller;
+
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import io.lettuce.core.dynamic.annotation.Param;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<SseEmitter> subscribe(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestHeader(value = "lastEventId", required = false, defaultValue = "")
+            String lastEventId) {
+
+
+        SseEmitter sseEmitter = notificationService.subscribe(userInfoDetails.getUserEntity().getUserId(), lastEventId);
+
+
+        return ResponseEntity.ok(sseEmitter);
+    }
+
+    @GetMapping("/unread-notification")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<NotificationDto>>> getUnreadNotifications(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ApiResponse<List<NotificationDto>> unReadNotifications = notificationService.getUnReadNotifications(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+        return ResponseEntity.ok(unReadNotifications);
+    }
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/dto/NotificationDto.java
+++ b/src/main/java/com/example/basketballmatching/notifications/dto/NotificationDto.java
@@ -1,0 +1,38 @@
+package com.example.basketballmatching.notifications.dto;
+
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+
+    private Long notificationId;
+
+    private NotificationType notificationType;
+
+    private String content;
+
+    private LocalDateTime createAt;
+
+    public static NotificationDto fromEntity(NotificationEntity notificationEntity) {
+
+        return NotificationDto.builder()
+                .notificationId(notificationEntity.getNotificationId())
+                .notificationType(notificationEntity.getNotificationType())
+                .content(notificationEntity.getContent())
+                .createAt(notificationEntity.getCreatedAt())
+                .build();
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/entity/NotificationEntity.java
+++ b/src/main/java/com/example/basketballmatching/notifications/entity/NotificationEntity.java
@@ -1,0 +1,50 @@
+package com.example.basketballmatching.notifications.entity;
+
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long notificationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private UserEntity receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isRead = false;
+
+
+    private LocalDateTime readDateTime;
+
+
+    public void setReadAndReadDateTime(LocalDateTime readDateTime) {
+        this.isRead = true;
+        this.readDateTime = readDateTime;
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/EmitterRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/EmitterRepository.java
@@ -1,0 +1,68 @@
+package com.example.basketballmatching.notifications.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepository {
+
+    public final Map<String, SseEmitter> emitter = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitter.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+
+    public void saveEventCache(String emitterId, Object event) {
+        eventCache.put(emitterId, event);
+    }
+
+    public Map<String, SseEmitter> findAllStartWithByUserId(String userId) {
+
+        return emitter.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    }
+
+    public Map<String, Object> findAllEventCacheStartWithUserId(String userId) {
+
+
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    }
+
+    public void deleteAllStratWithUserId(String userId) {
+        emitter.forEach(
+                (key, value) -> {
+                    if (key.startsWith(userId)) {
+                        emitter.remove(key);
+                    }
+                }
+        );
+    }
+
+    public void deleteByEmitterId(String emitterId) {
+        emitter.remove(emitterId);
+    }
+
+    public void deleteAllEventCacheStartWithUserId(String userId) {
+
+        eventCache.forEach(
+                (key, value) -> {
+                    if (key.startsWith(userId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/NotificationQueryRepository.java
@@ -1,0 +1,56 @@
+package com.example.basketballmatching.notifications.repository;
+
+
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.entity.QNotificationEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepository {
+
+    private final NotificationRepository notificationRepository;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<NotificationDto> getUnReadNotification(Long userId, Pageable pageable) {
+
+        QNotificationEntity notificationEntity = QNotificationEntity.notificationEntity;
+
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(notificationEntity.receiver.userId.eq(userId));
+        builder.and(notificationEntity.isRead.eq(false));
+        builder.and(notificationEntity.readDateTime.isNull());
+
+        List<NotificationEntity> notificationEntities = jpaQueryFactory
+                .select(notificationEntity)
+                .from(notificationEntity)
+                .where(builder)
+                .orderBy(notificationEntity.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        for (NotificationEntity notification : notificationEntities) {
+
+            notification.setReadAndReadDateTime(LocalDateTime.now());
+            notificationRepository.save(notification);
+        }
+
+
+        return notificationEntities.stream()
+                .map(NotificationDto::fromEntity)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.notifications.repository;
+
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.example.basketballmatching.notifications.service;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+public interface NotificationService {
+
+
+    SseEmitter subscribe(Long userId, String lastEventId);
+
+    void send(NotificationType notificationType, UserEntity userEntity, String content);
+
+
+    ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable);
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,130 @@
+package com.example.basketballmatching.notifications.service.impl;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.repository.EmitterRepository;
+import com.example.basketballmatching.notifications.repository.NotificationQueryRepository;
+import com.example.basketballmatching.notifications.repository.NotificationRepository;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class NotificationServiceImpl implements NotificationService {
+    private static final Long DEFAULT_TIMEOUT = 30L * 1000 * 60;
+
+    private final EmitterRepository emitterRepository;
+
+    private final NotificationRepository notificationRepository;
+
+    private final NotificationQueryRepository notificationQueryRepository;
+
+    private final UserRepository userRepository;
+
+    @Override
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String emitterId = userId + "_" + System.currentTimeMillis();
+
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(
+                () -> emitterRepository.deleteByEmitterId(emitterId)
+        );
+
+        emitter.onTimeout(() -> emitterRepository.deleteByEmitterId(emitterId));
+        emitter.onError((e) -> emitterRepository.deleteByEmitterId(emitterId));
+
+
+        sendToClient(emitter, emitterId,
+                "EventStream Created. [emitterId = " + emitterId + "]");
+
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithUserId(
+                    String.valueOf(userId)
+            );
+
+            events.entrySet().stream()
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(
+                            entry -> sendToClient(emitter, entry.getKey(), entry.getValue())
+                    );
+        }
+
+
+        return emitter;
+    }
+
+    @Override
+    @Transactional
+    public void send(NotificationType notificationType, UserEntity userEntity, String content) {
+
+        NotificationEntity notification = NotificationEntity.builder()
+                .receiver(userEntity)
+                .notificationType(notificationType)
+                .content(content)
+                .build();
+
+        notificationRepository.save(notification);
+
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithByUserId(
+                String.valueOf(notification.getReceiver().getUserId())
+        );
+
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    emitterRepository.saveEventCache(key, notification);
+                    sendToClient(emitter, key, NotificationDto.fromEntity(notification));
+                }
+        );
+
+
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        List<NotificationDto> notificationDtoList = notificationQueryRepository.getUnReadNotification(userId, pageable);
+
+        return ApiResponse.of("현재 읽지 않은 알림 조회에 성공하였습니다.", notificationDtoList);
+    }
+
+    private void sendToClient(SseEmitter sseEmitter, String emitterId, Object data) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .name("sse")
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteByEmitterId(emitterId);
+        }
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/type/NotificationType.java
+++ b/src/main/java/com/example/basketballmatching/notifications/type/NotificationType.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.notifications.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+
+    KICKED_OUT("강퇴"),
+    ACCEPT_GAME("경기 참가 수락"),
+    REJECT_GAME("경기 참가 거절"),
+    DELETE_GAME("경기 삭제");
+
+    private final String description;
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 승인 / 거절 / 강퇴 / 삭제 등 주요 이벤트 발생 시
실시간 알림 기능이 전혀 없었음

### 🚀 TO-BE
✅ SSE(Server-Sent Events) 기반 실시간 알림 기능 구현
- /api/v1/notification/subscribe 요청 시 SseEmitter 생성 및 연결 유지
- 서버에서 알림 발생 시 클라이언트로 즉시 push 전송
- 터미널(curl) 사용하여 실시간 수신 테스트 완료

✅ 읽음 상태 관리
- isRead, readDateTime 필드 추가
- QueryDsl기반으로 안읽은 알림만 조회
- 조회 후 자동으로 읽음 처리

---

## ✅ 체크리스트
- [x] 터미널(curl) 기반 SSE 실시간 테스트
- [x] 승인 / 거절 / 강퇴 / 삭제 이벤트 발생 시 즉시 알림 수신 확인
- [x] 읽지 않은 알림 조회 기능 검증

---
