### PR TITLE
[refactor] : Redis 캐시 회원 정보 조회 기능 개선

### DIFF
--- a/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
@@ -48,7 +48,7 @@ public class BlackListServiceImpl implements BlackListService {
     public CheckResponse createBlackListUser(Long userId, Long reportId) {
 
         // 관리자 존재 여부
-        userRepository.findById(userId)
+        userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 신고 내역 존재 여부
@@ -122,7 +122,7 @@ public class BlackListServiceImpl implements BlackListService {
     }
 
     private UserEntity getUser(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -63,7 +63,7 @@ public class GameUserController {
     @ApiResponse(responseCode = "400", description = "잘못된 요청",
             content = {@Content(mediaType = "application/json",
                     schema = @Schema(implementation = ErrorResponse.class))})
-    @PostMapping("/cancel")
+    @PatchMapping("/cancel")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> cancelGame(
             @AuthenticationPrincipal UserInfoDetails userInfoDetails,

--- a/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
@@ -1,0 +1,68 @@
+package com.example.basketballmatching.global.config;
+
+import com.example.basketballmatching.user.dto.UserDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf, ObjectMapper objectMapper) {
+
+
+        ObjectMapper cacheMapper = objectMapper.copy()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+
+        var key = RedisSerializationContext.SerializationPair
+                .fromSerializer(new StringRedisSerializer());
+
+        var value = RedisSerializationContext.SerializationPair
+                .fromSerializer(new GenericJackson2JsonRedisSerializer(cacheMapper));
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(key)
+                .serializeValuesWith(value)
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(3));
+        Jackson2JsonRedisSerializer<UserDto> userDtoSer = new Jackson2JsonRedisSerializer<>(cacheMapper, UserDto.class);
+
+
+
+        var userDtoValuePair = RedisSerializationContext.SerializationPair
+                .fromSerializer(userDtoSer);
+
+        Map<String, RedisCacheConfiguration> cacheConfig = new HashMap<>();
+        cacheConfig.put("userDto", defaultConfig
+                        .serializeValuesWith(userDtoValuePair)
+                .entryTtl(Duration.ofMinutes(10)));
+
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfig)
+                .build();
+
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/service/RedisService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/RedisService.java
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisService {
 
+
+
     private final RedisTemplate<String, String> redisTemplate;
 
     public void setDataExpireMinutes(String key, String value, Long expiredTime) {
@@ -35,6 +37,7 @@ public class RedisService {
         valueOperations.set(key, value, Duration.ofDays(days));
 
     }
+
 
 
     public String getData(String key) {

--- a/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
@@ -5,11 +5,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
 
     boolean existsByTargetUser_UserIdAndGameEntity_GameId(Long reportedUserId, Long gameId);
 
     Page<ReportEntity> findAllByIsBannedFalseOrderByReportedDateTimeDesc(Pageable pageable);
+
+    Optional<ReportEntity> findByTargetUser_UserId(Long targetUserUserId);
 
 }
 

--- a/src/main/java/com/example/basketballmatching/user/controller/UserController.java
+++ b/src/main/java/com/example/basketballmatching/user/controller/UserController.java
@@ -137,7 +137,7 @@ public class UserController {
             content = {@Content(mediaType = "application/json",
                     schema = @Schema(implementation = ErrorResponse.class))})
     @GetMapping("/user-info")
-    @PreAuthorize("hasAnyRole('USER')")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<CommonResponse<UserDto>> getUserInfo(@AuthenticationPrincipal UserInfoDetails userInfoDetails) {
 
         CommonResponse<UserDto> userInfo = userService.getUserInfo(userInfoDetails.getUserEntity().getUserId());

--- a/src/main/java/com/example/basketballmatching/user/service/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/UserService.java
@@ -17,6 +17,8 @@ public interface UserService {
     CheckResponse checkNickname(String nickname);
     CommonResponse<UserDto> getUserInfo(Long userId);
 
+
+
     CommonResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto);
 
     CheckResponse verifyPasswordCode(String email, String code);

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -5,8 +5,8 @@ import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
-import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.security.TokenProvider;
 import com.example.basketballmatching.global.service.RedisService;
@@ -20,6 +20,7 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +32,7 @@ import java.util.Objects;
 
 import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
-import static com.example.basketballmatching.notifications.type.NotificationType.*;
+import static com.example.basketballmatching.notifications.type.NotificationType.DELETE_GAME;
 
 @Service
 @RequiredArgsConstructor
@@ -44,12 +45,15 @@ public class UserServiceImpl implements UserService {
 
     private final RedisService redisService;
 
+    private final UserCacheService userCacheService;
+
     private final TokenProvider tokenProvider;
 
     private final ParticipantGameRepository participantGameRepository;
     private final GameRepository gameRepository;
     private final NotificationService notificationService;
     private final GameQueryRepository gameQueryRepository;
+
 
 
     /**
@@ -122,15 +126,16 @@ public class UserServiceImpl implements UserService {
      * 회원 정보 조회
      */
     @Override
+    @Transactional
     public CommonResponse<UserDto> getUserInfo(Long userId) {
 
-        UserEntity userEntity = getUser(userId);
+        log.info("[유저 정보 조회 시작] userId : {}", userId);
 
-        UserDto userDto = UserDto.fromEntity(userEntity);
-
+        UserDto userDto = userCacheService.getUserDtoCached(userId);
 
         return CommonResponse.of("회원정보 조회에 성공하였습니다.", userDto);
     }
+
 
 
 
@@ -139,6 +144,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "userDto", key = "#userId")
     public CommonResponse<UserDto> editUserInfo(Long userId, EditUserDto editUserDto) {
 
         log.info("[유저 회원정보 수정 시작 : {}]", userId);
@@ -250,6 +256,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "userDto", key = "#userId")
     public CheckResponse deleteUser(Long userId, String token) {
 
         UserEntity userEntity = getUser(userId);


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 회원 정보 조회 API가 매 요청마다 DB를 조회

### 🚀 TO-BE
✅ Redis Cache 적용 - 회원 정보 조회 로직 성능 개선
- 회원 정보 조회 결과를 Redis에 캐싱하도록 개선
   - 요청이 들어오면 캐시 먼저 조회
   - 캐시 존재 -> Redis 값으로 즉시 응답
   - 캐시 x -> DB조회 후 Redis에 저장 후 응답
- 캐시 키를 유저 기준으로 고정하여 조회 경로를 단순화

---

## ✅ 체크리스트
- [x] API 테스트
- [x] 사용자 정보 수정, 탈되 시 캐시 무효화


---
