### PR TITLE
[docs] : Swagger API 문서화 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,29 @@ dependencies {
     // oAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    //queryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -5,9 +5,15 @@ import com.example.basketballmatching.auth.dto.LoginDto;
 import com.example.basketballmatching.auth.dto.ReIssueTokenDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
-import com.example.basketballmatching.global.dto.ApiResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("api/v1/user")
 @RequiredArgsConstructor
+@Tag(name = "AUTH")
 public class AuthController {
 
 
@@ -27,8 +34,16 @@ public class AuthController {
     private final AuthService authService;
 
 
+    /**
+        유저 로그인
+     */
+    @Operation(summary = "유저 로그인")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenDto>> loginUser(
+    public ResponseEntity<CommonResponse<TokenDto>> loginUser(
             @RequestBody @Valid LoginDto.Request request
     ) {
 
@@ -40,12 +55,21 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(ApiResponse.of("로그인에 성공하였습니다.", token));
+                .body(CommonResponse.of("로그인에 성공하였습니다.", token));
 
     }
 
+    /**
+     * 토큰 재발급
+     */
+    @Operation(summary = "토큰 재발급")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"
+    )
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/reissue")
-    public ResponseEntity<ApiResponse<TokenDto>> reissue(
+    public ResponseEntity<CommonResponse<TokenDto>> reissue(
             @RequestBody @Valid ReIssueTokenDto request
             ) {
 
@@ -57,10 +81,18 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(ApiResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
+                .body(CommonResponse.of("토큰 재발급에 성공하였습니다.", reissueToken));
 
     }
 
+    /**
+     * 유저 로그아웃
+     */
+    @Operation(summary = "유저 로그아웃")
+    @ApiResponse(responseCode = "200", description = "유저 로그아웃 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/logout")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> logoutUser(

--- a/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/LoginDto.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.user.dto.SignUpDto;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -22,10 +23,12 @@ public class LoginDto {
     @Builder
     public static class Request {
 
+        @Schema(description = "이메일", example = "test@test.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "이메일 형식으로 입력해주세요.")
         private String email;
 
+        @Schema(description = "비밀번호", example = "Test@1234", defaultValue = "Test@1234")
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
                 message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")

--- a/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/ReIssueTokenDto.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -9,10 +10,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReIssueTokenDto {
 
+    @Schema(description = "이메일", example = "test@test.com")
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Email(message = "이메일 형식으로 입력해주세요.")
     private String email;
 
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String refreshToken;
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -39,7 +39,9 @@ public class AuthServiceImpl implements AuthService {
 
         log.info("[유저 로그인 시작]: {}", email);
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+
+
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (userEntity.getLoginProvider().equals(KAKAO)) {
@@ -48,6 +50,11 @@ public class AuthServiceImpl implements AuthService {
 
         if (!passwordEncoder.matches(password, userEntity.getPassword()) || password == null) {
                 throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+        String data = redisService.getData("blackList:" + userEntity.getEmail());
+
+        if (data != null) {
+            throw new CustomException(BLACKLIST_USER);
         }
 
 
@@ -73,7 +80,7 @@ public class AuthServiceImpl implements AuthService {
 
         log.info("[카카오 로그인 검증 시작] email : {}", email);
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (userEntity.getLoginProvider().equals(LOCAL)) {
@@ -114,7 +121,7 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(INVALID_TOKEN);
         }
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // refreshToken 검증

--- a/src/main/java/com/example/basketballmatching/blackList/controller/BlackListController.java
+++ b/src/main/java/com/example/basketballmatching/blackList/controller/BlackListController.java
@@ -2,9 +2,16 @@ package com.example.basketballmatching.blackList.controller;
 
 import com.example.basketballmatching.blackList.dto.BlackListDto;
 import com.example.basketballmatching.blackList.service.BlackListService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,14 +23,26 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/blacklist")
+@Tag(name = "BLACK_LIST")
 public class BlackListController {
 
     private final BlackListService blackListService;
 
+    /**
+     * 유저 블랙리스트 등록
+     */
+    @Operation(summary = "유저 블랙리스트 등록")
+    @ApiResponse(responseCode = "200", description = "유저 블랙리스트 등록 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/create")
     @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<CheckResponse> createBlackListUser(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "신고 받은 유저 아이디", example = "1")
             @RequestParam Long reportId
             ) {
 
@@ -35,16 +54,26 @@ public class BlackListController {
 
     }
 
+    /**
+     * 블랙리스트 유저 조회
+     */
+    @Operation(summary = "블랙리스트 유저 조회")
+    @ApiResponse(responseCode = "200", description = "블랙리스트 유저 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/list")
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<ApiResponse<Page<BlackListDto>>> getBlackListUsers(
+    public ResponseEntity<CommonResponse<Page<BlackListDto>>> getBlackListUsers(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        ApiResponse<Page<BlackListDto>> blackLists = blackListService.getBlackLists(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<Page<BlackListDto>> blackLists = blackListService.getBlackLists(userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
         return ResponseEntity.ok(blackLists);
     }

--- a/src/main/java/com/example/basketballmatching/blackList/service/BlackListService.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/BlackListService.java
@@ -1,7 +1,7 @@
 package com.example.basketballmatching.blackList.service;
 
 import com.example.basketballmatching.blackList.dto.BlackListDto;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +11,6 @@ public interface BlackListService {
 
     CheckResponse createBlackListUser(Long userId, Long reportId);
 
-    ApiResponse<Page<BlackListDto>> getBlackLists(Long userId, Pageable pageable);
+    CommonResponse<Page<BlackListDto>> getBlackLists(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
@@ -138,7 +138,7 @@ public class BlackListServiceImpl implements BlackListService {
 
         list.forEach(participantGameEntity -> {
 
-            participantGameEntity.getGameEntity().decreaseParticipantCount();
+
             participantGameEntity.setBlackUserStatus(participantGameEntity.getParticipantGameStatus(), LocalDateTime.now());
 
         });

--- a/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
@@ -8,7 +8,7 @@ import com.example.basketballmatching.blackList.service.BlackListService;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.service.RedisService;
@@ -19,14 +19,12 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.APPLY;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -89,7 +87,7 @@ public class BlackListServiceImpl implements BlackListService {
 
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<Page<BlackListDto>> getBlackLists(Long userId, Pageable pageable) {
+    public CommonResponse<Page<BlackListDto>> getBlackLists(Long userId, Pageable pageable) {
 
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -110,7 +108,7 @@ public class BlackListServiceImpl implements BlackListService {
         Page<BlackListDto> listDtoPage = new PageImpl<>(blackListDtos, pageable, blackListDtos.size());
 
 
-        return ApiResponse.of("블랙리스트 유저 조회에 성공하였습니다.", listDtoPage);
+        return CommonResponse.of("블랙리스트 유저 조회에 성공하였습니다.", listDtoPage);
     }
 
     private void validateBlackUser(UserEntity targetUser) {

--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/GameController.java
@@ -6,11 +6,17 @@ import com.example.basketballmatching.gameCreator.dto.GameDto;
 import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
@@ -23,62 +29,111 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/api/v1/game")
 @RequiredArgsConstructor
+@Tag(name = "GAME")
 public class GameController {
 
     private final GameService gameService;
 
+    /**
+     * 경기 생성
+     */
+    @Operation(summary = "경기 생성")
+    @ApiResponse(responseCode = "200", description = "경기 생성 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/create")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<CreateGameDto.Response>> createGame(
+    public ResponseEntity<CommonResponse<CreateGameDto.Response>> createGame(
             @RequestBody @Valid CreateGameDto.Request request,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
             ) {
 
-        ApiResponse<CreateGameDto.Response> game = gameService.createGame(userInfoDetails.getUserEntity().getUserId(), request);
+        CommonResponse<CreateGameDto.Response> game = gameService.createGame(userInfoDetails.getUserEntity().getUserId(), request);
 
 
         return ResponseEntity.ok(game);
 
     }
 
+    /**
+     * 경기 상세 조회
+     */
+    @Operation(summary = "경기 상세 조회")
+    @ApiResponse(responseCode = "200", description = "경기 상세 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/details")
-    public ResponseEntity<ApiResponse<GameDto>> detailGame(
+    public ResponseEntity<CommonResponse<GameDto>> detailGame(
             @RequestParam Long gameId
     ) {
 
-        ApiResponse<GameDto> gameDto = gameService.detailGame(gameId);
+        CommonResponse<GameDto> gameDto = gameService.detailGame(gameId);
 
         return ResponseEntity.ok(gameDto);
     }
 
+    /**
+     * 경기 검색 정렬
+     */
+    @Operation(summary = "경기 검색 정렬 ")
+    @ApiResponse(responseCode = "200", description = "경기 검색 정렬 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<Page<SearchGameDto>>> searchGame(
+    public ResponseEntity<CommonResponse<Page<SearchGameDto>>> searchGame(
+            @Parameter(name = "경기 날짜", example = "2025-12-02", required = true)
             @RequestParam @Valid LocalDate date,
+
+            @Parameter(name = "도시 이름", example = "INCHEON")
             @RequestParam(required = false) CityName cityName,
+
+            @Parameter(name = "경기 형식", example = "THREE_ON_THREE")
             @RequestParam(required = false) MatchFormat matchFormat,
+
+            @Parameter(name = "경기 실내외 형식", example = "INDOOR")
             @RequestParam(required = false) FieldStatus fieldStatus,
+
+            @Parameter(name = "경기 성별 형식", example = "MALE_ONLY")
             @RequestParam(required = false) MatchGenderType matchGenderType,
+
+            @Parameter(name = "경기 상태", example = "RECRUITING")
             @RequestParam(required = false) GameStatus gameStatus,
+
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        ApiResponse<Page<SearchGameDto>> searchGame = gameService.searchGame(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageRequest);
+        CommonResponse<Page<SearchGameDto>> searchGame = gameService.searchGame(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageRequest);
 
         return ResponseEntity.ok(searchGame);
     }
 
+    /**
+     * 경기 수정
+     */
+    @Operation(summary = "경기 수정")
+    @ApiResponse(responseCode = "200", description = "경기 수정 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/edit")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<GameDto>> editGame(
+    public ResponseEntity<CommonResponse<GameDto>> editGame(
             @RequestBody @Valid EditGameDto request,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "게임 아이디", example = "1")
             @RequestParam Long gameId
     ) {
 
-        ApiResponse<GameDto> editGame = gameService.editGame(request, gameId, userInfoDetails.getUserEntity().getUserId());
+        CommonResponse<GameDto> editGame = gameService.editGame(request, gameId, userInfoDetails.getUserEntity().getUserId());
 
 
         return ResponseEntity.ok(editGame);

--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
@@ -4,9 +4,16 @@ package com.example.basketballmatching.gameCreator.controller;
 import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
 import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -20,15 +27,27 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/game/creator")
 @RequiredArgsConstructor
+@Tag(name = "PARTICIPANT")
 public class ParticipantGameController {
 
     private final ParticipantGameService participantGameService;
 
+    /**
+     * 경기 참가 신청자 조회
+     */
+    @Operation(summary = "경기 참가 신청자 조회")
+    @ApiResponse(responseCode = "200", description = "경기 참가 신청자 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/search/apply")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<List<ApplyGameUserListDto>>> getApplyParticipantList (
+    public ResponseEntity<CommonResponse<List<ApplyGameUserListDto>>> getApplyParticipantList (
+            @Parameter(name = "게임아이디", example = "1", required = true)
             @RequestParam Long gameId,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
 
@@ -36,34 +55,57 @@ public class ParticipantGameController {
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC, "createdAt");
 
-        ApiResponse<List<ApplyGameUserListDto>> participantList = participantGameService.getApplyParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<List<ApplyGameUserListDto>> participantList = participantGameService.getApplyParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
 
 
         return ResponseEntity.ok(participantList);
     }
 
+    /**
+     * 경기 참가 수락자 조회
+     */
+    @Operation(summary = "경기 참가 수락자 조회")
+    @ApiResponse(responseCode = "200", description = "경기 참가 수락자 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/search/accept")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<List<AcceptGameUserListDto>>> getAcceptParticipantList(
+    public ResponseEntity<CommonResponse<List<AcceptGameUserListDto>>> getAcceptParticipantList(
+            @Parameter(name = "게임아이디", example = "1", required = true)
             @RequestParam Long gameId,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC, "createdAt");
 
-        ApiResponse<List<AcceptGameUserListDto>> acceptParticipantList = participantGameService.getAcceptParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<List<AcceptGameUserListDto>> acceptParticipantList = participantGameService.getAcceptParticipantList(gameId, userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
         return ResponseEntity.ok(acceptParticipantList);
     }
 
 
+    /**
+     * 경기 신청 수락
+     */
+    @Operation(summary = "경기 신청 수락")
+    @ApiResponse(responseCode = "200", description = "경기 신청 수락 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/accept")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> acceptGameUser (
+            @Parameter(name = "게임 아이디", example = "1", required = true)
             @RequestParam Long gameId,
+            @Parameter(name = "참가자 아이디", example = "1", required = true)
             @RequestParam Long participantId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {
@@ -73,10 +115,23 @@ public class ParticipantGameController {
         return ResponseEntity.ok(checkResponse);
     }
 
+
+    /**
+     * 경기 신청 거절
+     */
+    @Operation(summary = "경기 신청 거절")
+    @ApiResponse(responseCode = "200", description = "경기 신청 거절 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/reject")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> rejectGameUser (
+            @Parameter(name = "게임 아이디", example = "1", required = true)
             @RequestParam Long gameId,
+            @Parameter(name = "참가자 아이디", example = "1", required = true)
             @RequestParam Long participantId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {
@@ -86,10 +141,22 @@ public class ParticipantGameController {
         return ResponseEntity.ok(checkResponse);
     }
 
+    /**
+     * 경기 수락자 강퇴
+     */
+    @Operation(summary = "경기 수락자 강퇴")
+    @ApiResponse(responseCode = "200", description = "경기 수락자 강퇴 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/kickout")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> kickoutGameUser (
+            @Parameter(name = "게임 아이디", example = "1", required = true)
             @RequestParam Long gameId,
+            @Parameter(name = "참가자 아이디", example = "1", required = true)
             @RequestParam Long participantId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {
@@ -100,9 +167,20 @@ public class ParticipantGameController {
 
     }
 
+    /**
+     * 경기 삭제
+     */
+    @Operation(summary = "경기 삭제")
+    @ApiResponse(responseCode = "200", description = "경기 삭제 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/delete")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> deleteGame (
+            @Parameter(name = "경기 아이디", example = "1")
             @RequestParam Long gameId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
@@ -3,6 +3,7 @@ package com.example.basketballmatching.gameCreator.dto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.user.entity.UserEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -23,40 +24,51 @@ public class CreateGameDto {
     public static class Request {
 
 
+        @Schema(name = "경기 제목", example = "서울 xx체육관 3vs3 경기 인원 모집")
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
 
+        @Schema(name = "경기 상세 내용", example = "3대3경기 인원 모집입니다.")
         @NotBlank(message = "내용을 입력해주세요.")
         private String content;
 
+        @Schema(name = "경기 인원 수", example = "6")
         @NotNull(message = "인원수를 입력해주세요.")
         @Min(value = 6, message = "최소 6명이상입니다.")
         private Integer headCount;
 
+        @Schema(name = "경기 실내외", example = "INDOOR")
         @NotNull(message = "실내외를 입력해주세요.")
         private FieldStatus fieldStatus;
 
+        @Schema(name = "경기 형식", example = "THREE_ON_THREE")
         @NotNull(message = "경기형식을 입력해주세요.")
         private MatchFormat matchFormat;
 
+        @Schema(name = "경기 시작 날짜", example = "2025-11-22T15:00:00:00")
         @NotNull(message = "시작 날짜를 입력해주세요.")
         @Future(message = "시작 시간은 현재 시각 이후여야 합니다.")
         private LocalDateTime startDateTime;
 
+        @Schema(name = "경기 종료 날짜", example = "2025-11-22T17:00:00:00")
         @NotNull(message = "종료 날짜를 입력해주세요.")
         @Future(message = "종료 시간은 현재 시각 이후여야 합니다.")
         private LocalDateTime endDateTime;
 
+        @Schema(name = "경기 장소", example = "서울 xx 체육관")
         @NotBlank(message = "장소 이름을 입력해주세요.")
         private String placeName;
 
+        @Schema(name = "경기 주소", example = "서울특별시 강남구..")
         @NotBlank(message = "주소를 입력해주세요.")
         private String address;
+
 
         private Double latitude;
 
         private Double longitude;
 
+        @Schema(name = "경기 성별 유형", example = "MALE_ONLY")
         @NotNull(message = "성별을 입력해주세요.")
         private MatchGenderType matchGenderType;
 
@@ -91,38 +103,54 @@ public class CreateGameDto {
     @NoArgsConstructor
     @Builder
     public static class Response {
+
+        @Schema(name = "경기 PK", example = "1")
         private Long gameId;
 
+        @Schema(name = "경기 제목", example = "서울 xx체육관 3vs3 경기 인원 모집", defaultValue = "서울 xx체육관 3vs3 경기 인원 모집")
         private String title;
 
+        @Schema(name = "경기 상세 내용", example = "3대3경기 인원 모집입니다.", defaultValue = "3대3경기 인원 모집입니다.")
         private String content;
 
+        @Schema(name = "경기 인원 수", example = "6")
         private int headCount;
 
+        @Schema(name = "경기 참가 인원 수", example = "1", defaultValue = "1")
         private int participantCount;
 
+        @Schema(name = "경기 실내외", example = "INDOOR")
         private FieldStatus fieldStatus;
 
+        @Schema(name = "경기 형식", example = "THREE_ON_THREE")
         private MatchFormat matchFormat;
 
+        @Schema(name = "경기 상태", example = "RECRUITING")
         private GameStatus gameStatus;
 
+        @Schema(name = "경기 시작 날짜", example = "2025-11-22T15:00:00:00")
         private LocalDateTime startDateTime;
 
+        @Schema(name = "경기 장소", example = "서울 xx 체육관")
         private String placeName;
 
+        @Schema(name = "경기 주소", example = "서울특별시 강남구..")
         private String address;
 
         private Double latitude;
 
         private Double longitude;
 
+        @Schema(name = "도시 이름", example = "INCHEON")
         private CityName cityName;
 
+        @Schema(name = "경기 성별 유형", example = "MALE_ONLY")
         private MatchGenderType matchGenderType;
 
+        @Schema(name = "경기 생성자 아이디", example = "1")
         private Long creatorId;
 
+        @Schema(name = "경기 생성자 닉네임", example = "커리")
         private String creatorNickname;
 
         public static Response fromDto(GameDto gameDto) {

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/EditGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/EditGameDto.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.gameCreator.dto;
 
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,12 +10,16 @@ import lombok.Getter;
 @Builder
 public class EditGameDto {
 
+        @Schema(name = "경기 제목", example = "서울 xx체육관에서 3대3 인원 모집")
         private String title;
 
+        @Schema(name = "경기 상세 내용", example = "3대3인원 모집합니다.")
         private String content;
 
+        @Schema(name = "경기 인원 수", example = "6")
         private int headCount;
 
+        @Schema(name = "경기 형식", example = "THREE_ON_THREE")
         private MatchFormat matchFormat;
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/GameDto.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.gameCreator.dto;
 
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.type.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,46 +16,57 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class GameDto {
 
+    @Schema(name = "경기 PK", example = "1")
     private Long gameId;
 
+    @Schema(name = "경기 제목", example = "서울 xx체육관 3vs3 경기 인원 모집", defaultValue = "서울 xx체육관 3vs3 경기 인원 모집")
     private String title;
 
+    @Schema(name = "경기 상세 내용", example = "3대3경기 인원 모집입니다.", defaultValue = "3대3경기 인원 모집입니다.")
     private String content;
 
+    @Schema(name = "경기 인원 수", example = "6")
     private int headCount;
 
+    @Schema(name = "경기 참가 인원 수", example = "1", defaultValue = "1")
     private int participantCount;
 
+    @Schema(name = "경기 실내외", example = "INDOOR")
     private FieldStatus fieldStatus;
 
+    @Schema(name = "경기 형식", example = "THREE_ON_THREE")
     private MatchFormat matchFormat;
 
+    @Schema(name = "경기 상태", example = "RECRUITING")
     private GameStatus gameStatus;
 
+    @Schema(name = "경기 시작 날짜", example = "2025-11-22T15:00:00:00")
     private LocalDateTime startDateTime;
 
+    @Schema(name = "경기 종료 날짜", example = "2025-11-22T17:00:00:00")
     private LocalDateTime endDateTime;
 
-    private LocalDateTime createdAt;
 
-    private LocalDateTime updatedAt;
-
-    private LocalDateTime deletedDateTime;
-
+    @Schema(name = "경기 장소", example = "서울 xx 체육관")
     private String placeName;
 
+    @Schema(name = "경기 주소", example = "서울특별시 강남구..")
     private String address;
 
     private Double latitude;
 
     private Double longitude;
 
+    @Schema(name = "도시 이름", example = "INCHEON")
     private CityName cityName;
 
+    @Schema(name = "경기 주소", example = "서울특별시 강남구..")
     private MatchGenderType matchGenderType;
 
+    @Schema(name = "경기 생성자 아이디", example = "1")
     private Long creatorId;
 
+    @Schema(name = "경기 생성자 닉네임", example = "커리")
     private String creatorNickname;
 
 
@@ -72,9 +84,6 @@ public class GameDto {
                 .gameStatus(gameEntity.getGameStatus())
                 .startDateTime(gameEntity.getStartDateTime())
                 .endDateTime(gameEntity.getEndDateTime())
-                .createdAt(gameEntity.getCreatedAt())
-                .updatedAt(gameEntity.getUpdatedAt())
-                .deletedDateTime(gameEntity.getDeletedDateTime())
                 .placeName(gameEntity.getPlaceName())
                 .address(gameEntity.getAddress())
                 .latitude(gameEntity.getLatitude())

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/GameService.java
@@ -5,7 +5,7 @@ import com.example.basketballmatching.gameCreator.dto.EditGameDto;
 import com.example.basketballmatching.gameCreator.dto.GameDto;
 import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.type.*;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,12 +13,12 @@ import java.time.LocalDate;
 
 public interface GameService {
 
-    ApiResponse<CreateGameDto.Response> createGame(Long UserId, CreateGameDto.Request request);
+    CommonResponse<CreateGameDto.Response> createGame(Long UserId, CreateGameDto.Request request);
 
-    ApiResponse<GameDto> detailGame(Long gameId);
+    CommonResponse<GameDto> detailGame(Long gameId);
 
-    ApiResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable);
+    CommonResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable);
 
-    ApiResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId);
+    CommonResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/ParticipantGameService.java
@@ -2,7 +2,7 @@ package com.example.basketballmatching.gameCreator.service;
 
 import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
 import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -12,9 +12,9 @@ public interface ParticipantGameService {
 
 
 
-    ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable);
+    CommonResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable);
 
-    ApiResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable);
+    CommonResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable);
 
     CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -10,7 +10,7 @@ import com.example.basketballmatching.gameCreator.repository.GameQueryRepository
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
@@ -44,7 +44,7 @@ public class GameServiceImpl implements GameService {
      */
     @Override
     @Transactional
-    public ApiResponse<CreateGameDto.Response> createGame(Long userId, CreateGameDto.Request request) {
+    public CommonResponse<CreateGameDto.Response> createGame(Long userId, CreateGameDto.Request request) {
 
         log.info("[경기 생성 시작] userId = {} title = {}", userId, request.getTitle());
 
@@ -65,7 +65,7 @@ public class GameServiceImpl implements GameService {
         log.info("[경기 생성 완료] gameId = {}", gameEntity.getGameId());
 
 
-        return ApiResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
+        return CommonResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
     }
 
     /**
@@ -73,7 +73,7 @@ public class GameServiceImpl implements GameService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<GameDto> detailGame(Long gameId) {
+    public CommonResponse<GameDto> detailGame(Long gameId) {
 
         log.info("[경기 상세 조회 시작] gameId : {}", gameId);
 
@@ -85,7 +85,7 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 상세조회 완료] gameId : {}", gameId);
 
-        return ApiResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
+        return CommonResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
     }
 
     /**
@@ -93,7 +93,7 @@ public class GameServiceImpl implements GameService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable) {
+    public CommonResponse<Page<SearchGameDto>> searchGame(LocalDate date, CityName cityName, MatchFormat matchFormat, FieldStatus fieldStatus, MatchGenderType matchGenderType, GameStatus gameStatus, Pageable pageable) {
 
         log.info("[경기 검색 정렬 시작] date : {}", date);
 
@@ -101,12 +101,12 @@ public class GameServiceImpl implements GameService {
 
 
         if (responses.isEmpty()) {
-            return ApiResponse.of("경기 검색결과가 없습니다.", responses);
+            return CommonResponse.of("경기 검색결과가 없습니다.", responses);
         }
 
         log.info("[경기 검색 정렬 완료] date : {}", date);
 
-        return ApiResponse.of("경기 검색이 완료되었습니다.", responses);
+        return CommonResponse.of("경기 검색이 완료되었습니다.", responses);
     }
 
     /**
@@ -114,7 +114,7 @@ public class GameServiceImpl implements GameService {
      */
     @Override
     @Transactional
-    public ApiResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId) {
+    public CommonResponse<GameDto> editGame(EditGameDto request, Long gameId, Long userId) {
 
         log.info("[경기 수정 시작] loginId : {}, gameId : {}", userId, gameId);
 
@@ -169,7 +169,7 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 수정 완료] gameId : {}", gameId);
 
-        return ApiResponse.of("경기 수정이 완료되었습니다.", GameDto.fromEntity(gameEntity));
+        return CommonResponse.of("경기 수정이 완료되었습니다.", GameDto.fromEntity(gameEntity));
     }
 
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -8,7 +8,7 @@ import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.notifications.service.NotificationService;
@@ -48,7 +48,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable) {
+    public CommonResponse<List<ApplyGameUserListDto>> getApplyParticipantList(Long gameId, Long userId, Pageable pageable) {
 
         log.info("[경기 참가 신청자 조회 시작] gameId : {}, userId : {}", gameId, userId);
 
@@ -72,7 +72,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[경기 참가 신청자 조회 완료] gameId : {}, userId : {}", gameId, userId);
 
-        return ApiResponse.of("경기 신청자 조회가 완료되었습니다.", participantGameList);
+        return CommonResponse.of("경기 신청자 조회가 완료되었습니다.", participantGameList);
     }
 
 
@@ -81,7 +81,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable) {
+    public CommonResponse<List<AcceptGameUserListDto>> getAcceptParticipantList(Long gameId, Long userId, Pageable pageable) {
 
         log.info("[경기 참가 수락자 조회 시작] gameId : {}, userId : {}", gameId, userId);
 
@@ -107,7 +107,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         log.info("[경기 참가 수락자 조회 완료] gameId : {}, userId : {}", gameId, userId);
 
 
-        return ApiResponse.of("경기 참가자 조회가 완료되었습니다.", participantGameList);
+        return CommonResponse.of("경기 참가자 조회가 완료되었습니다.", participantGameList);
     }
 
     private Page<ParticipantGameEntity> getParticipantGameList(Pageable pageable, GameEntity gameEntity, ParticipantGameStatus participantGameStatus) {

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -3,9 +3,16 @@ package com.example.basketballmatching.gameUsers.controller;
 
 import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -20,71 +27,119 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/game")
+@Tag(name = "GAME_USER")
 public class GameUserController {
 
     private final GameUserService gameUserService;
 
+    /**
+     * 경기 참가
+     */
+    @Operation(summary = "경기 참가")
+    @ApiResponse(responseCode = "200", description = "경기 참가 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/apply")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<ApplyGameUserDto>> applyGame(
+    public ResponseEntity<CommonResponse<ApplyGameUserDto>> applyGame(
+            @Parameter(name = "경기 아이디", example = "1")
             @RequestParam Long gameId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
             ) {
 
-        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userInfoDetails.getUserEntity().getUserId());
+        CommonResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userInfoDetails.getUserEntity().getUserId());
 
         return ResponseEntity.ok(applyGame);
 
     }
-
+    /**
+     * 참가 경기 취소
+     */
+    @Operation(summary = "참가 경기 취소")
+    @ApiResponse(responseCode = "200", description = "참가 경기 취소 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/cancel")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> cancelGame(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
             @RequestParam Long gameId
     ) {
 
-        CheckResponse checkResponse = gameUserService.cancelGame(userId, gameId);
+        CheckResponse checkResponse = gameUserService.cancelGame(userInfoDetails.getUserEntity().getUserId(), gameId);
 
 
         return ResponseEntity.ok(checkResponse);
     }
 
+    /**
+     * 현재 예정 경기 조회
+     */
+    @Operation(summary = "현재 예정 경기 조회")
+    @ApiResponse(responseCode = "200", description = "현재 예정 경기 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/user/current-game")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<List<CurrentGameListDto>>> getMyCurrentGameList (
+    public ResponseEntity<CommonResponse<List<CurrentGameListDto>>> getMyCurrentGameList (
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size
     ){
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC,"gameEntity_startDateTime");
 
-        ApiResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
         return ResponseEntity.ok(myCurrentGameList);
     }
 
 
+    /**
+     * 지난 경기 조회
+     */
+    @Operation(summary = "지난 경기 조회")
+    @ApiResponse(responseCode = "200", description = "지난 경기 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/user/last-game")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<List<LastGameListDto>>> getMyLastGameList (
+    public ResponseEntity<CommonResponse<List<LastGameListDto>>> getMyLastGameList (
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size
     ){
 
         PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC,"gameEntity_startDateTime");
 
-        ApiResponse<List<LastGameListDto>> myCurrentGameList = gameUserService.getMyLastGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<List<LastGameListDto>> myCurrentGameList = gameUserService.getMyLastGameList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
         return ResponseEntity.ok(myCurrentGameList);
     }
 
+    /**
+     * 참가자 경기 실력 평가
+     */
+    @Operation(summary = "참가자 경기 실력 평가")
+    @ApiResponse(responseCode = "200", description = "참가자 경기 실력 평가 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/user/evaluate/{gameId}")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> evaluatePlayer(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "평가 경기 아이디", example = "1")
             @PathVariable Long gameId,
             @RequestBody @Valid EvaluatePlayerDto request
             ) {
@@ -95,13 +150,21 @@ public class GameUserController {
         return ResponseEntity.ok(checkResponse);
     }
 
+    /**
+     * 유저 랭크 조회
+     */
+    @Operation(summary = "유저 랭크 조회")
+    @ApiResponse(responseCode = "200", description = "유저 랭크 조회")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/user/rank")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<GameUserLevelDto>> getMyGameUserLevel(
+    public ResponseEntity<CommonResponse<GameUserLevelDto>> getMyGameUserLevel(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {
 
-        ApiResponse<GameUserLevelDto> myGameUserLevel = gameUserService.getMyGameUserLevel(userInfoDetails.getUserEntity().getUserId());
+        CommonResponse<GameUserLevelDto> myGameUserLevel = gameUserService.getMyGameUserLevel(userInfoDetails.getUserEntity().getUserId());
 
         return ResponseEntity.ok(myGameUserLevel);
     }

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/EvaluatePlayerDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/EvaluatePlayerDto.java
@@ -3,6 +3,7 @@ package com.example.basketballmatching.gameUsers.dto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameUsers.entity.LevelEntity;
 import com.example.basketballmatching.user.entity.UserEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -17,9 +18,11 @@ import lombok.NoArgsConstructor;
 @Builder
 public class EvaluatePlayerDto {
 
+    @Schema(name = "피평가자 아이디", example = "1")
     @NotNull
     private Long receiverId;
 
+    @Schema(name = "평가 점수", example = "1")
     @NotNull
     @Min(1)
     @Max(5)

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,7 +1,7 @@
 package com.example.basketballmatching.gameUsers.service;
 
 import com.example.basketballmatching.gameUsers.dto.*;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -10,15 +10,15 @@ import java.util.List;
 public interface GameUserService {
 
 
-    ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
+    CommonResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
 
     CheckResponse cancelGame(Long userId, Long gameId);
 
-    ApiResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable);
+    CommonResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable);
 
-    ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable);
+    CommonResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable);
 
     CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request);
 
-    ApiResponse<GameUserLevelDto> getMyGameUserLevel(Long userId);
+    CommonResponse<GameUserLevelDto> getMyGameUserLevel(Long userId);
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -290,7 +290,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         }
 
-        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(gameEntity.getGameId(),userEntity.getUserId())) {
+        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(),gameEntity.getGameId())) {
             throw new CustomException(ALREADY_APPLY_GAME_USER);
         }
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -11,7 +11,7 @@ import com.example.basketballmatching.gameUsers.entity.LevelEntity;
 import com.example.basketballmatching.gameUsers.repository.LevelRepository;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.gameUsers.type.GameUserLevel;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.entity.UserEntity;
@@ -52,7 +52,7 @@ public class GameUserServiceImpl implements GameUserService {
      */
     @Override
     @Transactional
-    public ApiResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
+    public CommonResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
         log.info("[경기 참가 신청 시작] gameId : {} userId : {}", gameId, userId);
 
 
@@ -88,7 +88,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, entity.getParticipantGameId());
 
-        return ApiResponse.of("경기 신청이 완료되었습니다.", participantDto);
+        return CommonResponse.of("경기 신청이 완료되었습니다.", participantDto);
     }
 
     /**
@@ -139,7 +139,7 @@ public class GameUserServiceImpl implements GameUserService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
+    public CommonResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
 
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -147,7 +147,7 @@ public class GameUserServiceImpl implements GameUserService {
 
         List<CurrentGameListDto> currentGameList = gameQueryRepository.getCurrentGameList(userId, pageable);
 
-        return ApiResponse.of("현재 예정된 게임 조회가 완료되었습니다.", currentGameList);
+        return CommonResponse.of("현재 예정된 게임 조회가 완료되었습니다.", currentGameList);
     }
 
     /**
@@ -155,7 +155,7 @@ public class GameUserServiceImpl implements GameUserService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
+    public CommonResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
 
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -164,7 +164,7 @@ public class GameUserServiceImpl implements GameUserService {
         List<LastGameListDto> lastGameList = gameQueryRepository.getLastGameList(userId, pageable);
 
 
-        return ApiResponse.of("지난 게임 조회가 완료되었습니다.", lastGameList);
+        return CommonResponse.of("지난 게임 조회가 완료되었습니다.", lastGameList);
     }
 
 
@@ -216,7 +216,7 @@ public class GameUserServiceImpl implements GameUserService {
 
     @Override
     @Transactional(readOnly = true)
-    public ApiResponse<GameUserLevelDto> getMyGameUserLevel(Long userId) {
+    public CommonResponse<GameUserLevelDto> getMyGameUserLevel(Long userId) {
 
         UserEntity userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -224,7 +224,7 @@ public class GameUserServiceImpl implements GameUserService {
         GameUserLevelDto gameUserLevelDto = GameUserLevelDto.fromEntity(userEntity);
 
 
-        return ApiResponse.of("유저 랭크 조회를 완료하였습니다.", gameUserLevelDto);
+        return CommonResponse.of("유저 랭크 조회를 완료하였습니다.", gameUserLevelDto);
     }
 
     // 최근 10경기 평균으로 Level측정

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -39,7 +39,11 @@ public class SecurityConfig {
                                         "/api/v1/user/reissue",
                                         "/api/oauth2/**",
                                         "/api/v1/game/details",
-                                        "api/v1/game/search"
+                                        "/api/v1/game/search",
+                                        "/swagger-ui.html",
+                                        "/swagger-ui/**",
+                                        "/v3/api-docs/**",
+                                        "/swagger"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/basketballmatching/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SwaggerConfig.java
@@ -1,0 +1,84 @@
+package com.example.basketballmatching.global.config;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.jackson.TypeNameResolver;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "BasketBallMatching API Document",
+                description = "API Document",
+                version = "v0.1"
+
+        ),
+        tags = {
+                @Tag(name = "USER", description = "회원 기능"),
+                @Tag(name = "AUTH", description = "인증/인가"),
+                @Tag(name = "REPORT", description = "유저 신고"),
+                @Tag(name = "GAME", description = "경기 생성자 기능"),
+                @Tag(name = "PARTICIPANT", description = "경기 참가 기능"),
+                @Tag(name = "GAME_USER", description = "경기 참가자 기능"),
+                @Tag(name = "NOTIFICATION", description = "알림 기능"),
+                @Tag(name = "BLACK_LIST", description = "블랙리스트 기능"),
+                @Tag(name = "OAUTH2", description = "소셜 로그인 (Kakao)")
+        }
+)
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void initialize() {
+        TypeNameResolver typeNameResolver = new TypeNameResolver() {
+            @Override
+            public String getNameOfClass(Class<?> cls) {
+
+                String className = cls.getName();
+                int lastIndex = className.lastIndexOf('.');
+                return className.substring(lastIndex + 1).replace("$", ".");
+            }
+        };
+
+        ModelConverters.getInstance().addConverter(
+                new ModelResolver(objectMapper, typeNameResolver)
+        );
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("Bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(
+                        new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement));
+
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/dto/CheckResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/dto/CheckResponse.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.global.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 public class CheckResponse {
 
     private final boolean success;
+
+    @Schema(name = "확인 메시지", example = "회원가입에 성공하였습니다.")
     private final String message;
 
 

--- a/src/main/java/com/example/basketballmatching/global/dto/CommonResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/dto/CommonResponse.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.global.dto;
 
-import lombok.AllArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -8,8 +8,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @RequiredArgsConstructor(staticName = "of")
-public class ApiResponse<T> {
+public class CommonResponse<T> {
 
+    @Schema(name = "확인 메시지", example = "***에 성공하였습니다.")
     private final String message;
     private final T data;
 

--- a/src/main/java/com/example/basketballmatching/global/dto/VerifyEmailDto.java
+++ b/src/main/java/com/example/basketballmatching/global/dto/VerifyEmailDto.java
@@ -1,5 +1,8 @@
 package com.example.basketballmatching.global.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,8 +10,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class VerifyEmailDto {
 
-
+    @Schema(description = "이메일", example = "test@test.com")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
     private String email;
+
+    @Schema(description = "인증번호", example = "123456")
+    @NotBlank(message = "인증번호는 필수 입력값입니다.")
     private String code;
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/dto/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.global.exception.dto;
 
 
 import com.example.basketballmatching.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +13,13 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class ErrorResponse {
-
+    @Schema(description = "HTTP 상태 코드", example = "400")
     private int statusCode;
+
+    @Schema(description = "에러코드", example = "USER_NOT_FOUND")
     private String errorCode;
+
+    @Schema(description = "에러메시지", example = "사용자를 찾을 수 없습니다.")
     private String errorMessage;
     private List<FieldErrorDetail> details;
 

--- a/src/main/java/com/example/basketballmatching/global/exception/dto/FieldErrorDetail.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/dto/FieldErrorDetail.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.global.exception.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +8,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(staticName = "of")
 public class FieldErrorDetail {
 
+    @Schema(description = "검증 실패한 필드명", example = "email")
     private final String field;
+
+    @Schema(description = "검증 실패 코드", example =  "NotBlank")
     private final String code;
+
+    @Schema(description = "검증 실패 메시지", example = "이메일은 필수 입력값입니다.")
     private final String message;
 }

--- a/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
+++ b/src/main/java/com/example/basketballmatching/global/security/UserInfoDetailsService.java
@@ -23,7 +23,7 @@ public class UserInfoDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        UserEntity userEntity = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         return new UserInfoDetails(userEntity);

--- a/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
+++ b/src/main/java/com/example/basketballmatching/notifications/controller/NotificationController.java
@@ -1,11 +1,17 @@
 package com.example.basketballmatching.notifications.controller;
 
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.notifications.dto.NotificationDto;
 import com.example.basketballmatching.notifications.service.NotificationService;
-import io.lettuce.core.dynamic.annotation.Param;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
@@ -20,14 +26,24 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notification")
+@Tag(name = "NOTIFICATION")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
+    /**
+     * 알림 구독 (SSE)
+     */
+    @Operation(summary = "알림 구독(SSE)")
+    @ApiResponse(responseCode = "200", description = "SSE 구독 연결 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<SseEmitter> subscribe(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "Last-Event-ID", description = "유실된 이벤트 복구를 위한 마지막 이벤트 ID")
             @RequestHeader(value = "lastEventId", required = false, defaultValue = "")
             String lastEventId) {
 
@@ -37,17 +53,26 @@ public class NotificationController {
 
         return ResponseEntity.ok(sseEmitter);
     }
-
+    /**
+     * 읽지 않은 알림 조회
+     */
+    @Operation(summary = "읽지 않은 알림 조회")
+    @ApiResponse(responseCode = "200", description = "읽지 않은 알림 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/unread-notification")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<List<NotificationDto>>> getUnreadNotifications(
+    public ResponseEntity<CommonResponse<List<NotificationDto>>> getUnreadNotifications(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        ApiResponse<List<NotificationDto>> unReadNotifications = notificationService.getUnReadNotifications(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<List<NotificationDto>> unReadNotifications = notificationService.getUnReadNotifications(userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
         return ResponseEntity.ok(unReadNotifications);
     }

--- a/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/NotificationService.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.notifications.service;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.notifications.dto.NotificationDto;
 import com.example.basketballmatching.notifications.type.NotificationType;
 import com.example.basketballmatching.user.entity.UserEntity;
@@ -17,7 +17,7 @@ public interface NotificationService {
     void send(NotificationType notificationType, UserEntity userEntity, String content);
 
 
-    ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable);
+    CommonResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable);
 
 
 

--- a/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/notifications/service/impl/NotificationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.notifications.service.impl;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.notifications.dto.NotificationDto;
 import com.example.basketballmatching.notifications.entity.NotificationEntity;
@@ -103,14 +103,14 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @Transactional
-    public ApiResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable) {
+    public CommonResponse<List<NotificationDto>> getUnReadNotifications(Long userId, Pageable pageable) {
 
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         List<NotificationDto> notificationDtoList = notificationQueryRepository.getUnReadNotification(userId, pageable);
 
-        return ApiResponse.of("현재 읽지 않은 알림 조회에 성공하였습니다.", notificationDtoList);
+        return CommonResponse.of("현재 읽지 않은 알림 조회에 성공하였습니다.", notificationDtoList);
     }
 
     private void sendToClient(SseEmitter sseEmitter, String emitterId, Object data) {

--- a/src/main/java/com/example/basketballmatching/report/controller/ReportController.java
+++ b/src/main/java/com/example/basketballmatching/report/controller/ReportController.java
@@ -1,11 +1,19 @@
 package com.example.basketballmatching.report.controller;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.report.dto.CreateReportDto;
 import com.example.basketballmatching.report.dto.ReportListDto;
 import com.example.basketballmatching.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -17,18 +25,28 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/report")
+@Tag(name = "REPORT")
 public class ReportController {
 
     private final ReportService reportService;
 
 
+    @Operation(summary = "유저 신고 등록")
+    @ApiResponse(responseCode = "200", description = "유저 신고 등록 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> createReport(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "신고받은 유저 아이디", example = "1")
             @RequestParam Long targetUserId,
+            @Parameter(name = "해당 게임 아이디", example = "1")
             @RequestParam Long gameId,
-            @RequestBody CreateReportDto request) {
+            @RequestBody @Valid CreateReportDto request) {
 
         CheckResponse checkResponse = reportService.createReport(userInfoDetails.getUserEntity().getUserId(), targetUserId, gameId, request);
 
@@ -36,16 +54,23 @@ public class ReportController {
         return ResponseEntity.ok(checkResponse);
     }
 
+    @Operation(summary = "신고 받은 유저 조회")
+    @ApiResponse(responseCode = "200", description = "신고 받은 유저 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/list")
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<ApiResponse<Page<ReportListDto>>> getReportUserList(
+    public ResponseEntity<CommonResponse<Page<ReportListDto>>> getReportUserList(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,
+            @Parameter(name = "페이지", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(name = "페이지 사이즈", example = "10")
             @RequestParam(defaultValue = "10") int size) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        ApiResponse<Page<ReportListDto>> reportedUserList = reportService.getReportedUserList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
+        CommonResponse<Page<ReportListDto>> reportedUserList = reportService.getReportedUserList(userInfoDetails.getUserEntity().getUserId(), pageRequest);
 
 
         return ResponseEntity.ok(reportedUserList);

--- a/src/main/java/com/example/basketballmatching/report/dto/CreateReportDto.java
+++ b/src/main/java/com/example/basketballmatching/report/dto/CreateReportDto.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.report.dto;
 
 import com.example.basketballmatching.report.type.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,9 +11,11 @@ import lombok.Getter;
 
 public class CreateReportDto {
 
+    @Schema(name = "신고 유형", example = "POOR_SPORTSMANSHIP", defaultValue = "POOR_SPORTSMANSHIP")
     @NotBlank(message = "신고 유형을 입력해주세요.")
     private ReportType reportType;
 
+    @Schema(name = "신고 내용", example = "비매너 행위", defaultValue = "비매너 행위")
     @NotBlank(message = "신고 내용을 입력해주세요.")
     private String content;
 

--- a/src/main/java/com/example/basketballmatching/report/service/ReportService.java
+++ b/src/main/java/com/example/basketballmatching/report/service/ReportService.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.report.service;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.report.dto.CreateReportDto;
 import com.example.basketballmatching.report.dto.ReportListDto;
@@ -12,7 +12,7 @@ public interface ReportService {
 
     CheckResponse createReport(Long reportId, Long targetUserId, Long gameId, CreateReportDto createReportDto);
 
-    ApiResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable);
+    CommonResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable);
 
 
 }

--- a/src/main/java/com/example/basketballmatching/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/report/service/impl/ReportServiceImpl.java
@@ -3,7 +3,7 @@ package com.example.basketballmatching.report.service.impl;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.report.dto.CreateReportDto;
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Objects;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -83,7 +82,7 @@ public class ReportServiceImpl implements ReportService {
 
     @Override
     @Transactional
-    public ApiResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable) {
+    public CommonResponse<Page<ReportListDto>> getReportedUserList(Long userId, Pageable pageable) {
 
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -95,6 +94,6 @@ public class ReportServiceImpl implements ReportService {
         Page<ReportListDto> reportListDtos = reportEntities
                 .map(ReportListDto::fromEntity);
 
-        return ApiResponse.of("신고목록 조회를 완료하였습니다.", reportListDtos);
+        return CommonResponse.of("신고목록 조회를 완료하였습니다.", reportListDtos);
     }
 }

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -1,13 +1,21 @@
 package com.example.basketballmatching.user.controller;
 
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.VerifyEmailDto;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
 import com.example.basketballmatching.global.service.MailService;
 import com.example.basketballmatching.user.dto.*;
+import com.example.basketballmatching.user.dto.SignUpDto.Response;
 import com.example.basketballmatching.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
+@Tag(name = "USER")
 public class UserController {
 
 
@@ -27,20 +36,40 @@ public class UserController {
     private final MailService mailService;
 
 
+    /**
+     * 회원가입
+     */
+    @Operation(summary = "회원가입")
+    @ApiResponse(responseCode = "200", description = "회원가입에 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignUpDto.Response>> signup(
+    public ResponseEntity<CommonResponse<Response>> signup(
             @RequestBody @Valid SignUpDto.Request request
             ) {
 
-        ApiResponse<SignUpDto.Response> response = userService.signUp(request);
+        CommonResponse<Response> response = userService.signUp(request);
 
 
         return ResponseEntity.ok(response);
 
     }
 
+    /**
+     * 이메일 중복 확인
+     */
+
+    @Operation(summary = "이메일 중복 확인")
+    @ApiResponse(responseCode = "200", description = "이메일 중복 확인 성공",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    content = {@Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/check-email")
     public ResponseEntity<CheckResponse> checkEmail(
+            @Parameter(name = "이메일", example = "test@test.com", required = true)
             @RequestParam String email
     ) {
         CheckResponse checkResponse = userService.checkEmail(email);
@@ -48,8 +77,16 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
     }
 
+    @Operation(summary = "닉네임 중복 확인")
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/check-nickname")
     public ResponseEntity<CheckResponse> checkNickname(
+            @Parameter(name = "닉네임", example = "커리", required = true)
             @RequestParam String nickname
     ) {
         CheckResponse checkResponse = userService.checkNickname(nickname);
@@ -57,8 +94,18 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
     }
 
+
+
+    @Operation(summary = "회원가입 이메일 전송")
+    @ApiResponse(responseCode = "200", description = "회원가입 이메일 전송 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/send-mail")
     public ResponseEntity<CheckResponse> sendMailAuth(
+            @Parameter(name = "이메일", example = "test@test.com", required = true)
             @RequestParam String email
     ) {
         mailService.sendAuthMail(email);
@@ -66,6 +113,13 @@ public class UserController {
         return ResponseEntity.ok(CheckResponse.of(true, "이메일 인증번호가 전송되었습니다."));
     }
 
+    @Operation(summary = "회원가입 이메일 인증번호 확인")
+    @ApiResponse(responseCode = "200", description = "회원가입 이메일 인증번호 확인 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/verify-mail")
     public ResponseEntity<CheckResponse> verifyEmailAuth(
             @RequestBody VerifyEmailDto request
@@ -77,30 +131,47 @@ public class UserController {
 
     }
 
+    @Operation(summary = "회원 정보 조회")
+    @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/user-info")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<UserDto>> getUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails) {
+    public ResponseEntity<CommonResponse<UserDto>> getUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails) {
 
-        ApiResponse<UserDto> userInfo = userService.getUserInfo(userInfoDetails.getUserEntity().getUserId());
+        CommonResponse<UserDto> userInfo = userService.getUserInfo(userInfoDetails.getUserEntity().getUserId());
 
         return ResponseEntity.ok(userInfo);
 
     }
 
+    @Operation(summary = "회원 정보 수정")
+    @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/edit-info")
     @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<ApiResponse<UserDto>> editUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails, @RequestBody @Valid EditUserDto editUserDto) {
+    public ResponseEntity<CommonResponse<UserDto>> editUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails, @RequestBody @Valid EditUserDto editUserDto) {
 
         Long userId = userInfoDetails.getUserEntity().getUserId();
 
-        ApiResponse<UserDto> response = userService.editUserInfo(userId, editUserDto);
+        CommonResponse<UserDto> response = userService.editUserInfo(userId, editUserDto);
 
         return ResponseEntity.ok(response);
 
     }
-
+    @Operation(summary = "비밀번호 변경 인증번호 전송")
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 인증번호 전송 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/password/send-auth")
     public ResponseEntity<CheckResponse> sendPasswordAuthCode(
+            @Parameter(name = "이메일", example = "test@test.com", required = true)
             @RequestParam String email
     ) {
 
@@ -110,6 +181,13 @@ public class UserController {
 
     }
 
+    @Operation(summary = "비밀번호 변경 인증번호 확인")
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 인증번호 확인 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PostMapping("/password/verify-code")
     public ResponseEntity<CheckResponse> verifyPasswordCode(
             @RequestBody VerifyEmailDto request
@@ -120,6 +198,14 @@ public class UserController {
         return ResponseEntity.ok(checkResponse);
     }
 
+
+    @Operation(summary = "비밀번호 찾기 비밀번호 변경")
+    @ApiResponse(responseCode = "200", description = "비밀번호 찾기 비밀번호 변경 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PatchMapping("/password/reset")
     public ResponseEntity<CheckResponse> resetPassword(
             @RequestBody @Valid ResetPasswordDto request
@@ -132,6 +218,13 @@ public class UserController {
 
     }
 
+    @Operation(summary = "비밀번호 변경")
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PreAuthorize("hasAnyRole('USER')")
     @PatchMapping("/password/change")
     public ResponseEntity<CheckResponse> changePassword(
@@ -144,6 +237,13 @@ public class UserController {
 
     }
 
+    @Operation(summary = "회원 탈퇴")
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CheckResponse.class))})
+    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
     @PreAuthorize("hasAnyRole('USER')")
     @PatchMapping("/delete")
     public ResponseEntity<CheckResponse> deleteUser(

--- a/src/main/java/com/example/basketballmatching/user/dto/ChangePasswordDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/ChangePasswordDto.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.user.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -13,17 +14,20 @@ import lombok.Getter;
 public class ChangePasswordDto {
 
 
+    @Schema(description = "현재 비밀번호", example = "Test@1234", defaultValue = "Test@1234")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
             message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
     private String currentPassword;
 
 
+    @Schema(description = "변경 비밀번호", example = "Test@1234", defaultValue = "Test@1234")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
             message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
     private String newPassword;
 
+    @Schema(description = "변경 비밀번호 확인", example = "Test@1234", defaultValue = "Test@1234")
     private String newCheckPassword;
 
 }

--- a/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.user.dto;
 
 import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -15,15 +16,19 @@ import lombok.Getter;
 public class EditUserDto {
 
 
+    @Schema(name = "닉네임", example = "커리", defaultValue = "커리")
     private String nickname;
 
-
+    @Schema(description = "휴대폰 번호", example = "010-1111-0000")
     @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
     private String phone;
 
+    @Schema(description = "주소", example = "서울특별시 강남구")
     private String address;
 
+    @Schema(description = "성별", example = "MALE", defaultValue = "MALE")
     private GenderType genderType;
 
+    @Schema(description = "포지션", example = "NONE", defaultValue = "NONE")
     private Position position;
 }

--- a/src/main/java/com/example/basketballmatching/user/dto/ResetPasswordDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/ResetPasswordDto.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -10,15 +11,18 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ResetPasswordDto {
 
+    @Schema(description = "이메일", example = "test@test.com")
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Email(message = "이메일 형식으로 입력해주세요.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "Test@1234", defaultValue = "Test@1234")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
             message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
     private String password;
 
+    @Schema(description = "비밀번호 확인", example = "Test@1234", defaultValue = "Test@1234")
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
     private String checkPassword;
 }

--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -6,6 +6,7 @@ import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -25,45 +26,56 @@ public class SignUpDto {
     @Builder
     public static class Request {
 
+        @Schema(description = "이메일", example = "test@test.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "이메일 형식으로 입력해주세요.")
         private String email;
 
+        @Schema(description = "비밀번호", example = "Test@1234", defaultValue = "Test@1234")
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
                 message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
         private String password;
 
+        @Schema(description = "비밀번호 확인", example = "Test@1234", defaultValue = "Test@1234")
         @NotBlank(message = "비밀번호 확인을 입력해주세요.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,}$",
                 message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
         private String checkPassword;
 
+        @Schema(description = "닉네임", example = "커리")
         @NotBlank(message = "닉네임을 입력해주세요.")
         private String nickname;
 
+        @Schema(description = "이름", example = "서장훈")
         @NotBlank(message = "이름을 입력해주세요.")
         private String name;
 
+        @Schema(description = "생년월일", example = "19970101")
         @JsonFormat(
             shape = JsonFormat.Shape.STRING,
                 pattern = "yyyy-MM-dd"
         )
         private LocalDate birth;
 
+        @Schema(description = "휴대폰 번호", example = "010-1111-0000")
         @NotBlank(message = "휴대폰 번호를 입력해주세요.")
         @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
         private String phone;
 
+        @Schema(description = "주소", example = "서울특별시 강남구")
         @NotBlank(message = "주소를 입력해주세요.")
         private String address;
 
+        @Schema(description = "포지션", example = "NONE", defaultValue = "NONE")
         @NotNull(message = "포지션을 입력해주세요.")
         private Position position;
 
+        @Schema(description = "성별", example = "MALE", defaultValue = "MALE")
         @NotNull(message = "성별을 입력해주세요.")
         private GenderType genderType;
 
+        @Schema(description = "로그인 타입", example = "LOCAL", defaultValue = "LOCAL")
         private LoginProvider loginProvider;
 
         public static UserEntity toEntity(SignUpDto.Request request) {
@@ -93,24 +105,34 @@ public class SignUpDto {
     @Builder
     public static class Response {
 
+        @Schema(description = "이메일", example = "test@test.com")
         private String email;
 
+        @Schema(description = "닉네임", example = "커리")
         private String nickname;
 
+        @Schema(description = "이름", example = "서장훈")
         private String name;
 
+        @Schema(description = "생년월일", example = "19970101")
         private LocalDate birth;
 
+        @Schema(description = "휴대폰 번호", example = "010-1111-0000")
         private String phone;
 
+        @Schema(description = "주소", example = "서울특별시 강남구")
         private String address;
 
+        @Schema(description = "포지션", example = "NONE", defaultValue = "NONE")
         private Position position;
 
+        @Schema(description = "성별", example = "MALE", defaultValue = "MALE")
         private GenderType genderType;
 
+        @Schema(description = "권한", example = "USER", defaultValue = "USER")
         private UserType userType;
 
+        @Schema(description = "생성 일시", example = "2025-11-22T15:00:00:00", defaultValue = "2025-11-22T15:00:00:00")
         private LocalDateTime createdAt;
 
         public static Response fromDto (UserDto userDto) {

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,28 +17,40 @@ import java.time.LocalDateTime;
 @Builder
 public class UserDto {
 
+    @Schema(description = "PK", example = "1", defaultValue = "1")
     private Long userId;
 
+    @Schema(description = "이메일", example = "test@test.com")
     private String email;
 
+    @Schema(description = "닉네임", example = "커리")
     private String nickname;
 
+    @Schema(description = "이름", example = "서장훈")
     private String name;
 
+    @Schema(description = "생년월일", example = "19970101")
     private LocalDate birth;
 
+    @Schema(description = "휴대폰 번호", example = "010-1111-0000")
     private String phone;
 
+    @Schema(description = "주소", example = "서울특별시 강남구")
     private String address;
 
+    @Schema(description = "포지션", example = "NONE", defaultValue = "NONE")
     private Position position;
 
+    @Schema(description = "성별", example = "MALE", defaultValue = "MALE")
     private GenderType genderType;
 
+    @Schema(description = "권한", example = "USER", defaultValue = "USER")
     private UserType userType;
 
+    @Schema(description = "생성 일시", example = "2025-11-22T15:00:00:00", defaultValue = "2025-11-22T15:00:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "변경 일시", example = "2025-11-22T15:00:00:00", defaultValue = "2025-11-22T15:00:00:00")
     private LocalDateTime updatedAt;
 
     public static UserDto fromEntity(UserEntity userEntity) {

--- a/src/main/java/com/example/basketballmatching/user/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/controller/OAuth2Controller.java
@@ -3,9 +3,12 @@ package com.example.basketballmatching.user.oauth2.controller;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.user.oauth2.dto.KakaoDto.Response;
 import com.example.basketballmatching.user.oauth2.service.OAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,12 +25,12 @@ import java.io.IOException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth2")
+@Tag(name = "OAUTH2")
 public class OAuth2Controller {
 
     private final OAuthService oAuthService;
 
-    private final AuthService authService;
-
+    @Operation(summary = "카카오 로그인 요청 (리다이렉트)")
     @GetMapping("/login/kakao")
     public void getKakaoAuthUrl(HttpServletResponse response) throws IOException {
 
@@ -35,9 +38,11 @@ public class OAuth2Controller {
 
     }
 
-
+    @Operation(summary = "카카오 콜백 (code 수신 후 로그인 처리)")
+    @ApiResponse(responseCode = "200", description = "카카오 로그인 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
     @GetMapping("/kakao")
-    public ResponseEntity<ApiResponse<Response>> kakaoLogin(
+    public ResponseEntity<CommonResponse<Response>> kakaoLogin(
             @RequestParam(name = "code") String code
     ) throws IOException{
 
@@ -52,6 +57,6 @@ public class OAuth2Controller {
 
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(ApiResponse.of("카카오 로그인에 성공하였습니다.", Response.fromDto(tokenDto.getUserDto(), tokenDto.getRefreshToken())));
+                .body(CommonResponse.of("카카오 로그인에 성공하였습니다.", Response.fromDto(tokenDto.getUserDto(), tokenDto.getRefreshToken())));
     }
 }

--- a/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuthService.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuthService.java
@@ -1,9 +1,6 @@
 package com.example.basketballmatching.user.oauth2.service;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
-import com.example.basketballmatching.global.dto.ApiResponse;
-import com.example.basketballmatching.user.dto.UserDto;
-import com.example.basketballmatching.user.oauth2.dto.KakaoDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface OAuthService {

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -11,8 +11,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByNickname(String nickname);
 
-    Optional<UserEntity> findByEmail(String email);
+    Optional<UserEntity> findByEmailAndDeletedDateTimeIsNull(String email);
 
     Optional<UserEntity> findByUserIdAndDeletedDateTimeIsNull(Long userId);
+
+    Optional<UserEntity> findByEmail(String email);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/service/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.user.service;
 
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.user.dto.ChangePasswordDto;
 import com.example.basketballmatching.user.dto.EditUserDto;
@@ -10,14 +10,14 @@ import com.example.basketballmatching.user.dto.UserDto;
 public interface UserService {
 
 
-    ApiResponse<SignUpDto.Response> signUp(SignUpDto.Request request);
+    CommonResponse<SignUpDto.Response> signUp(SignUpDto.Request request);
 
 
     CheckResponse checkEmail(String email);
     CheckResponse checkNickname(String nickname);
-    ApiResponse<UserDto> getUserInfo(Long userId);
+    CommonResponse<UserDto> getUserInfo(Long userId);
 
-    ApiResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto);
+    CommonResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto);
 
     CheckResponse verifyPasswordCode(String email, String code);
 

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -5,14 +5,12 @@ import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
-import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
 import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.notifications.service.NotificationService;
-import com.example.basketballmatching.notifications.type.NotificationType;
 import com.example.basketballmatching.user.dto.ChangePasswordDto;
 import com.example.basketballmatching.user.dto.EditUserDto;
 import com.example.basketballmatching.user.dto.SignUpDto;
@@ -59,7 +57,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional
-    public ApiResponse<SignUpDto.Response> signUp(SignUpDto.Request request) {
+    public CommonResponse<SignUpDto.Response> signUp(SignUpDto.Request request) {
 
         log.info("유저 회원가입 시작 : {}", request.getEmail());
 
@@ -88,7 +86,7 @@ public class UserServiceImpl implements UserService {
 
         log.info("유저 회원가입 완료");
 
-        return ApiResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity)));
+        return CommonResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity)));
     }
 
     /**
@@ -128,7 +126,7 @@ public class UserServiceImpl implements UserService {
      * 회원 정보 조회
      */
     @Override
-    public ApiResponse<UserDto> getUserInfo(Long userId) {
+    public CommonResponse<UserDto> getUserInfo(Long userId) {
 
         UserEntity userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -136,7 +134,7 @@ public class UserServiceImpl implements UserService {
         UserDto userDto = UserDto.fromEntity(userEntity);
 
 
-        return ApiResponse.of("회원정보 조회에 성공하였습니다.", userDto);
+        return CommonResponse.of("회원정보 조회에 성공하였습니다.", userDto);
     }
 
 
@@ -145,7 +143,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional
-    public ApiResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto) {
+    public CommonResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto) {
 
         log.info("[유저 회원정보 수정 시작 : {}]", userId);
 
@@ -165,7 +163,7 @@ public class UserServiceImpl implements UserService {
 
         log.info("[유저 회원정보 수정 완료 : {}]", true);
 
-        return ApiResponse.of("회원정보 수정이 완료되었습니다.", userDto);
+        return CommonResponse.of("회원정보 수정이 완료되었습니다.", userDto);
     }
 
 

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
@@ -13,7 +13,7 @@ import com.example.basketballmatching.gameCreator.type.CityName;
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.entity.UserEntity;
@@ -35,7 +35,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -128,7 +127,7 @@ class GameServiceImplTest {
 
         // when
 
-        ApiResponse<CreateGameDto.Response> game = gameService.createGame(userEntity.getUserId(), request);
+        CommonResponse<CreateGameDto.Response> game = gameService.createGame(userEntity.getUserId(), request);
 
 
         // then
@@ -214,7 +213,7 @@ class GameServiceImplTest {
 
         // when
 
-        ApiResponse<GameDto> detailGame = gameService.detailGame(gameEntity.getGameId());
+        CommonResponse<GameDto> detailGame = gameService.detailGame(gameEntity.getGameId());
 
         // then
 
@@ -254,11 +253,11 @@ class GameServiceImplTest {
 
         // when
 
-        ApiResponse<Page<SearchGameDto>> searchedGame1 = gameService.searchGame(LocalDate.now(), CityName.INCHEON, null, null, null, null, PageRequest.of(0, 10));
+        CommonResponse<Page<SearchGameDto>> searchedGame1 = gameService.searchGame(LocalDate.now(), CityName.INCHEON, null, null, null, null, PageRequest.of(0, 10));
 
 
         // 검색 결과 존재하지 않을 시
-        ApiResponse<Page<SearchGameDto>> searchedGame2 = gameService.searchGame(LocalDate.now().plusDays(2), CityName.INCHEON, null, null, null, null, PageRequest.of(0, 10));
+        CommonResponse<Page<SearchGameDto>> searchedGame2 = gameService.searchGame(LocalDate.now().plusDays(2), CityName.INCHEON, null, null, null, null, PageRequest.of(0, 10));
 
 
         // then
@@ -290,7 +289,7 @@ class GameServiceImplTest {
                 .headCount(10)
                 .build();
 
-        ApiResponse<GameDto> editedGame = gameService.editGame(request, gameEntity.getGameId(), tokenDto.getUserDto().getUserId());
+        CommonResponse<GameDto> editedGame = gameService.editGame(request, gameEntity.getGameId(), tokenDto.getUserDto().getUserId());
 
 
         // then

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -13,7 +13,7 @@ import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
 import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
 import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
@@ -24,7 +24,6 @@ import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,8 +33,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -142,7 +139,7 @@ class GameUserServiceImplTest {
 
         // when
 
-        ApiResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        CommonResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
 
 
         // then
@@ -345,7 +342,7 @@ class GameUserServiceImplTest {
         gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
 
         // when
-        ApiResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+        CommonResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userEntity.getUserId(), PageRequest.of(0, 10));
 
         // then
 
@@ -379,7 +376,7 @@ class GameUserServiceImplTest {
         gameRepository.save(gameEntity);
         // when
 
-        ApiResponse<List<LastGameListDto>> myLastGameList = gameUserService.getMyLastGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+        CommonResponse<List<LastGameListDto>> myLastGameList = gameUserService.getMyLastGameList(userEntity.getUserId(), PageRequest.of(0, 10));
 
         // then
 

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -2,7 +2,7 @@ package com.example.basketballmatching.user.service.impl;
 
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
-import com.example.basketballmatching.global.dto.ApiResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
@@ -27,13 +27,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.longThat;
-import static org.mockito.BDDMockito.given;
 
 
 @SpringBootTest
@@ -97,7 +93,7 @@ class UserServiceImplTest {
                 .build();
         // when
 
-        ApiResponse<SignUpDto.Response> response = userService.signUp(request);
+        CommonResponse<SignUpDto.Response> response = userService.signUp(request);
         // then
 
         assertEquals("회원가입에 성공하였습니다.", response.getMessage());
@@ -220,7 +216,7 @@ class UserServiceImplTest {
 
         // when
 
-        ApiResponse<UserDto> userInfo = userService.getUserInfo(tokenDto.getUserDto().getUserId());
+        CommonResponse<UserDto> userInfo = userService.getUserInfo(tokenDto.getUserDto().getUserId());
 
         // then
 
@@ -258,7 +254,7 @@ class UserServiceImplTest {
 
         // when
 
-        ApiResponse<UserDto> response = userService.editUserInfo(tokenDto.getUserDto().getUserId()
+        CommonResponse<UserDto> response = userService.editUserInfo(tokenDto.getUserDto().getUserId()
                 , EditUserDto.builder()
                         .nickname("테스트 닉네임2")
                         .position(Position.CENTER)


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- API 문서화 도구(Swagger/OpenAPI)가 미구현
- 컨트롤러별 기능 구분이 명확하지 않아, 신규 참여자나 프론트엔드 입장에서 전체 API 흐름을 한 번에 파악하기 어려움
- JWT 인증이 필요한 API 테스트 시, 헤더에 토큰을 수동으로 넣어야 해 실수 가능성이 높고 테스트 효율이 떨어짐

### 🚀 TO-BE
- `springdoc-openapi` 기반 Swagger UI를 도입하여 전체 API 스펙을 자동으로 문서화
  - `SwaggerConfig`에서 OpenAPI 메타 정보(title, description, version) 및 태그 그룹 정의
  - JWT Bearer 인증 스키마(`bearerAuth`)를 등록하여 Swagger UI 상단 `Authorize` 버튼으로 토큰 입력 후 인증이 필요한 API를 바로 테스트할 수 있도록 구성
- DTO 및 공통 응답 포맷 문서화
  - `CheckResponse`, `CommonResponse`, 각종 `*Dto`의 필드에 `@Schema`를 추가하여 필드 설명 및 example 제공
  - 요청 DTO(`LoginDto`, `ReIssueTokenDto`, `CreateGameDto.Request` 등)와 응답 DTO(`CreateGameDto.Response`, `GameDto`, `NotificationDto` 등)의 구조를 Swagger에서 직관적으로 확인 가능
- 내부 static 클래스 DTO 이름 깨짐 방지를 위한 ModelResolver 구현
  - `TypeNameResolver`를 통해 `OuterClass$InnerClass` 형태를 `OuterClass.InnerClass` 형태로 노출되도록 수정해 Swagger Schema 이름 가독성 개선
- 비즈니스 로직 변경 없이, 문서화 및 개발/테스트 편의성만 향상하는 방향으로 적용

---

## ✅ 체크리스트
- [x] API 테스트
- [x] Swagger UI 정상 작동
- [x] 주요 기능 동작 확인


---
