### PR TITLE
[refactor] : 유저API 및 경기 API 로직 리펙토링

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/impl/AuthServiceImpl.java
@@ -9,7 +9,6 @@ import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
-import com.example.basketballmatching.user.type.LoginProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,39 +33,34 @@ public class AuthServiceImpl implements AuthService {
 
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public TokenDto loginUser(String email, String password) {
 
         log.info("[유저 로그인 시작]: {}", email);
 
 
 
-        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        if (userEntity.getLoginProvider().equals(KAKAO)) {
-            throw new CustomException(PROVIDER_NOT_MATCH);
-        }
-
-        if (!passwordEncoder.matches(password, userEntity.getPassword()) || password == null) {
-                throw new CustomException(PASSWORD_NOT_MATCH);
-        }
-        String data = redisService.getData("blackList:" + userEntity.getEmail());
-
-        if (data != null) {
-            throw new CustomException(BLACKLIST_USER);
-        }
+        UserEntity userEntity = getUser(email);
 
 
+
+        // 로그인 형식 검사
+        validateLocalLogin(userEntity);
+
+        // 비밀번호 유효성 검사
+        validatePassword(password, userEntity);
+
+        // 블랙리스트 유저 검사
+        validateNotBlackList(userEntity.getEmail());
 
 
         UserDto userDto = UserDto.fromEntity(userEntity);
 
 
-        String accessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+        String accessToken = issueAccessToken(userDto);
         log.info("accessToken 생성 완료.");
 
-        String refreshToken = tokenProvider.createRefreshToken(userDto.getEmail());
+        String refreshToken = issueRefreshToken(userDto);
         log.info("refreshToken 생성 완료");
 
         log.info("[유저 로그인 완료] email : {}", userDto.getEmail());
@@ -74,32 +68,34 @@ public class AuthServiceImpl implements AuthService {
         return new TokenDto(accessToken, refreshToken, userDto);
     }
 
+
+
+
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public TokenDto kakaoLogin(String email) {
 
         log.info("[카카오 로그인 검증 시작] email : {}", email);
 
-        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(email);
 
-        if (userEntity.getLoginProvider().equals(LOCAL)) {
-            throw new CustomException(PROVIDER_NOT_MATCH);
-        }
+        // 로그인 형식 검사
+        validateKakaoLogin(userEntity);
 
         UserDto userDto = UserDto.fromEntity(userEntity);
 
-        String accessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+        String accessToken = issueAccessToken(userDto);
 
-        String refreshToken = tokenProvider.createRefreshToken(userDto.getEmail());
-
+        String refreshToken = issueRefreshToken(userDto);
 
         log.info("[카카오 로그인 완료] email : {}", userDto.getEmail());
 
         return new TokenDto(accessToken, refreshToken, userDto);
     }
 
+
     @Override
+    @Transactional(readOnly = true)
     public TokenDto reissue(String email, String refreshToken) {
 
         log.info("[토큰 재발급 시작]: {}", email);
@@ -107,35 +103,26 @@ public class AuthServiceImpl implements AuthService {
         String redisToken = redisService.getData("refreshToken:" + email);
 
 
-        if (redisToken == null) {
-            throw new CustomException(NOT_FOUND_TOKEN);
-        }
+        // 재발금 유효성 검사
+        validateReissue(email, refreshToken, redisToken);
 
-        if (!redisToken.equals(refreshToken)) {
-            throw new CustomException(INVALID_TOKEN);
-        }
-
-        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
-
-        if (!userEmail.equals(email)) {
-            throw new CustomException(INVALID_TOKEN);
-        }
-
-        UserEntity userEntity = userRepository.findByEmailAndDeletedDateTimeIsNull(email)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(email);
 
         // refreshToken 검증
         tokenProvider.validateRefreshToken(refreshToken);
 
         UserDto userDto = UserDto.fromEntity(userEntity);
 
-        String reissuedAccessToken = tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+        String reissuedAccessToken = issueAccessToken(userDto);
 
 
         return new TokenDto(reissuedAccessToken, redisToken, userDto);
     }
 
+
+
     @Override
+    @Transactional(readOnly = true)
     public CheckResponse logoutUser(String email, String token) {
 
         log.info("[유저 로그아웃 시작] : {}", email);
@@ -154,5 +141,64 @@ public class AuthServiceImpl implements AuthService {
         return CheckResponse.of(true, "로그아웃 완료되었습니다.");
     }
 
+    private void validateKakaoLogin(UserEntity userEntity) {
+        if (userEntity.getLoginProvider().equals(LOCAL)) {
+            throw new CustomException(PROVIDER_NOT_MATCH);
+        }
+    }
+
+    private void validateLocalLogin(UserEntity userEntity) {
+        if (userEntity.getLoginProvider().equals(KAKAO)) {
+            throw new CustomException(PROVIDER_NOT_MATCH);
+        }
+    }
+
+    private void validateNotBlackList(String email) {
+
+        String data = redisService.getData("blackList:" + email);
+
+        if (data != null) {
+            throw new CustomException(BLACKLIST_USER);
+        }
+
+    }
+
+    private void validatePassword(String password, UserEntity user) {
+        if (password == null || !passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+    }
+
+    private String issueAccessToken(UserDto userDto) {
+
+        return tokenProvider.createAccessToken(userDto.getEmail(), userDto.getName(), userDto.getUserType());
+
+    }
+
+    private String issueRefreshToken(UserDto userDto) {
+        return tokenProvider.createRefreshToken(userDto.getEmail());
+    }
+
+
+    private UserEntity getUser(String email) {
+        return userRepository.findByEmailAndDeletedDateTimeIsNull(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private void validateReissue(String email, String refreshToken, String redisToken) {
+        if (redisToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        if (!redisToken.equals(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
+
+        if (!userEmail.equals(email)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+    }
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
@@ -1,12 +1,12 @@
 package com.example.basketballmatching.gameCreator.repository;
 
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
-import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -48,9 +48,9 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 생성 시작] userId = {} title = {}", userId, request.getTitle());
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
+        // 경기 생성 유효성 검사
         validateCreateGame(request);
 
         GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
@@ -68,6 +68,7 @@ public class GameServiceImpl implements GameService {
         return CommonResponse.of("경기 생성이 완료되었습니다.", CreateGameDto.Response.fromDto(GameDto.fromEntity(gameEntity)));
     }
 
+
     /**
      * 경기 상세조회
      */
@@ -77,8 +78,7 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 상세 조회 시작] gameId : {}", gameId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
 
         GameDto gameDto = GameDto.fromEntity(gameEntity);
@@ -87,6 +87,8 @@ public class GameServiceImpl implements GameService {
 
         return CommonResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
     }
+
+
 
     /**
      * 경기 검색 정렬
@@ -119,12 +121,24 @@ public class GameServiceImpl implements GameService {
         log.info("[경기 수정 시작] loginId : {}, gameId : {}", userId, gameId);
 
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
+        // 경기 수정 사항 유효성 검사
+        validateEditGame(request, gameEntity, userEntity);
+
+
+        gameEntity.editGameInfo(request);
+
+
+
+        log.info("[경기 수정 완료] gameId : {}", gameId);
+
+        return CommonResponse.of("경기 수정이 완료되었습니다.", GameDto.fromEntity(gameEntity));
+    }
+
+    private void validateEditGame(EditGameDto request, GameEntity gameEntity, UserEntity userEntity) {
         if (!gameEntity.getUserEntity().getUserId().equals(userEntity.getUserId())) {
             throw new CustomException(NOT_GAME_CREATOR);
         }
@@ -132,7 +146,6 @@ public class GameServiceImpl implements GameService {
         if(request.getMatchFormat() != null && request.getHeadCount() == 0) {
             throw new CustomException(UPDATE_GAME_HEAD_COUNT);
         }
-
 
 
         if (request.getHeadCount() > 0) {
@@ -160,16 +173,6 @@ public class GameServiceImpl implements GameService {
 
             }
         }
-
-
-
-        gameEntity.editGameInfo(request);
-
-        gameRepository.save(gameEntity);
-
-        log.info("[경기 수정 완료] gameId : {}", gameId);
-
-        return CommonResponse.of("경기 수정이 완료되었습니다.", GameDto.fromEntity(gameEntity));
     }
 
 
@@ -216,5 +219,15 @@ public class GameServiceImpl implements GameService {
             throw new CustomException(PLACE_SCHEDULE_OVERLAP);
         }
 
+    }
+
+    private UserEntity getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private GameEntity getGame(Long gameId) {
+        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
+import com.example.basketballmatching.gameCreator.type.GameStatus;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
@@ -52,16 +53,12 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[경기 참가 신청자 조회 시작] gameId : {}, userId : {}", gameId, userId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
-            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
-            throw new CustomException(NOT_GAME_CREATOR);
-        }
+        // 경기 개설자인지 조회
+        validateGameCreator(gameEntity, userEntity);
 
         // 지원자 목록 조회 (엔티티 기준)
         Page<ParticipantGameEntity> pages = getParticipantGameList(pageable, gameEntity, APPLY);
@@ -76,6 +73,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     }
 
 
+
+
     /**
      * 경기 참가 수락자 조회
      */
@@ -86,16 +85,12 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         log.info("[경기 참가 수락자 조회 시작] gameId : {}, userId : {}", gameId, userId);
 
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
-            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
-            throw new CustomException(NOT_GAME_CREATOR);
-        }
+        // 경기 개설자인지 조회
+        validateGameCreator(gameEntity, userEntity);
 
         // 지원자 목록 조회 (엔티티 기준)
         Page<ParticipantGameEntity> pages = getParticipantGameList(pageable, gameEntity, ACCEPT);
@@ -110,11 +105,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         return CommonResponse.of("경기 참가자 조회가 완료되었습니다.", participantGameList);
     }
 
-    private Page<ParticipantGameEntity> getParticipantGameList(Pageable pageable, GameEntity gameEntity, ParticipantGameStatus participantGameStatus) {
-        Page<ParticipantGameEntity> pages = participantGameRepository.
-                findByParticipantGameStatusAndGameEntity_GameId(participantGameStatus, gameEntity.getGameId(), pageable);
-        return pages;
-    }
+
 
     /**
      * 경기 수락
@@ -125,44 +116,31 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantId, gameId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
-            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
-            throw new CustomException(NOT_GAME_CREATOR);
-        }
+        // 경기 개설자인지 조회
+        validateGameCreator(gameEntity, userEntity);
 
-        boolean exists = participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participantId, gameId);
 
-        if (!exists) {
-            throw new CustomException(NOT_APPLY_USER);
-        }
-        LocalDateTime now = LocalDateTime.now();
-        if (gameEntity.getStartDateTime().isBefore(now)) {
-            throw new CustomException(ALREADY_START_GAME);
-        }
 
         if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
             throw new CustomException(FULL_HEADCOUNT_GAME);
         }
 
+        LocalDateTime now = validateStartDateTime(gameEntity);
 
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
-        if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
-            throw new CustomException(ALREADY_ACCEPT_USER);
-        }
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
+
+        // 경기 참가자 상태 유효성 검사
+        validateGameStatusInAcceptAndReject(participantGameEntity.getParticipantGameStatus());
 
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, now);
 
-        participantGameRepository.save(participantGameEntity);
 
 
         notificationService.send(NotificationType.ACCEPT_GAME, participantGameEntity.getUserEntity(),
@@ -176,6 +154,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     }
 
 
+
+
+
     /**
      * 경기 거절
      */
@@ -185,19 +166,19 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantId, gameId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
         if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
             throw new CustomException(NOT_GAME_CREATOR);
         }
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
+
+        // 경기 참가자 상태 유효성 검사
+        validateGameStatusInAcceptAndReject(participantGameEntity.getParticipantGameStatus());
 
 
         // 경기 생성자는 거절할 수 없음.
@@ -205,21 +186,12 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
             throw new CustomException(NOT_REJECT_CREATOR);
         }
 
-        if (participantGameEntity.getParticipantGameStatus().equals(REJECT)) {
-            throw new CustomException(ALREADY_REJECT_USER);
-        }
+        LocalDateTime now = validateStartDateTime(gameEntity);
 
-        if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
-            throw new CustomException(ALREADY_ACCEPT_USER);
-        }
 
-        if (gameEntity.getStartDateTime().isBefore(LocalDateTime.now())) {
-            throw new CustomException(ALREADY_START_GAME);
-        }
+        participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, now);
 
-        participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, LocalDateTime.now());
 
-        participantGameRepository.save(participantGameEntity);
 
         notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
@@ -227,6 +199,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         return CheckResponse.of(true, "경기 거절을 완료하였습니다.");
     }
+
+
 
 
     /**
@@ -238,40 +212,27 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantId, gameId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
-            throw new CustomException(NOT_GAME_CREATOR);
-        }
+        validateGameCreator(gameEntity, userEntity);
 
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
 
         if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
             throw new CustomException(NOT_KICKOUT_CREATOR);
         }
 
-        if (participantGameEntity.getParticipantGameStatus().equals(KICKOUT)) {
-            throw new CustomException(ALREADY_KICKOUT_USER);
-        }
+        // 경기 참가자 상태 유효성 검사
+        validateGameStatusInKickOut(participantGameEntity.getParticipantGameStatus());
 
-        if (!participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
-            throw new CustomException(NOT_ACCEPT_USER);
-        }
 
-        LocalDateTime now = LocalDateTime.now();
-
-        if (gameEntity.getStartDateTime().isBefore(now)) {
-            throw new CustomException(ALREADY_START_GAME);
-        }
+        LocalDateTime now = validateStartDateTime(gameEntity);
 
         participantGameEntity.setParticipantGameStatusAndKickoutDateTime(KICKOUT, now);
-        participantGameRepository.save(participantGameEntity);
+
 
         gameRepository.save(participantGameEntity.getGameEntity());
 
@@ -286,6 +247,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
     }
 
+
+
     /**
      * 경기 삭제
      */
@@ -295,15 +258,11 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         log.info("[경기 삭제 시작] userId : {}, gameId : {}", userId, gameId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
-            throw new CustomException(NOT_GAME_CREATOR);
-        }
+        validateGameCreator(gameEntity, userEntity);
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -311,21 +270,25 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
             throw new CustomException(NOT_DELETE_GAME);
         }
 
