### PR TITLE
[fix] : 참가자 경기 평가 로직의 n+1 문제 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,28 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   pull_request:
-    branches:
-      - main
+    branches: [ "main" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # ✅ 여기서 환경변수 주입 (중요!!)
+    env:
+      SPRING_PROFILES_ACTIVE: test
+      DB_URL: jdbc:mysql://127.0.0.1:3306/basketball?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      DB_USERNAME: root
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: 6379
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+      KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+
     services:
       mysql:
         image: mysql:8.0
@@ -23,7 +36,7 @@ jobs:
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
-          --health-retries=5
+          --health-retries=10
 
       redis:
         image: redis:7
@@ -33,36 +46,34 @@ jobs:
           --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5
-
+          --health-retries 10
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      ## JDK 설정
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
-      ## application.yml secret 값 복붙
+
       - name: Create application.yml
         run: |
           mkdir -p src/main/resources
           printf "%s\n" "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
-          cat src/test/resources/application-test.yml
-
+          cat src/main/resources/application.yml
 
       - name: Create application-test.yml
         run: |
           mkdir -p src/test/resources
           printf "%s\n" "${{ secrets.APPLICATION_TEST }}" > src/test/resources/application-test.yml
           cat src/test/resources/application-test.yml
-      ## Gradle Build를 위한 권한 부여
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # 🔥 테스트 생략하고 빌드만 수행
-      - name: Build without tests
-        run: ./gradlew clean build
+      # ✅ 테스트 포함
+      - name: Build with tests
+        run: ./gradlew clean test --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,14 @@ jobs:
         run: |
           mkdir -p src/main/resources
           printf "%s\n" "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
+          cat src/test/resources/application-test.yml
+
 
       - name: Create application-test.yml
         run: |
           mkdir -p src/test/resources
           printf "%s\n" "${{ secrets.APPLICATION_TEST }}" > src/test/resources/application-test.yml
+          cat src/test/resources/application-test.yml
       ## Gradle Build를 위한 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,44 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    # ✅ 여기서 환경변수 주입 (중요!!)
-    env:
-      SPRING_PROFILES_ACTIVE: test
-      DB_URL: jdbc:mysql://127.0.0.1:3306/basketball?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-      DB_USERNAME: root
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      REDIS_HOST: 127.0.0.1
-      REDIS_PORT: 6379
-      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
-      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
-      KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          MYSQL_DATABASE: basketball
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping --silent"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -65,15 +27,9 @@ jobs:
           printf "%s\n" "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
           cat src/main/resources/application.yml
 
-      - name: Create application-test.yml
-        run: |
-          mkdir -p src/test/resources
-          printf "%s\n" "${{ secrets.APPLICATION_TEST }}" > src/test/resources/application-test.yml
-          cat src/test/resources/application-test.yml
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # ✅ 테스트 포함
+
       - name: Build with tests
-        run: ./gradlew clean test --stacktrace
+        run: ./gradlew clean build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew clean build
+      # ⚠️ 핵심: test profile 강제 활성화
+      - name: Build with Gradle (Run Tests with test profile)
+        run: ./gradlew clean build -Dspring.profiles.active=test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
+          cache: gradle
 
-      - name: Grant execute permission for gradlew
+      - name: Grant execute permission for Gradle Wrapper
         run: chmod +x gradlew
 
-      # ⚠️ 핵심: test profile 강제 활성화
-      - name: Build with Gradle (Run Tests with test profile)
-        run: ./gradlew clean build -Dspring.profiles.active=test
+      # ===============================
+      # 🧪 테스트 (test 프로필 강제 적용)
+      # ===============================
+      - name: Run Tests with test profile
+        run: ./gradlew clean test -Dspring.profiles.active=test
+
+      # ===============================
+      # 📦 빌드
+      #  - 테스트 후 빌드 실행
+      # ===============================
+      - name: Build (without tests)
+        run: ./gradlew build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: gradle
+          cache: 'gradle'
 
-      - name: Grant execute permission for Gradle Wrapper
+      - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # ===============================
-      # 🧪 테스트 (test 프로필 강제 적용)
-      # ===============================
-      - name: Run Tests with test profile
-        run: ./gradlew clean test -Dspring.profiles.active=test
-
-      # ===============================
-      # 📦 빌드
-      #  - 테스트 후 빌드 실행
-      # ===============================
-      - name: Build (without tests)
-        run: ./gradlew build -x test
+      # 🔥 테스트 생략하고 빌드만 수행
+      - name: Build without tests
+        run: ./gradlew clean build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,13 @@ jobs:
       ## application.yml secret 값 복붙
       - name: Create application.yml
         run: |
-          echo"${{secrets.APPLICATION}}" > src/main/resources/application.yml
+          mkdir -p src/main/resources
+          printf "%s\n" "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
 
       - name: Create application-test.yml
         run: |
-          echo"${{secrets.APPLICATION_TEST}}" > src/main/resources/application-test.yml
-
+          mkdir -p src/test/resources
+          printf "%s\n" "${{ secrets.APPLICATION_TEST }}" > src/test/resources/application-test.yml
       ## Gradle Build를 위한 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle (skip tests for now)
-        run: ./gradlew clean build -x test
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,54 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MYSQL_DATABASE: basketball
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
+      ## JDK 설정
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
+      ## application.yml secret 값 복붙
+      - name: Create application.yml
+        run: |
+          echo"${{secrets.APPLICATION}}" > src/main/resources/application.yml
 
+      - name: Create application-test.yml
+        run: |
+          echo"${{secrets.APPLICATION_TEST}}" > src/main/resources/application-test.yml
+
+      ## Gradle Build를 위한 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       # 🔥 테스트 생략하고 빌드만 수행
       - name: Build without tests
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build

--- a/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/controller/ParticipantGameController.java
@@ -43,11 +43,11 @@ public class ParticipantGameController {
     @GetMapping("/search/apply")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CommonResponse<List<ApplyGameUserListDto>>> getApplyParticipantList (
-            @Parameter(name = "게임아이디", example = "1", required = true)
+            @Parameter(name = "gameId", example = "1", required = true)
             @RequestParam Long gameId,
-            @Parameter(name = "페이지", example = "0")
+            @Parameter(name = "page", example = "0")
             @RequestParam(defaultValue = "0") int page,
-            @Parameter(name = "페이지 사이즈", example = "10")
+            @Parameter(name = "size", example = "10")
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
 
@@ -180,7 +180,7 @@ public class ParticipantGameController {
     @PatchMapping("/delete")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> deleteGame (
-            @Parameter(name = "경기 아이디", example = "1")
+            @Parameter(name = "경기 아이디", example = "1L")
             @RequestParam Long gameId,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -57,6 +57,7 @@ public class ParticipantGameEntity extends BaseEntity {
                 .participantGameStatus(ParticipantGameStatus.ACCEPT)
                 .gameEntity(gameEntity)
                 .userEntity(userEntity)
+                .acceptDateTime(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
@@ -67,7 +67,7 @@ public class GameQueryRepository {
         return new PageImpl<>(searchGames, pageable, total);
     }
 
-    public List<GameEntity> findRecent10GamesByUser(UserEntity userEntity) {
+    public List<Long> findRecent10GamesByUser(UserEntity userEntity) {
 
         QParticipantGameEntity participantGameEntity = QParticipantGameEntity.participantGameEntity;
 
@@ -77,9 +77,11 @@ public class GameQueryRepository {
 
         builder.and(participantGameEntity.userEntity.eq(userEntity));
         builder.and(gameEntity.endDateTime.before(LocalDateTime.now()));
+        builder.and(gameEntity.deletedDateTime.isNull());
+        builder.and(participantGameEntity.participantGameStatus.eq(ACCEPT));
 
         return jpaQueryFactory
-                .select(participantGameEntity.gameEntity)
+                .select(gameEntity.gameId)
                 .from(participantGameEntity)
                 .join(participantGameEntity.gameEntity, gameEntity)
                 .where(builder)

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/GameAvgScoreDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/GameAvgScoreDto.java
@@ -1,0 +1,14 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GameAvgScoreDto {
+
+    private final Long gameId;
+
+    private final Double avgScore;
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/repository/LevelQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/repository/LevelQueryRepository.java
@@ -1,0 +1,39 @@
+package com.example.basketballmatching.gameUsers.repository;
+
+import com.example.basketballmatching.gameUsers.dto.GameAvgScoreDto;
+import com.example.basketballmatching.gameUsers.entity.QLevelEntity;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LevelQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<GameAvgScoreDto> findAvgScoreByGames(Long receiverId, List<Long> gameIds) {
+
+        QLevelEntity levelEntity = QLevelEntity.levelEntity;
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        GameAvgScoreDto.class,
+                        levelEntity.gameEntity.gameId,
+                        levelEntity.score.avg()
+                ))
+                .from(levelEntity)
+                .where(
+                        levelEntity.receiver.userId.eq(receiverId),
+                        levelEntity.gameEntity.gameId.in(gameIds)
+                )
+                .groupBy(levelEntity.gameEntity.gameId)
+                .fetch();
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepo
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
 import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.gameUsers.entity.LevelEntity;
+import com.example.basketballmatching.gameUsers.repository.LevelQueryRepository;
 import com.example.basketballmatching.gameUsers.repository.LevelRepository;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.gameUsers.type.GameUserLevel;
@@ -45,6 +46,7 @@ public class GameUserServiceImpl implements GameUserService {
     private final UserRepository userRepository;
 
     private final GameRepository gameRepository;
+    private final LevelQueryRepository levelQueryRepository;
 
 
     /**
@@ -56,11 +58,9 @@ public class GameUserServiceImpl implements GameUserService {
         log.info("[경기 참가 신청 시작] gameId : {} userId : {}", gameId, userId);
 
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
-        GameEntity gameEntity = gameRepository.findByGameIdWithLock(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGameWithLock(gameId);
 
         validateParticipantInfo(userEntity, gameEntity);
 
@@ -77,7 +77,7 @@ public class GameUserServiceImpl implements GameUserService {
 
 
         gameEntity.increaseParticipantCount();
-        gameRepository.save(gameEntity);
+
 
 
 
@@ -91,6 +91,7 @@ public class GameUserServiceImpl implements GameUserService {
         return CommonResponse.of("경기 신청이 완료되었습니다.", participantDto);
     }
 
+
     /**
      * 경기 참가 취소
      */
@@ -98,11 +99,9 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional
     public CheckResponse cancelGame(Long userId, Long gameId) {
 
-        GameEntity gameEntity = gameRepository.findByGameIdWithLock(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGameWithLock(gameId);
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+        ParticipantGameEntity participantGameEntity = getParticipantGame(userId, gameId);
 
 
 
@@ -123,7 +122,6 @@ public class GameUserServiceImpl implements GameUserService {
 
 
         participantGameEntity.setParticipantGameStatusAndCanceledDateTime(CANCEL, now);
-        participantGameRepository.save(participantGameEntity);
 
         gameEntity.decreaseParticipantCount();
         gameRepository.save(gameEntity);
@@ -134,6 +132,8 @@ public class GameUserServiceImpl implements GameUserService {
         return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
     }
 
+
+
     /**
      * 현재 예정 경기 조회
      */
@@ -141,8 +141,7 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional(readOnly = true)
     public CommonResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
 
-        userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        getUser(userId);
 
 
         List<CurrentGameListDto> currentGameList = gameQueryRepository.getCurrentGameList(userId, pageable);
@@ -157,8 +156,7 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional(readOnly = true)
     public CommonResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
 
-        userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        getUser(userId);
 
 
         List<LastGameListDto> lastGameList = gameQueryRepository.getLastGameList(userId, pageable);
@@ -175,18 +173,15 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional
     public CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request) {
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity = getGame(gameId);
 
         if (gameEntity.getEndDateTime().isAfter(LocalDateTime.now())) {
             throw new CustomException(NOT_GAME_ENDED);
         }
 
-        ParticipantGameEntity evaluator = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), evaluatorId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+        ParticipantGameEntity evaluator = getParticipantGame(evaluatorId, gameEntity.getGameId());
 
-        ParticipantGameEntity receiver = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, request.getReceiverId())
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+        ParticipantGameEntity receiver = getParticipantGame(request.getReceiverId(), gameId);
 
         if (evaluator.getParticipantGameId().equals(receiver.getParticipantGameId())) {
             throw new CustomException(CANNOT_EVALUATE_SELF);
@@ -214,12 +209,13 @@ public class GameUserServiceImpl implements GameUserService {
         return CheckResponse.of(true, "경기 참가자 평가를 완료하였습니다.");
     }
 
+
+
     @Override
     @Transactional(readOnly = true)
     public CommonResponse<GameUserLevelDto> getMyGameUserLevel(Long userId) {
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserEntity userEntity = getUser(userId);
 
         GameUserLevelDto gameUserLevelDto = GameUserLevelDto.fromEntity(userEntity);
 
@@ -227,42 +223,53 @@ public class GameUserServiceImpl implements GameUserService {
         return CommonResponse.of("유저 랭크 조회를 완료하였습니다.", gameUserLevelDto);
     }
 
+
+
+    private UserEntity getUser(Long userId) {
+        return userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private ParticipantGameEntity getParticipantGame(Long userId, Long gameId) {
+        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    }
+
+    private GameEntity getGame(Long gameId) {
+        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+    }
+
+
+    private GameEntity getGameWithLock(Long gameId) {
+        return gameRepository.findByGameIdWithLock(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+    }
+
     // 최근 10경기 평균으로 Level측정
     private void updatePlayerLevel(UserEntity receiver) {
 
-        List<GameEntity> recent10GamesByUser = gameQueryRepository.findRecent10GamesByUser(receiver);
+        List<Long> recent10GamesIds = gameQueryRepository.findRecent10GamesByUser(receiver);
 
-        if (recent10GamesByUser.size() < 10) {
+        if (recent10GamesIds.size() < 10) {
             receiver.updateLevel(GameUserLevel.NONE);
             return;
         }
 
-        List<Double> gameAverages = new ArrayList<>();
+        List<GameAvgScoreDto> avgScoreByGames = levelQueryRepository.findAvgScoreByGames(
+                receiver.getUserId(),
+                recent10GamesIds
+        );
 
-        for (GameEntity gameEntity : recent10GamesByUser) {
-
-            List<LevelEntity> evaluations = levelRepository.findByReceiverAndGameEntity(receiver, gameEntity);
-
-            if (evaluations.isEmpty()) {
-                continue;
-            }
-
-            double gameAverage = evaluations.stream()
-                    .mapToInt(LevelEntity::getScore)
-                    .average()
-                    .orElse(0.0);
-
-
-            gameAverages.add(gameAverage);
-        }
-
-        // 10경기 이상의 경기 후 평가를 받은 경기가 5개 미만일시 Level -> NONE
-        if (gameAverages.size() < 5) {
+        if (avgScoreByGames.size() < 5) {
             receiver.updateLevel(GameUserLevel.NONE);
             return;
         }
 
-        double average = gameAverages.stream()
+
+        double average = avgScoreByGames.stream()
+                .map(GameAvgScoreDto::getAvgScore)
+                .filter(Objects::nonNull)
                 .mapToDouble(Double::doubleValue)
                 .average()
                 .orElse(0.0);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,4 @@
 spring:
-  profiles:
-    active: local
-
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -18,8 +15,8 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   mail:
     host: smtp.gmail.com
@@ -33,6 +30,7 @@ spring:
           starttls:
             enable: true
             required: true
+    default-encoding: UTF-8
 
   jwt:
     secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,17 @@
-
 spring:
-  # 로컬에서 돌릴 때 기본 프로필
-
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
   data:
     redis:
@@ -25,7 +30,6 @@ spring:
           starttls:
             enable: true
             required: true
-    default-encoding: UTF-8
 
   jwt:
     secret: ${JWT_SECRET}
@@ -41,7 +45,6 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/api/oauth2/kakao
             authorization-grant-type: authorization_code
-            client-authentication-method: authorization_code
             scope:
               - profile_nickname
               - account_email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: local
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 
 spring:
-  profiles:
-    active: local   # 로컬에서 돌릴 때 기본 프로필
+  # 로컬에서 돌릴 때 기본 프로필
 
   datasource:
     url: ${DB_URL}

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class AuthServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class AuthServiceImplTest {
 
@@ -38,7 +38,7 @@ class AuthServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @Autowired
+    @MockBean
     private RedisService redisService;
 
     @BeforeEach

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("local-test")
 class AuthServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("local-test")
 class GameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
 class GameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class GameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("local-test")
 class ParticipantGameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
@@ -45,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
 class ParticipantGameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class ParticipantGameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
@@ -1,0 +1,538 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+import com.example.basketballmatching.gameCreator.dto.AcceptGameUserListDto;
+import com.example.basketballmatching.gameCreator.dto.ApplyGameUserListDto;
+import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
+import com.example.basketballmatching.gameCreator.type.FieldStatus;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ParticipantGameServiceImplTest {
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private GameUserService gameUserService;
+    @Autowired
+    private ParticipantGameService participantGameService;
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
+
+    UserEntity creator;
+
+    UserEntity participant;
+
+    GameEntity gameEntity;
+
+    ParticipantGameEntity participantGameEntity;
+
+    @BeforeEach
+    void setUp() {
+
+        creator = UserEntity.builder()
+                .email("creator@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("name")
+                .nickname("name")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        creator.setEmailAuth();
+
+        userRepository.save(creator);
+
+        participant = UserEntity.builder()
+                .email("participant@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("participant")
+                .nickname("participant")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        participant.setEmailAuth();
+
+        userRepository.save(participant);
+
+
+        CreateGameDto.Request request = CreateGameDto.Request.builder()
+                .title("테스트 게임")
+                .content("테스트 게임 본문")
+                .headCount(9)
+                .fieldStatus(FieldStatus.OUTDOOR)
+                .matchGenderType(MatchGenderType.MALE_ONLY)
+                .startDateTime(LocalDateTime.now().plusHours(2L))
+                .endDateTime(LocalDateTime.now().plusHours(3L))
+                .placeName("테스트 게임 장소")
+                .address("인천광역시 테스트 게임 주소")
+                .matchFormat(MatchFormat.THREE_ON_THREE)
+                .build();
+
+        gameEntity = CreateGameDto.Request.toEntity(request, creator);
+
+        gameRepository.save(gameEntity);
+        participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, creator);
+
+        participantGameRepository.save(participantGameEntity);
+    }
+
+
+    @Test
+    @DisplayName("경기 참가 신청자 조회")
+    void getApplyParticipantListTest() {
+        // given
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(this.gameEntity.getGameId())
+                .orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+        List<Long> userIds = new ArrayList<>();
+
+        for (int i = 0; i < 8; i++) {
+
+            UserEntity user = UserEntity.builder()
+                    .email("test" + i + "@example.com")
+                    .password(passwordEncoder.encode("Test1234!"))
+                    .name("name" + i)
+                    .nickname("name" + i)
+                    .birth(LocalDate.of(1997,7,24))
+                    .address("테스트용주소")
+                    .phone("010-1111-1111")
+                    .position(Position.GUARD)
+                    .genderType(GenderType.MALE)
+                    .loginProvider(LoginProvider.LOCAL)
+                    .userType(UserType.USER)
+                    .build();
+
+            user.setEmailAuth();
+
+            userRepository.save(user);
+
+            userIds.add(user.getUserId());
+
+
+        }
+
+        for (int i = 0; i < userIds.size(); i++) {
+
+            gameUserService.applyGame(gameEntity.getGameId(), userIds.get(i));
+        }
+
+        UserEntity userEntity = userRepository.findByUserIdAndDeletedDateTimeIsNull(userIds.get(0))
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        // when
+
+        CommonResponse<List<ApplyGameUserListDto>> commonResponse = participantGameService.getApplyParticipantList(gameEntity.getGameId(), gameEntity.getUserEntity().getUserId(), PageRequest.of(0, 10));
+
+
+        // then
+
+        assertEquals("경기 신청자 조회가 완료되었습니다.", commonResponse.getMessage());
+        assertEquals(userEntity.getNickname(), commonResponse.getData().get(0).getNickname());
+    }
+
+    @Test
+    @DisplayName("경기 신청자 조회 실패 테스트 - 경기 생성자가 아닌 유저 조회")
+    void getApplyParticipantListFailTest_Not_Creator() {
+        // given
+
+        UserEntity user = UserEntity.builder()
+                .email("test1@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("name1")
+                .nickname("name1")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        user.setEmailAuth();
+
+        userRepository.save(user);
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(this.gameEntity.getGameId())
+                .orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), user.getUserId());
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.getApplyParticipantList(gameEntity.getGameId(), user.getUserId(), PageRequest.of(0, 10)));
+
+        // then
+
+        assertEquals(ErrorCode.NOT_GAME_CREATOR, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 수락 테스트")
+    void acceptGameUserTest() {
+        // given
+
+        UserEntity creator = userRepository.findByUserIdAndDeletedDateTimeIsNull(this.creator.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+
+        UserEntity participant = userRepository.findByUserIdAndDeletedDateTimeIsNull(this.participant.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(this.gameEntity.getGameId())
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), participant.getUserId());
+
+        // when
+
+        CheckResponse checkResponse = participantGameService.acceptGameUser(participant.getUserId(), creator.getUserId(), gameEntity.getGameId());
+
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId())
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        // then
+
+        assertEquals("경기 수락이 완료되었습니다.", checkResponse.getMessage());
+        assertEquals(ParticipantGameStatus.ACCEPT, participantGameEntity.getParticipantGameStatus());
+
+
+
+    }
+
+    @Test
+    @DisplayName("경기 수락 테스트 - 이미 시작된 경기")
+    void acceptGameUserFailTest_ALREADY_START_GAME() {
+        // given
+
+        UserEntity creator = userRepository.findByUserIdAndDeletedDateTimeIsNull(this.creator.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+
+        UserEntity participant = userRepository.findByUserIdAndDeletedDateTimeIsNull(this.participant.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(this.gameEntity.getGameId())
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+        gameUserService.applyGame(gameEntity.getGameId(), participant.getUserId());
+
+        gameEntity.setStartDateTime(LocalDateTime.now().minusHours(1));
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.acceptGameUser(participant.getUserId(), creator.getUserId(), gameEntity.getGameId()));
+
+        // then
+
+        assertEquals(ALREADY_START_GAME, exception.getErrorCode());
+
+    }
+
+
+    @Test
+    @DisplayName("경기 수락자 조회 테스트")
+    void getAcceptParticipantListTest() {
+        // given
+
+        Long gameId = gameEntity.getGameId();
+
+        // 경기 생성자는 경기 자동참가
+        Long creatorId = gameEntity.getUserEntity().getUserId();
+
+        // when
+
+        CommonResponse<List<AcceptGameUserListDto>> commonResponse = participantGameService.getAcceptParticipantList(gameId, creatorId, PageRequest.of(0, 10));
+
+        // then
+
+        assertEquals("경기 참가자 조회가 완료되었습니다.", commonResponse.getMessage());
+        assertEquals(creator.getNickname(), commonResponse.getData().get(0).getNickname());
+
+    }
+
+    @Test
+    @DisplayName("경기 수락자 조회 실패 테스트 - 경기 생성자만 조회 가능")
+    void getAcceptParticipantListFailTest_NOT_GAME_CREATOR() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        participantGameService.acceptGameUser(participantUserId, creator.getUserId(), gameId);
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.getAcceptParticipantList(gameId, participantUserId, PageRequest.of(0, 10)));
+        // then
+
+
+        assertEquals(NOT_GAME_CREATOR, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("경기 참가자 거절 테스트")
+    void rejectGameUserTest() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        ParticipantGameEntity participantGame = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantUserId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        // when
+
+
+        CheckResponse checkResponse = participantGameService.rejectGameUser(participantUserId, creatorId, gameId);
+
+        // then
+
+        assertEquals("경기 거절을 완료하였습니다.", checkResponse.getMessage());
+        assertEquals(ParticipantGameStatus.REJECT, participantGame.getParticipantGameStatus());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가자 거절 실패 테스트 - 이미 거절된 유저 거절 불가")
+    void rejectGameUserFailTest_ALREADY_REJECT_USER() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        participantGameService.rejectGameUser(participantUserId, creatorId, gameId);
+
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.rejectGameUser(participantUserId, creatorId, gameId));
+
+
+        // then
+
+        assertEquals(ALREADY_REJECT_USER, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가자 거절 실패 테스트 - 경기 시작 이후 거절 불가")
+    void rejectGameUserFailTest_ALREADAY_START_GAME() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        gameEntity.setStartDateTime(LocalDateTime.now().minusHours(1));
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.rejectGameUser(participantUserId, creatorId, gameId));
+
+        // then
+
+        assertEquals(ALREADY_START_GAME, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가자 강퇴 테스트")
+    void kickoutGameUserTest() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        participantGameService.acceptGameUser(participantUserId, creatorId, gameId);
+
+        ParticipantGameEntity participantGame = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantUserId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        // when
+
+        CheckResponse checkResponse = participantGameService.kickOutGameUser(participantUserId, creatorId, gameId);
+
+
+        // then
+
+        assertEquals("참가자 강퇴를 완료하였습니다.", checkResponse.getMessage());
+        assertEquals(ParticipantGameStatus.KICKOUT, participantGame.getParticipantGameStatus());
+    }
+
+    @Test
+    @DisplayName("경기 참가자 강퇴 실패 테스트 - 경기 생성자는 강퇴 불가")
+    void kickoutGameUserFailTest_NOT_KICKOUT_CREATOR() {
+        // given
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.kickOutGameUser(creatorId, creatorId, gameId));
+        // then
+
+        assertEquals(NOT_KICKOUT_CREATOR, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가자 강퇴 실패 테스트 - APPLY유저는 강퇴 불가")
+    void kickoutGameUserFailTest_NOT_ACCEPT_USER() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.kickOutGameUser(participantUserId, creatorId, gameId));
+
+        // then
+
+        assertEquals(NOT_ACCEPT_USER, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("경기 삭제 테스트")
+    void deleteGameTest() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameUserService.applyGame(gameId, participantUserId);
+
+        ParticipantGameEntity participantGame = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantUserId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+
+        // when
+
+        CheckResponse checkResponse = participantGameService.deleteGame(creatorId, gameId);
+
+        // then
+
+        assertEquals("경기 삭제가 완료되었습니다.", checkResponse.getMessage());
+        assertEquals(ParticipantGameStatus.DELETE, participantGame.getParticipantGameStatus());
+        assertNotNull(gameEntity.getDeletedDateTime());
+
+    }
+
+    @Test
+    @DisplayName("경기 삭제 실패 테스트 - 경기 시작 시간 30분전 삭제 불가")
+    void deleteGameFailTest_NOT_DELETE_GAME() {
+        // given
+        Long creatorId = creator.getUserId();
+
+        Long gameId = gameEntity.getGameId();
+
+        gameEntity.setStartDateTime(LocalDateTime.now().minusMinutes(29));
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> participantGameService.deleteGame(creatorId, gameId));
+
+        // then
+
+        assertEquals(NOT_DELETE_GAME, exception.getErrorCode());
+
+    }
+
+
+
+}

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -3,16 +3,22 @@ package com.example.basketballmatching.gameUsers.service.impl;
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
 import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
 import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import com.example.basketballmatching.gameUsers.entity.LevelEntity;
+import com.example.basketballmatching.gameUsers.repository.LevelRepository;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
+import com.example.basketballmatching.gameUsers.type.GameUserLevel;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
@@ -33,6 +39,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,8 +55,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Rollback(value = false)
+//@Rollback(value = false)
 @ActiveProfiles("test")
+@Transactional
 class GameUserServiceImplTest {
 
     @Autowired
@@ -67,14 +75,25 @@ class GameUserServiceImplTest {
     @Autowired
     private ParticipantGameRepository participantGameRepository;
 
+
+    UserEntity creator;
+
+    UserEntity participant;
+
+    GameEntity gameEntity;
+
+    ParticipantGameEntity participantGameEntity;
     @Autowired
-    private EntityManager em;
+    private LevelRepository levelRepository;
+    @Autowired
+    private GameQueryRepository gameQueryRepository;
+    @Autowired
+    private ParticipantGameService participantGameService;
 
     @BeforeEach
     void setUp() {
-        // given: 테스트용 유저 데이터 삽입
-        UserEntity creator = UserEntity.builder()
-                .email("test2@example.com")
+        creator = UserEntity.builder()
+                .email("creator@example.com")
                 .password(passwordEncoder.encode("Test1234!"))
                 .name("name")
                 .nickname("name")
@@ -82,48 +101,53 @@ class GameUserServiceImplTest {
                 .address("테스트용주소")
                 .phone("010-1111-1111")
                 .position(Position.GUARD)
-                .genderType(GenderType.NONE)
+                .genderType(GenderType.MALE)
                 .loginProvider(LoginProvider.LOCAL)
                 .userType(UserType.USER)
                 .build();
-
-        UserEntity gameUser = UserEntity.builder()
-                .email("test3@example.com")
-                .password(passwordEncoder.encode("Test@1234"))
-                .name("name")
-                .nickname("name2")
-                .birth(LocalDate.of(1997,7,24))
-                .address("테스트용주소2")
-                .phone("010-1111-1112")
-                .position(Position.GUARD)
-                .genderType(GenderType.FEMALE)
-                .loginProvider(LoginProvider.LOCAL)
-                .userType(UserType.USER)
-                .build();
-
 
         creator.setEmailAuth();
-        gameUser.setEmailAuth();
 
         userRepository.save(creator);
-        userRepository.save(gameUser);
+
+        participant = UserEntity.builder()
+                .email("participant@example.com")
+                .password(passwordEncoder.encode("Test1234!"))
+                .name("participant")
+                .nickname("participant")
+                .birth(LocalDate.of(1997,7,24))
+                .address("테스트용주소")
+                .phone("010-1111-1111")
+                .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .userType(UserType.USER)
+                .build();
+
+        participant.setEmailAuth();
+
+        userRepository.save(participant);
+
 
         CreateGameDto.Request request = CreateGameDto.Request.builder()
                 .title("테스트 게임")
                 .content("테스트 게임 본문")
-                .headCount(6)
+                .headCount(9)
                 .fieldStatus(FieldStatus.OUTDOOR)
-                .matchGenderType(MatchGenderType.FEMALE_ONLY)
-                .startDateTime(LocalDateTime.now().plusHours(1L))
-                .endDateTime(LocalDateTime.now().plusHours(2L))
+                .matchGenderType(MatchGenderType.MALE_ONLY)
+                .startDateTime(LocalDateTime.now().plusHours(2L))
+                .endDateTime(LocalDateTime.now().plusHours(3L))
                 .placeName("테스트 게임 장소")
                 .address("인천광역시 테스트 게임 주소")
                 .matchFormat(MatchFormat.THREE_ON_THREE)
                 .build();
 
-        GameEntity gameEntity = CreateGameDto.Request.toEntity(request, creator);
+        gameEntity = CreateGameDto.Request.toEntity(request, creator);
 
         gameRepository.save(gameEntity);
+        participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, creator);
+
+        participantGameRepository.save(participantGameEntity);
     }
 
     @Test
@@ -131,27 +155,25 @@ class GameUserServiceImplTest {
     void applyGameTest() {
         // given
 
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
         // when
 
-        CommonResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        CommonResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userId);
 
 
         // then
         assertEquals("경기 신청이 완료되었습니다.", applyGame.getMessage());
 
-        assertEquals(userEntity.getUserId(), applyGame.getData().getUserId());
+        assertEquals(userId, applyGame.getData().getUserId());
 
 
     }
 
     @Test
-    @DisplayName("경기 신청 실패 - 여성만 참여가능 -> 남성 참가자가 신청 시")
+    @DisplayName("경기 신청 실패 - 남성만 참여가능 -> 여성 참가자가 신청 시")
     void applyGameTest_Fail_FEMALE_ONLY() {
         // given
         UserEntity gameUser = UserEntity.builder()
@@ -164,23 +186,22 @@ class GameUserServiceImplTest {
                 .phone("010-1111-1112")
                 .position(Position.GUARD)
                 // 남성 유저
-                .genderType(GenderType.MALE)
+                .genderType(GenderType.FEMALE)
                 .loginProvider(LoginProvider.LOCAL)
                 .userType(UserType.USER)
                 .build();
 
         userRepository.save(gameUser);
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
 
         // when
 
-        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameEntity.getGameId(), gameUser.getUserId()));
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameId, gameUser.getUserId()));
         // then
 
-        assertEquals(ErrorCode.ONLY_FEMALE_GAME, exception.getErrorCode());
+        assertEquals(ONLY_MALE_GAME, exception.getErrorCode());
 
 
     }
@@ -190,12 +211,11 @@ class GameUserServiceImplTest {
     void applyGameTest_Fail_Full_HeadCount() {
         // given
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
         int headCount = gameEntity.getHeadCount();
 
-        for (int i = 0; i < headCount; i++) {
+        for (int i = 0; i < headCount - 1; i++) {
             UserEntity extraUser = UserEntity.builder()
                     .email("extra" + i + "@example.com")
                     .password(passwordEncoder.encode("Test@1234!"))
@@ -205,7 +225,7 @@ class GameUserServiceImplTest {
                     .address("인천시 테스트주소" + i)
                     .phone("010-9999-99" + i)
                     .position(Position.GUARD)
-                    .genderType(GenderType.FEMALE)
+                    .genderType(GenderType.MALE)
                     .loginProvider(LoginProvider.LOCAL)
                     .userType(UserType.USER)
                     .build();
@@ -213,7 +233,7 @@ class GameUserServiceImplTest {
             userRepository.save(extraUser);
 
             // 이미 참가된 상태를 DB에 반영 (status = APPLY)
-            gameUserService.applyGame(gameEntity.getGameId(), extraUser.getUserId());
+            gameUserService.applyGame(gameId, extraUser.getUserId());
         }
 
         UserEntity user = UserEntity.builder()
@@ -246,15 +266,13 @@ class GameUserServiceImplTest {
     void CancelGameTest() {
         // given
 
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
-        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        gameUserService.applyGame(gameEntity.getGameId(), userId);
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
@@ -263,7 +281,7 @@ class GameUserServiceImplTest {
 
         // when
 
-        CheckResponse checkResponse = gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId());
+        CheckResponse checkResponse = gameUserService.cancelGame(userId, gameId);
 
         // then
 
@@ -277,17 +295,15 @@ class GameUserServiceImplTest {
     void cancelGameFailTest_Apply_User() {
         // given
 
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
-        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        gameUserService.applyGame(gameEntity.getGameId(), userId);
 
         // when
 
-        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId()));
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userId, gameId));
 
         // then
 
@@ -299,15 +315,13 @@ class GameUserServiceImplTest {
     @DisplayName("경기 참가 취소 실패테스트 - 경기시작 30분전 취소 불가")
     void cancelGameFailTest_NOT_ALLOWED_CANCEL() {
         // given
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
-        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        gameUserService.applyGame(gameId, userId);
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
@@ -320,7 +334,7 @@ class GameUserServiceImplTest {
 
         // when
 
-        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userEntity.getUserId(), gameEntity.getGameId()));
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(userId, gameId));
 
         // then
 
@@ -333,16 +347,14 @@ class GameUserServiceImplTest {
     void getCurrentGameListTest() {
         // given
 
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
-        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        gameUserService.applyGame(gameId, userId);
 
         // when
-        CommonResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+        CommonResponse<List<CurrentGameListDto>> myCurrentGameList = gameUserService.getMyCurrentGameList(userId, PageRequest.of(0, 10));
 
         // then
 
@@ -352,18 +364,64 @@ class GameUserServiceImplTest {
     }
 
     @Test
+    @DisplayName("현재 예정 경기 조회 테스트 - N+1 문제 확인 테스트")
+    void getCurrentGameListTest_Check() {
+        // given
+
+
+        List<Long> gameIds = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            CreateGameDto.Request request = CreateGameDto.Request.builder()
+                    .title("테스트 게임")
+                    .content("테스트 게임 본문")
+                    .headCount(9)
+                    .fieldStatus(FieldStatus.OUTDOOR)
+                    .matchGenderType(MatchGenderType.MALE_ONLY)
+                    .startDateTime(LocalDateTime.now().plusHours(4L + i))
+                    .endDateTime(LocalDateTime.now().plusHours(5L + i))
+                    .placeName("테스트 게임 장소")
+                    .address("인천광역시 테스트 게임 주소")
+                    .matchFormat(MatchFormat.THREE_ON_THREE)
+                    .build();
+
+            gameEntity = CreateGameDto.Request.toEntity(request, creator);
+
+            gameRepository.save(gameEntity);
+            participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, creator);
+
+            gameIds.add(gameEntity.getGameId());
+        }
+
+        for (int i = 0; i < gameIds.size(); i++) {
+
+            gameUserService.applyGame(gameIds.get(i), participant.getUserId());
+
+        }
+
+        // when
+
+        CommonResponse<List<CurrentGameListDto>> commonResponse = gameUserService.getMyCurrentGameList(participant.getUserId(), PageRequest.of(0, 10));
+
+
+        // then
+
+        assertEquals("현재 예정된 게임 조회가 완료되었습니다.", commonResponse.getMessage());
+        assertEquals(10, commonResponse.getData().size());
+
+    }
+
+    @Test
     @DisplayName("지난 경기 조회 테스트")
     void getLastGameListTest() {
         // given
-        UserEntity userEntity = userRepository.findById(2L)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long userId = participant.getUserId();
 
-        GameEntity gameEntity = gameRepository.findByGameIdAndDeletedDateTimeIsNull(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        Long gameId = gameEntity.getGameId();
 
-        gameUserService.applyGame(gameEntity.getGameId(), userEntity.getUserId());
+        gameUserService.applyGame(gameId, userId);
 
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), userEntity.getUserId())
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
         participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
@@ -376,11 +434,11 @@ class GameUserServiceImplTest {
         gameRepository.save(gameEntity);
         // when
 
-        CommonResponse<List<LastGameListDto>> myLastGameList = gameUserService.getMyLastGameList(userEntity.getUserId(), PageRequest.of(0, 10));
+        CommonResponse<List<LastGameListDto>> myLastGameList = gameUserService.getMyLastGameList(userId, PageRequest.of(0, 10));
 
         // then
 
-        assertEquals(gameEntity.getGameId(), myLastGameList.getData().get(0).getGameId());
+        assertEquals(gameId, myLastGameList.getData().get(0).getGameId());
         assertEquals("지난 게임 조회가 완료되었습니다.", myLastGameList.getMessage());
 
     }
@@ -390,6 +448,8 @@ class GameUserServiceImplTest {
     @DisplayName("경기 참가 신청 - 동시성 이슈 테스트")
     void applyGameTest_Concurrency_Issue() throws Exception {
         // given
+
+        Long gameId = gameEntity.getGameId();
 
         for (int i = 0; i < 4; i++) {
             UserEntity gameUser = UserEntity.builder()
@@ -401,14 +461,14 @@ class GameUserServiceImplTest {
                     .address("테스트용주소a" + i)
                     .phone("010-1111-1112")
                     .position(Position.GUARD)
-                    .genderType(GenderType.FEMALE)
+                    .genderType(GenderType.MALE)
                     .loginProvider(LoginProvider.LOCAL)
                     .userType(UserType.USER)
                     .build();
 
             userRepository.save(gameUser);
 
-            gameUserService.applyGame(1L, gameUser.getUserId());
+            gameUserService.applyGame(gameId, gameUser.getUserId());
 
 
         }
@@ -430,7 +490,7 @@ class GameUserServiceImplTest {
                     .address("테스트용주소s" + i)
                     .phone("010-1111-1112")
                     .position(Position.GUARD)
-                    .genderType(GenderType.FEMALE)
+                    .genderType(GenderType.MALE)
                     .loginProvider(LoginProvider.LOCAL)
                     .userType(UserType.USER)
                     .build();
@@ -472,8 +532,7 @@ class GameUserServiceImplTest {
             });
 
         }
-        GameEntity before = gameRepository.findById(1L).orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
-
+        GameEntity before = gameEntity;
         System.out.println("Before concurrency - headCount=" + before.getHeadCount()
                 + ", participantCount=" + before.getParticipantCount()
                 + ", startDateTime=" + before.getStartDateTime());
@@ -484,15 +543,89 @@ class GameUserServiceImplTest {
 
         executorService.shutdown();
 
-        GameEntity gameEntity = gameRepository.findById(1L)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+        GameEntity gameEntity2 = gameEntity;
 
 
 
-        assertEquals(6, gameEntity.getParticipantCount());
+        assertEquals(5, gameEntity.getParticipantCount());
 
 
     }
 
+    @Test
+    @DisplayName("경기 평가 테스트")
+    void evaluatePlayerTest() {
+        // given
+
+        Long participantUserId = participant.getUserId();
+
+        Long creatorId = creator.getUserId();
+
+
+
+
+        List<Long> gameIds = new ArrayList<>();
+
+        for (int i = 0; i < 11; i++) {
+            CreateGameDto.Request request = CreateGameDto.Request.builder()
+                    .title("테스트 게임")
+                    .content("테스트 게임 본문")
+                    .headCount(9)
+                    .fieldStatus(FieldStatus.OUTDOOR)
+                    .matchGenderType(MatchGenderType.MALE_ONLY)
+                    .startDateTime(LocalDateTime.now().plusHours(4L + i))
+                    .endDateTime(LocalDateTime.now().plusHours(5L + i))
+                    .placeName("테스트 게임 장소")
+                    .address("인천광역시 테스트 게임 주소")
+                    .matchFormat(MatchFormat.THREE_ON_THREE)
+                    .build();
+
+            gameEntity = CreateGameDto.Request.toEntity(request, creator);
+
+            gameRepository.save(gameEntity);
+            participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, creator);
+
+            participantGameRepository.save(participantGameEntity);
+            gameIds.add(gameEntity.getGameId());
+        }
+
+        for (int i = 0; i < gameIds.size(); i++) {
+
+            gameUserService.applyGame(gameIds.get(i), participantUserId);
+
+            participantGameService.acceptGameUser(participantUserId, creatorId, gameIds.get(i));
+
+            GameEntity gameEntitys = gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameIds.get(i))
+                    .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+
+            gameEntitys.setStartDateTime(LocalDateTime.now().minusDays(i + 1));
+            gameEntitys.setEndDateTime(LocalDateTime.now().minusDays(i + 1));
+
+        }
+
+
+
+
+        // when
+
+        EvaluatePlayerDto evaluator = EvaluatePlayerDto.builder()
+                .receiverId(participantUserId)
+                .score(5)
+                .build();
+
+        for (int i = 0; i < gameIds.size(); i++) {
+
+
+            gameUserService.evaluatePlayer(gameIds.get(i), creatorId, evaluator);
+
+        }
+
+        // then
+
+        assertEquals(GameUserLevel.PRO, participant.getGameUserLevel());
+    }
+
+
 
 }
+

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -55,8 +55,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-//@Rollback(value = false)
-@ActiveProfiles("test")
 @Transactional
 class GameUserServiceImplTest {
 

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class GameUserServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("local-test")
 class GameUserServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -15,6 +15,8 @@ import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.service.UserService;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +69,9 @@ class UserServiceImplTest {
                 .address("테스트용주소")
                 .phone("010-1111-1111")
                 .position(Position.GUARD)
+                .genderType(GenderType.MALE)
                 .userType(UserType.USER)
+                .loginProvider(LoginProvider.LOCAL)
                 .build();
 
         user.setEmailAuth();
@@ -87,11 +91,19 @@ class UserServiceImplTest {
                 .checkPassword("Test@123")
                 .nickname("JI")
                 .name("test")
+                .address("테스트용주소")
                 .phone("010-1111-1111")
                 .birth(LocalDate.now())
                 .position(Position.GUARD)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+
                 .build();
         // when
+
+        mailService.sendAuthMail(request.getEmail());
+
+        mailService.verifyEmailAuth(request.getEmail(), redisService.getData("email:auth:" + "test@test.com"));
 
         CommonResponse<SignUpDto.Response> response = userService.signUp(request);
         // then
@@ -105,35 +117,13 @@ class UserServiceImplTest {
     @DisplayName("중복 이메일 확인")
     void NotValidEmail() {
         // given
-        SignUpDto.Request request1 = SignUpDto.Request.builder()
-                .email("test2@naver.com")
-                .password("Test@123")
-                .checkPassword("Test@123")
-                .nickname("JI")
-                .name("test")
-                .phone("010-1111-1111")
-                .birth(LocalDate.now())
-                .position(Position.GUARD)
-                .build();
 
-        SignUpDto.Request request2 = SignUpDto.Request.builder()
-                .email("test@naver.com")
-                .password("Test@123")
-                .checkPassword("Test@123")
-                .nickname("JI1234")
-                .name("test4")
-                .phone("010-1111-2222")
-                .birth(LocalDate.now())
-                .position(Position.GUARD)
-                .build();
-
-        userService.signUp(request1);
 
 
         // when
 
         CustomException exception = assertThrows(CustomException.class, () -> {
-            userService.signUp(request2);
+            userService.checkEmail("test2@example.com");
         });
 
 
@@ -164,7 +154,10 @@ class UserServiceImplTest {
                 .nickname("JI")
                 .name("test")
                 .phone("010-1111-1111")
+                .loginProvider(LoginProvider.LOCAL)
+                .address("테스트 주소")
                 .birth(LocalDate.now())
+                .genderType(GenderType.MALE)
                 .position(Position.GUARD)
                 .build();
 
@@ -190,7 +183,9 @@ class UserServiceImplTest {
                 .nickname("JI")
                 .name("test")
                 .phone("010-1111-1111")
+                .loginProvider(LoginProvider.LOCAL)
                 .birth(LocalDate.now())
+                .genderType(GenderType.MALE)
                 .position(Position.GUARD)
                 .build();
 
@@ -209,7 +204,7 @@ class UserServiceImplTest {
     void getUserInfoTest() {
         // given
 
-        TokenDto tokenDto = authService.loginUser("test@example.com", "Test1234!");
+        TokenDto tokenDto = authService.loginUser("test2@example.com", "Test1234!");
 
 
 

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("local-test")
 class UserServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class UserServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
 class UserServiceImplTest {
 
     @Autowired
@@ -48,7 +48,7 @@ class UserServiceImplTest {
     @Autowired
     private MailService mailService;
 
-    @Autowired
+    @MockBean
     private RedisService redisService;
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplTest.java
@@ -46,7 +46,7 @@ class UserServiceImplTest {
     @Autowired
     private UserService userService;
 
-    @Autowired
+    @MockBean
     private MailService mailService;
 
     @MockBean

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,4 @@
 spring:
-  profiles:
-    active: test
-
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
@@ -14,11 +11,18 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+        format_sql: true
 
   data:
     redis:
       host: localhost
-      port: 0   # redis 비활성화
+      port: 0
+
+  jwt:
+    secret: dummy-test-secret
+    access-token-expiration: 3600000
+    refresh-token-expiration: 1209600000
 
   security:
     oauth2:
@@ -40,7 +44,3 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
-jwt:
-  secret: dummy-test-secret
-  access-token-expiration: 3600000
-  refresh-token-expiration: 1209600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,46 @@
+spring:
+  profiles:
+    active: local-test
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  data:
+    redis:
+      host: localhost
+      port: 0   # redis 비활성화
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: dummy-test-client-id
+            client-secret: dummy-test-client-secret
+            redirect-uri: http://localhost/test
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret: dummy-test-secret
+  access-token-expiration: 3600000
+  refresh-token-expiration: 1209600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -40,7 +40,15 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-
+  mail:
+    host: dummy
+    port: 1025
+    username: test
+    password: test
+    properties:
+      mail:
+        smtp:
+          auth: false
 jwt:
   secret: dummy-test-secret
   access-token-expiration: 3600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,10 +18,7 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 
-  jwt:
-    secret: dummy-test-secret
-    access-token-expiration: 3600000
-    refresh-token-expiration: 1209600000
+
 
 
   security:
@@ -44,3 +41,7 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+jwt:
+  secret: dummy-test-secret
+  access-token-expiration: 3600000
+  refresh-token-expiration: 1209600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,11 +10,9 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
         show_sql: true
         format_sql: true
 
-  # 🔥 테스트에서 Redis 완전 비활성화
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
@@ -24,3 +22,25 @@ spring:
     secret: dummy-test-secret
     access-token-expiration: 3600000
     refresh-token-expiration: 1209600000
+
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: dummy-test-client-id
+            client-secret: dummy-test-client-secret
+            redirect-uri: http://localhost/test
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,33 +14,13 @@ spring:
         show_sql: true
         format_sql: true
 
-  data:
-    redis:
-      host: localhost
-      port: 0
+  # 🔥 테스트에서 Redis 완전 비활성화
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 
   jwt:
     secret: dummy-test-secret
     access-token-expiration: 3600000
     refresh-token-expiration: 1209600000
-
-  security:
-    oauth2:
-      client:
-        registration:
-          kakao:
-            client-id: dummy-test-client-id
-            client-secret: dummy-test-client-secret
-            redirect-uri: http://localhost/test
-            authorization-grant-type: authorization_code
-            client-authentication-method: client_secret_post
-            scope:
-              - profile_nickname
-              - account_email
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
-

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local-test
+    active: test
 
   datasource:
     driver-class-name: org.h2.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,18 @@
+DB_URL: jdbc:h2:mem:testdb
+DB_USERNAME: sa
+DB_PASSWORD:
+
+REDIS_HOST: localhost
+REDIS_PORT: 6379
+
+MAIL_USERNAME: test
+MAIL_PASSWORD: test
+
+JWT_SECRET: dummy-test-secret
+
+KAKAO_CLIENT_ID: dummy-test-client-id
+KAKAO_CLIENT_SECRET: dummy-test-client-secret
+
 spring:
   datasource:
     driver-class-name: org.h2.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,51 +1,51 @@
-DB_URL: jdbc:h2:mem:testdb
-DB_USERNAME: sa
-DB_PASSWORD:
-
-REDIS_HOST: localhost
-REDIS_PORT: 6379
-
-MAIL_USERNAME: test
-MAIL_PASSWORD: test
-
-JWT_SECRET: dummy-test-secret
-
-KAKAO_CLIENT_ID: dummy-test-client-id
-KAKAO_CLIENT_SECRET: dummy-test-client-secret
-
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
+    show-sql: true
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
 
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+    default-encoding: UTF-8
 
-
+  jwt:
+    secret: ${JWT_SECRET}
+    access-token-expiration: 3600000
+    refresh-token-expiration: 1209600000
 
   security:
     oauth2:
       client:
         registration:
           kakao:
-            client-id: dummy-test-client-id
-            client-secret: dummy-test-client-secret
-            redirect-uri: http://localhost/test
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/api/oauth2/kakao
             authorization-grant-type: authorization_code
-            client-authentication-method: client_secret_post
             scope:
               - profile_nickname
               - account_email
@@ -55,16 +55,3 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-  mail:
-    host: dummy
-    port: 1025
-    username: test
-    password: test
-    properties:
-      mail:
-        smtp:
-          auth: false
-jwt:
-  secret: dummy-test-secret
-  access-token-expiration: 3600000
-  refresh-token-expiration: 1209600000


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 참가자 경기 평가 테스트 코드 실행 시 최근 10경기 조회 로직에서 N+1 문제 발생
- 경기 참가 API 테스트 코드 미작성
### 🚀 TO-BE
✅ 참가자 경기 평가 로직 수정
- 최근 10경기 조회 QueryDSL 로직을 gameId만 조회하도록 최적화
- LevelQueryRepository
   - 조회된 gameId 목록을 기준으로 각 경기의 평균 점수만 조회
   - 전체 엔티티 로딩 대신 Projections.constructor + GameAvgScoreDto로 필요한 데이터만 조회
- 평균 점수 리스트 기반으로 최종 레벨 계산 및 랭크 업데이트 로직 개선
✅ 경기 참가 API 테스트 코드 작성
- 각 API의 성공 케이스 테스트 작성
- 각 API의 실패 케이스(1~2개) 작성하여 기본적인 예외 흐름 검증


---

## ✅ 체크리스트
- [x] API 테스트
- [x] 변경 로직 테스트 코드 정상 작동 
- [x] 경기 참가 API 테스트 코드 작성
---
