### PR TITLE
[feat] : 유저 신고 기능 및 신고 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -18,28 +18,14 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
     boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long userId, Long gameId);
 
-    int countByParticipantGameStatusAndGameEntity_GameId(
-            ParticipantGameStatus participantGameStatus, Long gameId
-    );
 
     Page<ParticipantGameEntity> findByParticipantGameStatusAndGameEntity_GameId(ParticipantGameStatus status, Long gameId, Pageable pageable);
 
     List<ParticipantGameEntity> findByParticipantGameStatusInAndGameEntity_GameId(List<ParticipantGameStatus> statuses, Long gameId);
 
-    Optional<ParticipantGameEntity> findByGameEntity_GameIdAndParticipantGameId(Long gameId, Long userId);
-
-
-    Page<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatusIn(Long userId, List<ParticipantGameStatus> statuses, Pageable pageable);
-
-
-    Page<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatus(Long userId, ParticipantGameStatus participantGameStatus, Pageable pageable);
 
 
     Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
-
-
-
-    List<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatus(Long userId, ParticipantGameStatus participantGameStatus);
 
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -3,16 +3,20 @@ package com.example.basketballmatching.gameCreator.repository;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
 
-    boolean existsByParticipantGameIdAndGameEntity_GameId(Long gameId, Long UserId);
+    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long userId, Long gameId);
 
     int countByParticipantGameStatusAndGameEntity_GameId(
             ParticipantGameStatus participantGameStatus, Long gameId
@@ -32,6 +36,8 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
 
     Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
+
+
 
     List<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatus(Long userId, ParticipantGameStatus participantGameStatus);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -11,6 +11,8 @@ import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import com.example.basketballmatching.notifications.type.NotificationType;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     private final GameRepository gameRepository;
 
     private final UserRepository userRepository;
+
+    private final NotificationService notificationService;
 
 
     /**
@@ -132,7 +136,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
-        boolean exists = participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(participantId, gameId);
+        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participantId, gameId);
 
         if (!exists) {
             throw new CustomException(NOT_APPLY_USER);
@@ -149,7 +153,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findById(participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
@@ -159,6 +163,10 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, now);
 
         participantGameRepository.save(participantGameEntity);
+
+
+        notificationService.send(NotificationType.ACCEPT_GAME, participantGameEntity.getUserEntity(),
+                participantGameEntity.getGameEntity().getTitle() + "에 참가가 수락되었습니다.");
 
 
 
@@ -188,7 +196,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
 
@@ -212,6 +220,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, LocalDateTime.now());
 
         participantGameRepository.save(participantGameEntity);
+
+        notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
         log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantId, gameId);
 
@@ -239,7 +249,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndParticipantGameId(gameId, participantId)
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
@@ -265,6 +275,10 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         gameEntity.decreaseParticipantCount();
         gameRepository.save(gameEntity);
+
+        notificationService.send(NotificationType.KICKED_OUT, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에서 강퇴당하였습니다.");
+
+
 
         log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantId, gameId);
 
@@ -303,6 +317,16 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         participantGameEntityList.forEach(participantGame ->
                 participantGame.setParticipantGameStatusAndDeletedDateTime(DELETE, now));
+
+        participantGameEntityList
+                .stream()
+                .filter(participantGameEntity -> !Objects.equals(participantGameEntity.getUserEntity().getUserId(), userEntity.getUserId()))
+                .forEach(
+
+                participantGame ->
+                    notificationService.send(NotificationType.DELETE_GAME, participantGame.getUserEntity(), participantGame.getGameEntity().getTitle() + "의 게임이 삭제되었습니다.")
+
+        );
 
         participantGameRepository.saveAll(participantGameEntityList);
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -98,7 +98,7 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional
     public CheckResponse cancelGame(Long userId, Long gameId) {
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+        GameEntity gameEntity = gameRepository.findByGameIdWithLock(gameId)
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
 
         ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
@@ -290,7 +290,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         }
 
-        if (participantGameRepository.existsByParticipantGameIdAndGameEntity_GameId(userEntity.getUserId(), gameEntity.getGameId())) {
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(gameEntity.getGameId(),userEntity.getUserId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -77,7 +77,11 @@ public enum ErrorCode {
     NOT_GAME_ENDED(HttpStatus.BAD_REQUEST, "아직 경기가 종료되지 않았습니다."),
     CANNOT_EVALUATE_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 평가할 수 없습니다."),
     ALREADY_EVALUATED(HttpStatus.BAD_REQUEST, "이미 평가한 참가자입니다."),
-    INVALID_LEVEL_SCORE(HttpStatus.BAD_REQUEST, "평가점수는 1 ~ 5점만 입력가능합니다.")
+    INVALID_LEVEL_SCORE(HttpStatus.BAD_REQUEST, "평가점수는 1 ~ 5점만 입력가능합니다."),
+
+
+    // report
+    ALREADY_REPORTED_USER(HttpStatus.BAD_REQUEST, "이미 신고받은 유저입니다.")
     ;
 
 

--- a/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
+++ b/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
@@ -1,0 +1,57 @@
+package com.example.basketballmatching.notifications.controller;
+
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import io.lettuce.core.dynamic.annotation.Param;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<SseEmitter> subscribe(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestHeader(value = "lastEventId", required = false, defaultValue = "")
+            String lastEventId) {
+
+
+        SseEmitter sseEmitter = notificationService.subscribe(userInfoDetails.getUserEntity().getUserId(), lastEventId);
+
+
+        return ResponseEntity.ok(sseEmitter);
+    }
+
+    @GetMapping("/unread-notification")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ApiResponse<List<NotificationDto>>> getUnreadNotifications(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ApiResponse<List<NotificationDto>> unReadNotifications = notificationService.getUnReadNotifications(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+        return ResponseEntity.ok(unReadNotifications);
+    }
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/dto/NotificationDto.java
+++ b/src/main/java/com/example/basketballmatching/notifications/dto/NotificationDto.java
@@ -1,0 +1,38 @@
+package com.example.basketballmatching.notifications.dto;
+
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+
+    private Long notificationId;
+
+    private NotificationType notificationType;
+
+    private String content;
+
+    private LocalDateTime createAt;
+
+    public static NotificationDto fromEntity(NotificationEntity notificationEntity) {
+
+        return NotificationDto.builder()
+                .notificationId(notificationEntity.getNotificationId())
+                .notificationType(notificationEntity.getNotificationType())
+                .content(notificationEntity.getContent())
+                .createAt(notificationEntity.getCreatedAt())
+                .build();
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/entity/NotificationEntity.java
+++ b/src/main/java/com/example/basketballmatching/notifications/entity/NotificationEntity.java
@@ -1,0 +1,50 @@
+package com.example.basketballmatching.notifications.entity;
+
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long notificationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private UserEntity receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isRead = false;
+
+
+    private LocalDateTime readDateTime;
+
+
+    public void setReadAndReadDateTime(LocalDateTime readDateTime) {
+        this.isRead = true;
+        this.readDateTime = readDateTime;
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/EmitterRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/EmitterRepository.java
@@ -1,0 +1,68 @@
+package com.example.basketballmatching.notifications.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepository {
+
+    public final Map<String, SseEmitter> emitter = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitter.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+
+    public void saveEventCache(String emitterId, Object event) {
+        eventCache.put(emitterId, event);
+    }
+
+    public Map<String, SseEmitter> findAllStartWithByUserId(String userId) {
+
+        return emitter.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    }
+
+    public Map<String, Object> findAllEventCacheStartWithUserId(String userId) {
+
+
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    }
+
+    public void deleteAllStratWithUserId(String userId) {
+        emitter.forEach(
+                (key, value) -> {
+                    if (key.startsWith(userId)) {
+                        emitter.remove(key);
+                    }
+                }
+        );
+    }
+
+    public void deleteByEmitterId(String emitterId) {
+        emitter.remove(emitterId);
+    }
+
+    public void deleteAllEventCacheStartWithUserId(String userId) {
+
+        eventCache.forEach(
+                (key, value) -> {
+                    if (key.startsWith(userId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/NotificationQueryRepository.java
@@ -1,0 +1,56 @@
+package com.example.basketballmatching.notifications.repository;
+
+
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.entity.QNotificationEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepository {
+
+    private final NotificationRepository notificationRepository;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<NotificationDto> getUnReadNotification(Long userId, Pageable pageable) {
+
+        QNotificationEntity notificationEntity = QNotificationEntity.notificationEntity;
+
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(notificationEntity.receiver.userId.eq(userId));
+        builder.and(notificationEntity.isRead.eq(false));
+        builder.and(notificationEntity.readDateTime.isNull());
+
+        List<NotificationEntity> notificationEntities = jpaQueryFactory
+                .select(notificationEntity)
+                .from(notificationEntity)
+                .where(builder)
+                .orderBy(notificationEntity.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        for (NotificationEntity notification : notificationEntities) {
+
+            notification.setReadAndReadDateTime(LocalDateTime.now());
+            notificationRepository.save(notification);
+        }
+
+
+        return notificationEntities.stream()
+                .map(NotificationDto::fromEntity)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/example/basketballmatching/notifications/repository/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.notifications.repository;
+
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.example.basketballmatching.notifications.service;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+public interface NotificationService {
+
+
+    SseEmitter subscribe(Long userId, String lastEventId);
+
+    void send(NotificationType notificationType, UserEntity userEntity, String content);
+
+
+    ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable);
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,130 @@
+package com.example.basketballmatching.notifications.service.impl;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.notifications.dto.NotificationDto;
+import com.example.basketballmatching.notifications.entity.NotificationEntity;
+import com.example.basketballmatching.notifications.repository.EmitterRepository;
+import com.example.basketballmatching.notifications.repository.NotificationQueryRepository;
+import com.example.basketballmatching.notifications.repository.NotificationRepository;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class NotificationServiceImpl implements NotificationService {
+    private static final Long DEFAULT_TIMEOUT = 30L * 1000 * 60;
+
+    private final EmitterRepository emitterRepository;
+
+    private final NotificationRepository notificationRepository;
+
+    private final NotificationQueryRepository notificationQueryRepository;
+
+    private final UserRepository userRepository;
+
+    @Override
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String emitterId = userId + "_" + System.currentTimeMillis();
+
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(
+                () -> emitterRepository.deleteByEmitterId(emitterId)
+        );
+
+        emitter.onTimeout(() -> emitterRepository.deleteByEmitterId(emitterId));
+        emitter.onError((e) -> emitterRepository.deleteByEmitterId(emitterId));
+
+
+        sendToClient(emitter, emitterId,
+                "EventStream Created. [emitterId = " + emitterId + "]");
+
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithUserId(
+                    String.valueOf(userId)
+            );
+
+            events.entrySet().stream()
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(
+                            entry -> sendToClient(emitter, entry.getKey(), entry.getValue())
+                    );
+        }
+
+
+        return emitter;
+    }
+
+    @Override
+    @Transactional
+    public void send(NotificationType notificationType, UserEntity userEntity, String content) {
+
+        NotificationEntity notification = NotificationEntity.builder()
+                .receiver(userEntity)
+                .notificationType(notificationType)
+                .content(content)
+                .build();
+
+        notificationRepository.save(notification);
+
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithByUserId(
+                String.valueOf(notification.getReceiver().getUserId())
+        );
+
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    emitterRepository.saveEventCache(key, notification);
+                    sendToClient(emitter, key, NotificationDto.fromEntity(notification));
+                }
+        );
+
+
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        List<NotificationDto> notificationDtoList = notificationQueryRepository.getUnReadNotification(userId, pageable);
+
+        return ApiResponse.of("현재 읽지 않은 알림 조회에 성공하였습니다.", notificationDtoList);
+    }
+
+    private void sendToClient(SseEmitter sseEmitter, String emitterId, Object data) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .name("sse")
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteByEmitterId(emitterId);
+        }
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/notifications/type/NotificationType.java
+++ b/src/main/java/com/example/basketballmatching/notifications/type/NotificationType.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.notifications.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+
+    KICKED_OUT("강퇴"),
+    ACCEPT_GAME("경기 참가 수락"),
+    REJECT_GAME("경기 참가 거절"),
+    DELETE_GAME("경기 삭제");
+
+    private final String description;
+}

--- a/src/main/java/com/example/basketballmatching/report/controller/ReportController.java
+++ b/src/main/java/com/example/basketballmatching/report/controller/ReportController.java
@@ -1,0 +1,55 @@
+package com.example.basketballmatching.report.controller;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import com.example.basketballmatching.report.dto.CreateReportDto;
+import com.example.basketballmatching.report.dto.ReportListDto;
+import com.example.basketballmatching.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckResponse> createReport(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam Long reportedUserId,
+            @RequestParam Long gameId,
+            @RequestBody CreateReportDto request) {
+
+        CheckResponse checkResponse = reportService.createReport(userInfoDetails.getUserEntity().getUserId(), reportedUserId, gameId, request);
+
+
+        return ResponseEntity.ok(checkResponse);
+    }
+
+    @GetMapping("/list")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Page<ReportListDto>>> getReportUserList(
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ApiResponse<Page<ReportListDto>> reportedUserList = reportService.getReportedUserList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+
+
+        return ResponseEntity.ok(reportedUserList);
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/report/dto/CreateReportDto.java
+++ b/src/main/java/com/example/basketballmatching/report/dto/CreateReportDto.java
@@ -1,0 +1,19 @@
+package com.example.basketballmatching.report.dto;
+
+import com.example.basketballmatching.report.type.ReportType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+
+public class CreateReportDto {
+
+    @NotBlank(message = "신고 유형을 입력해주세요.")
+    private ReportType reportType;
+
+    @NotBlank(message = "신고 내용을 입력해주세요.")
+    private String content;
+
+}

--- a/src/main/java/com/example/basketballmatching/report/dto/ReportListDto.java
+++ b/src/main/java/com/example/basketballmatching/report/dto/ReportListDto.java
@@ -1,0 +1,45 @@
+package com.example.basketballmatching.report.dto;
+
+import com.example.basketballmatching.report.entity.ReportEntity;
+import com.example.basketballmatching.report.type.ReportType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ReportListDto {
+
+    private Long reportId;
+
+    private Long reportUserId;
+
+    private Long reportedUserId;
+
+    private String reportedUserNickname;
+
+    private ReportType reportType;
+
+    private String content;
+
+    private LocalDateTime reportedDateTime;
+
+    public static ReportListDto fromEntity(ReportEntity report) {
+
+        return ReportListDto.builder()
+                .reportId(report.getReportId())
+                .reportUserId(report.getReportUser().getUserId())
+                .reportedUserId(report.getReportedUser().getUserId())
+                .reportedUserNickname(report.getReportedUser().getNickname())
+                .reportType(report.getReportType())
+                .content(report.getContent())
+                .reportedDateTime(report.getReportedDateTime())
+                .build();
+
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/report/entity/ReportEntity.java
+++ b/src/main/java/com/example/basketballmatching/report/entity/ReportEntity.java
@@ -1,0 +1,63 @@
+package com.example.basketballmatching.report.entity;
+
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.report.dto.CreateReportDto;
+import com.example.basketballmatching.report.type.ReportType;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReportEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_user_id", nullable = false)
+    private UserEntity reportUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private UserEntity reportedUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private GameEntity gameEntity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportType reportType;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime reportedDateTime;
+
+
+    public static ReportEntity create(UserEntity reportUser, UserEntity reportedUser, GameEntity gameEntity, CreateReportDto createReportDto) {
+        return ReportEntity.builder()
+                .reportUser(reportUser)
+                .reportedUser(reportedUser)
+                .gameEntity(gameEntity)
+                .reportType(createReportDto.getReportType())
+                .content(createReportDto.getContent())
+                .reportedDateTime(LocalDateTime.now())
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
@@ -1,0 +1,16 @@
+package com.example.basketballmatching.report.repository;
+
+import com.example.basketballmatching.report.entity.ReportEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
+
+    boolean existsByReportedUser_UserIdAndGameEntity_GameId(Long reportedUserId, Long gameId);
+
+    Page<ReportEntity> findAllByOrderByReportedDateTimeDesc(Pageable pageable);
+
+}
+
+

--- a/src/main/java/com/example/basketballmatching/report/service/ReportService.java
+++ b/src/main/java/com/example/basketballmatching/report/service/ReportService.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.report.service;
+
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.report.dto.CreateReportDto;
+import com.example.basketballmatching.report.dto.ReportListDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportService {
+
+
+    CheckResponse createReport(Long reportId, Long reportedId, Long gameId, CreateReportDto createReportDto);
+
+    ApiResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable);
+
+
+}

--- a/src/main/java/com/example/basketballmatching/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/report/service/impl/ReportServiceImpl.java
@@ -1,0 +1,99 @@
+package com.example.basketballmatching.report.service.impl;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.report.dto.CreateReportDto;
+import com.example.basketballmatching.report.dto.ReportListDto;
+import com.example.basketballmatching.report.entity.ReportEntity;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.report.service.ReportService;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final GameRepository gameRepository;
+
+    private final ParticipantGameRepository participantGameRepository;
+
+    private final UserRepository userRepository;
+
+    private final ReportRepository reportRepository;
+
+
+    @Override
+    @Transactional
+    public CheckResponse createReport(Long reportUserId, Long reportedUserId, Long gameId, CreateReportDto createReportDto) {
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (gameEntity.getEndDateTime().isAfter(now)) {
+            throw new CustomException(NOT_GAME_ENDED);
+        }
+
+        UserEntity reportUser = userRepository.findById(reportUserId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), reportUser.getUserId())) {
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+
+        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(reportedUserId, gameEntity.getGameId());
+
+        if (!exists) {
+            throw new CustomException(PARTICIPANT_NOT_FOUND);
+        }
+
+        UserEntity reportedUser = userRepository.findById(reportedUserId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        boolean existsByReport = reportRepository.existsByReportedUser_UserIdAndGameEntity_GameId(reportedUser.getUserId(), gameEntity.getGameId());
+
+        if (existsByReport) {
+            throw new CustomException(ALREADY_REPORTED_USER);
+        }
+
+        ReportEntity reportEntity = ReportEntity.create(reportUser, reportedUser, gameEntity, createReportDto);
+
+        reportRepository.save(reportEntity);
+
+        return CheckResponse.of(true, "해당 유저 신고를 완료하였습니다.");
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        Page<ReportEntity> reportEntities = reportRepository.findAllByOrderByReportedDateTimeDesc(pageable);
+
+
+        Page<ReportListDto> reportListDtos = reportEntities.map(ReportListDto::fromEntity);
+
+        return ApiResponse.of("신고목록 조회를 완료하였습니다.", reportListDtos);
+    }
+}

--- a/src/main/java/com/example/basketballmatching/report/type/ReportType.java
+++ b/src/main/java/com/example/basketballmatching/report/type/ReportType.java
@@ -1,0 +1,15 @@
+package com.example.basketballmatching.report.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportType {
+
+    POOR_SPORTSMANSHIP("비매너 및 악의적 플레이"),
+    NO_SHOW("무단 불참 / 노쇼"),
+    ABUSIVE_LANGUAGE("욕설 및 언어폭력");
+
+    private final String description;
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 유저 신고 기능 미구현
- 관리자 신고 유저 목록 조회 기능 미구현

### 🚀 TO-BE
✅ 신고 기능 구현
- 경기 종료 이후 신고 가능
- 경기 주최자만이 신고 가능
- 동일경기 내의 동일 유저 중복 신고 불가

✅ 신고 목록 조회 기능 구현
- 관리자 권한 접근 가능
- 최신순으로 정렬
- 페이징 처리

---

## ✅ 체크리스트
- [x] API테스트
- [x] 신고 기능 구현
- [x] 신고 목록 조회 기능 구현

---