+
+        // ACCEPT/ APPLY 유저 리스트
         List<ParticipantGameEntity> participantGameEntityList = participantGameRepository.findByParticipantGameStatusInAndGameEntity_GameId(List.of(ACCEPT, APPLY), gameId);
 
 
+        // 조회 유저 상태 DELETE로 변경
         participantGameEntityList.forEach(participantGame ->
                 participantGame.setParticipantGameStatusAndDeletedDateTime(DELETE, now));
 
+        // 삭제 알림 전송
         participantGameEntityList
                 .stream()
                 .filter(participantGameEntity -> !Objects.equals(participantGameEntity.getUserEntity().getUserId(), userEntity.getUserId()))
                 .forEach(
 
-                participantGame ->
-                    notificationService.send(NotificationType.DELETE_GAME, participantGame.getUserEntity(), participantGame.getGameEntity().getTitle() + "의 게임이 삭제되었습니다.")
+                        participantGame ->
+                                notificationService.send(NotificationType.DELETE_GAME, participantGame.getUserEntity(), participantGame.getGameEntity().getTitle() + "의 게임이 삭제되었습니다.")
 
-        );
+                );
 
         participantGameRepository.saveAll(participantGameEntityList);
 
@@ -339,5 +302,59 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         return CheckResponse.of(true, "경기 삭제가 완료되었습니다.");
     }
 
