### PR TITLE
[fix] : 회원탈퇴 유저 및 블랙리스트 로그인 차단 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,29 @@ dependencies {
     // oAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    //queryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -39,7 +39,9 @@ public class AuthServiceImpl implements AuthService {
 
         log.info("[유저 로그인 시작]: {}", email);
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+
+
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (userEntity.getLoginProvider().equals(KAKAO)) {
@@ -48,6 +50,11 @@ public class AuthServiceImpl implements AuthService {
 
         if (!passwordEncoder.matches(password, userEntity.getPassword()) || password == null) {
                 throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+        String data = redisService.getData("blackList:" + userEntity.getEmail());
+
+        if (data != null) {
+            throw new CustomException(BLACKLIST_USER);
         }
 
 
@@ -73,7 +80,7 @@ public class AuthServiceImpl implements AuthService {
 
         log.info("[카카오 로그인 검증 시작] email : {}", email);
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (userEntity.getLoginProvider().equals(LOCAL)) {
@@ -114,7 +121,7 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(INVALID_TOKEN);
         }
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // refreshToken 검증

--- a/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
@@ -138,7 +138,7 @@ public class BlackListServiceImpl implements BlackListService {
 
         list.forEach(participantGameEntity -> {
 
-            participantGameEntity.getGameEntity().decreaseParticipantCount();
+
             participantGameEntity.setBlackUserStatus(participantGameEntity.getParticipantGameStatus(), LocalDateTime.now());
 
         });

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -290,7 +290,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         }
 
-        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(gameEntity.getGameId(),userEntity.getUserId())) {
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(),gameEntity.getGameId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 

--- a/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
+++ b/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
@@ -23,7 +23,7 @@ public class UserInfoDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         return new UserInfoDetails(userEntity);

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -11,8 +11,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByNickname(String nickname);
 
-    Optional<UserEntity> findByEmail(String email);
+    Optional<UserEntity> findByEmailAndDeletedDateTimeIsNull(String email);
 
     Optional<UserEntity> findByUserIdAndDeletedDateTimeIsNull(Long userId);
+
+    Optional<UserEntity> findByEmail(String email);
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 회원 탈퇴 유저(Soft Delete)가 로그인 가능한 문제 발생
- 블랙리스트 유저 로그인 성공 문제 발생

### 🚀 TO-BE
✅ 탈퇴 유저 로그인 차단 처리
- 로그인 시 deletedDateTime이 null 인지 확인
   - JPA 메서드 변경 findByUserIdAndDeletedDateTimeIsNull
- 탈퇴 유저는 즉시 USER_NOT_FOUND 반환

✅ 블랙리스트 유저 로그인 차단 로직 추가
- AuthService login 로직 내부에서 Redis "blackList:<email>" 체크 후 로그인 차단
- 기존처럼 AuthentificationFilter에서도 토큰 접근 차단

---

## ✅ 체크리스트
- [x] 회원 탈퇴 유저 로그인 차단
- [x] 블랙리스트 유저 로그인 차단
- [x] API 테스트
---