+    public void validateGameStatusInAcceptAndReject(ParticipantGameStatus status) {
 
+        switch (status) {
+
+            case ACCEPT -> throw new CustomException(ALREADY_ACCEPT_USER);
+            case REJECT -> throw new CustomException(ALREADY_REJECT_USER);
+
+        }
+
+    }
+
+    private void validateGameStatusInKickOut(ParticipantGameStatus status) {
+
+        switch (status) {
+            case APPLY -> throw new CustomException(NOT_ACCEPT_USER);
+            case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
+        }
+    }
+
+
+
+    private void validateGameCreator(GameEntity gameEntity, UserEntity userEntity) {
+        if (!Objects.equals(gameEntity.getUserEntity().getUserId(), userEntity.getUserId())) {
+            log.error("[CustomException 발생] errorCode : {}", NOT_GAME_CREATOR);
+            throw new CustomException(NOT_GAME_CREATOR);
+        }
+    }
+
+    private UserEntity getUser(Long userId) {
+        return userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private GameEntity getGame(Long gameId) {
+        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+    }
+
+    private Page<ParticipantGameEntity> getParticipantGameList(Pageable pageable, GameEntity gameEntity, ParticipantGameStatus participantGameStatus) {
+        return participantGameRepository.
+                findByParticipantGameStatusAndGameEntity_GameId(participantGameStatus, gameEntity.getGameId(), pageable);
+    }
+
+    private ParticipantGameEntity getParticipantGame(GameEntity gameEntity, Long participantId) {
+        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    }
+
+    private static LocalDateTime validateStartDateTime(GameEntity gameEntity) {
+        LocalDateTime now = LocalDateTime.now();
+        if (gameEntity.getStartDateTime().isBefore(now)) {
+            throw new CustomException(ALREADY_START_GAME);
+        }
+        return now;
+    }
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- Auth
   -메서드별 중복 로직 존재
- 게임 생성 API 및 경기 참가 API
   - 메서드별 중복 로직 존재
   - 중복된 조회/ 검증 로직 다수 존재

### 🚀 TO-BE
✅ Auth
- 토큰 검증, 사용자 조회, 재발급 로직 메서드 분리
- 중복제거 및 가독성 향상(getUser()...)

✅ 게임 생성 로직 리펙토링
- 게임 생성
   - 모든 개별메서드로 분리
---

## ✅ 체크리스트
- [x] AuthService 리펙토링
- [x] 게임 생성 로직 검증
- [x] 참가/수락/거절/강퇴 전체 메서드 분리 및 가독성 향상
- [x] Swagger API 동작 검증

---
