### PR TITLE
[refactor] : GameUserService 평가 로직 분리

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/service/EvaluationService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/EvaluationService.java
@@ -1,0 +1,10 @@
+package com.example.basketballmatching.gameCreator.service;
+
+import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
+import com.example.basketballmatching.global.dto.CheckResponse;
+
+public interface EvaluationService {
+
+    CheckResponse evaluatePlayer(Long gameId, Long evaluatorUserId, EvaluatePlayerDto evaluatePlayerDto);
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/EvaluationServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/EvaluationServiceImpl.java
@@ -1,0 +1,115 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.service.EvaluationService;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.gameUsers.dto.EvaluatePlayerDto;
+import com.example.basketballmatching.gameUsers.entity.LevelEntity;
+import com.example.basketballmatching.gameUsers.repository.LevelRepository;
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.ACCEPT;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationServiceImpl implements EvaluationService {
+
+
+    private final GameRepository gameRepository;
+    private final ParticipantGameRepository participantGameRepository;
+    private final LevelRepository levelRepository;
+    private final UserLevelService userLevelService;
+
+    @Override
+    @Transactional
+    public CheckResponse evaluatePlayer(Long gameId, Long evaluatorUserId, EvaluatePlayerDto evaluatePlayerDto) {
+
+        GameEntity gameEntity = getGame(gameId);
+
+        validateGameEnded(gameEntity);
+
+        ParticipantGameEntity evaluator = getParticipantGame(evaluatorUserId, gameId);
+        ParticipantGameEntity receiver = getParticipantGame(evaluatePlayerDto.getReceiverId(), gameId);
+
+        validateNotSelf(evaluator, receiver);
+        validateScore(evaluatePlayerDto.getScore());
+        validateNotDuplicated(gameId, evaluator.getUserEntity().getUserId(), receiver.getUserEntity().getUserId());
+
+        validateOnlyAcceptedUser(evaluator, receiver);
+
+        LevelEntity levelEntity = EvaluatePlayerDto.toEntity(
+                evaluator.getUserEntity(),
+                receiver.getUserEntity(),
+                gameEntity,
+                evaluatePlayerDto.getScore()
+        );
+
+        levelRepository.save(levelEntity);
+
+        userLevelService.recalculateLevel(receiver.getUserEntity().getUserId());
+
+        return CheckResponse.of(true, "경기 참가자 평가를 완료하였습니다.");
+    }
+
+    private static void validateOnlyAcceptedUser(ParticipantGameEntity evaluator, ParticipantGameEntity receiver) {
+        if (!evaluator.getParticipantGameStatus().equals(ACCEPT) || !receiver.getParticipantGameStatus().equals(ACCEPT)) {
+
+            throw new CustomException(ONLY_EVALUATE_ACCEPT_USER);
+        }
+    }
+
+
+    private GameEntity getGame(Long gameId) {
+        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+    }
+
+    private ParticipantGameEntity getParticipantGame(Long userId, Long gameId) {
+        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    }
+
+    private void validateGameEnded(GameEntity gameEntity) {
+
+        if (gameEntity.getEndDateTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(NOT_GAME_ENDED);
+        }
+
+    }
+
+    private void validateNotSelf(ParticipantGameEntity evaluator, ParticipantGameEntity receiver) {
+
+        if (evaluator.getParticipantGameId().equals(receiver.getParticipantGameId())) {
+            throw new CustomException(CANNOT_EVALUATE_SELF);
+        }
+
+    }
+
+    private void validateScore(int score) {
+        if (score < 1 || score > 5) {
+            throw new CustomException(INVALID_LEVEL_SCORE);
+        }
+    }
+
+    private void validateNotDuplicated(Long gameId, Long evaluatorUserId, Long receiverUserId) {
+
+        boolean exists = levelRepository.existsByGameEntity_GameIdAndEvaluator_UserIdAndReceiver_UserId(gameId, evaluatorUserId, receiverUserId);
+
+        if (exists) {
+            throw new CustomException(ALREADY_EVALUATED);
+        }
+
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -112,9 +112,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    public CheckResponse acceptGameUser(Long participantId, Long userId, Long gameId) {
+    public CheckResponse acceptGameUser(Long participantUserId, Long userId, Long gameId) {
 
-        log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantUserId, gameId);
 
         GameEntity gameEntity = getGame(gameId);
 
@@ -134,7 +134,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantUserId);
 
         // 경기 참가자 상태 유효성 검사
         validateGameStatusInAcceptAndReject(participantGameEntity.getParticipantGameStatus());
@@ -148,7 +148,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-        log.info("[참가자 경기 수락 완료] participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[참가자 경기 수락 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "경기 수락이 완료되었습니다.");
     }
@@ -162,9 +162,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    public CheckResponse rejectGameUser(Long participantId, Long userId, Long gameId) {
+    public CheckResponse rejectGameUser(Long participantUserId, Long userId, Long gameId) {
 
-        log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantUserId, gameId);
 
         GameEntity gameEntity = getGame(gameId);
 
@@ -175,7 +175,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         }
 
 
-        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantUserId);
 
         // 경기 참가자 상태 유효성 검사
         validateGameStatusInAcceptAndReject(participantGameEntity.getParticipantGameStatus());
@@ -195,7 +195,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
-        log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "경기 거절을 완료하였습니다.");
     }
@@ -208,9 +208,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    public CheckResponse kickOutGameUser(Long participantId, Long userId, Long gameId) {
+    public CheckResponse kickOutGameUser(Long participantUserId, Long userId, Long gameId) {
 
-        log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantUserId, gameId);
 
         GameEntity gameEntity = getGame(gameId);
 
@@ -219,7 +219,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         validateGameCreator(gameEntity, userEntity);
 
 
-        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantId);
+        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantUserId);
 
         if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
             throw new CustomException(NOT_KICKOUT_CREATOR);
@@ -240,7 +240,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-        log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantId, gameId);
+        log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "참가자 강퇴를 완료하였습니다.");
 
@@ -345,8 +345,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
                 findByParticipantGameStatusAndGameEntity_GameId(participantGameStatus, gameEntity.getGameId(), pageable);
     }
 
-    private ParticipantGameEntity getParticipantGame(GameEntity gameEntity, Long participantId) {
-        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantId)
+    private ParticipantGameEntity getParticipantGame(GameEntity gameEntity, Long participantUserId) {
+        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantUserId)
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
     }
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/UserLevelService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/UserLevelService.java
@@ -1,0 +1,61 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
+import com.example.basketballmatching.gameUsers.dto.GameAvgScoreDto;
+import com.example.basketballmatching.gameUsers.repository.LevelQueryRepository;
+import com.example.basketballmatching.gameUsers.type.GameUserLevel;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.example.basketballmatching.gameUsers.type.GameUserLevel.NONE;
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class UserLevelService {
+
+
+    private final UserRepository userRepository;
+    private final GameQueryRepository gameQueryRepository;
+    private final LevelQueryRepository levelQueryRepository;
+
+    public void recalculateLevel(Long userId) {
+
+        UserEntity userEntity = userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        List<Long> recent10GamesIds = gameQueryRepository.findRecent10GamesByUser(userEntity);
+
+        if (recent10GamesIds.size() < 10) {
+            userEntity.updateLevel(NONE);
+            return;
+        }
+
+        List<GameAvgScoreDto> avgScoreByGames = levelQueryRepository.findAvgScoreByGames(userEntity.getUserId(), recent10GamesIds);
+
+        if (avgScoreByGames.size() < 5) {
+            userEntity.updateLevel(NONE);
+            return;
+        }
+
+        double average = avgScoreByGames.stream()
+                .map(GameAvgScoreDto::getAvgScore)
+                .filter(Objects::nonNull)
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0.0);
+
+        userEntity.updateLevel(GameUserLevel.fromScore(average));
+
+        userRepository.save(userEntity);
+
+
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -1,6 +1,8 @@
 package com.example.basketballmatching.gameUsers.controller;
 
 
+import com.example.basketballmatching.gameCreator.service.EvaluationService;
+import com.example.basketballmatching.gameCreator.service.impl.UserLevelService;
 import com.example.basketballmatching.gameUsers.dto.*;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.CommonResponse;
@@ -31,6 +33,7 @@ import java.util.List;
 public class GameUserController {
 
     private final GameUserService gameUserService;
+    private final EvaluationService evaluationService;
 
     /**
      * 경기 참가
@@ -145,7 +148,7 @@ public class GameUserController {
             @RequestBody @Valid EvaluatePlayerDto request
             ) {
 
-        CheckResponse checkResponse = gameUserService.evaluatePlayer(gameId, userInfoDetails.getUserEntity().getUserId(), request);
+        CheckResponse checkResponse = evaluationService.evaluatePlayer(gameId, userInfoDetails.getUserEntity().getUserId(), request);
 
 
         return ResponseEntity.ok(checkResponse);

--- a/src/main/java/com/example/basketballmatching/gameUsers/entity/LevelEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/entity/LevelEntity.java
@@ -23,6 +23,7 @@ public class LevelEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long levelId;
 
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "evaluator_id")
     private UserEntity evaluator;

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -18,7 +18,6 @@ public interface GameUserService {
 
     CommonResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable);
 
-    CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request);
 
     CommonResponse<GameUserLevelDto> getMyGameUserLevel(Long userId);
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -6,14 +6,13 @@ import com.example.basketballmatching.gameCreator.repository.GameQueryRepository
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
-import com.example.basketballmatching.gameUsers.dto.*;
-import com.example.basketballmatching.gameUsers.entity.LevelEntity;
-import com.example.basketballmatching.gameUsers.repository.LevelQueryRepository;
-import com.example.basketballmatching.gameUsers.repository.LevelRepository;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.GameUserLevelDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
 import com.example.basketballmatching.gameUsers.service.GameUserService;
-import com.example.basketballmatching.gameUsers.type.GameUserLevel;
-import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
@@ -25,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,12 +39,10 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final GameQueryRepository gameQueryRepository;
 
-    private final LevelRepository levelRepository;
 
     private final UserRepository userRepository;
 
     private final GameRepository gameRepository;
-    private final LevelQueryRepository levelQueryRepository;
 
 
     /**
@@ -166,48 +162,6 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
-    /**
-     * 경기 참가자 평가
-     */
-    @Override
-    @Transactional
-    public CheckResponse evaluatePlayer(Long gameId, Long evaluatorId, EvaluatePlayerDto request) {
-
-        GameEntity gameEntity = getGame(gameId);
-
-        if (gameEntity.getEndDateTime().isAfter(LocalDateTime.now())) {
-            throw new CustomException(NOT_GAME_ENDED);
-        }
-
-        ParticipantGameEntity evaluator = getParticipantGame(evaluatorId, gameEntity.getGameId());
-
-        ParticipantGameEntity receiver = getParticipantGame(request.getReceiverId(), gameId);
-
-        if (evaluator.getParticipantGameId().equals(receiver.getParticipantGameId())) {
-            throw new CustomException(CANNOT_EVALUATE_SELF);
-        }
-
-        boolean exists = levelRepository.existsByGameEntity_GameIdAndEvaluator_UserIdAndReceiver_UserId(gameId, evaluator.getUserEntity().getUserId(), receiver.getUserEntity().getUserId());
-
-        if (exists) {
-            throw new CustomException(ALREADY_EVALUATED);
-        }
-
-        if (request.getScore()< 1 || request.getScore() > 5) {
-            throw new CustomException(INVALID_LEVEL_SCORE);
-        }
-
-        LevelEntity levelEntity = EvaluatePlayerDto.toEntity(evaluator.getUserEntity(), receiver.getUserEntity(), gameEntity, request.getScore());
-
-
-        levelRepository.save(levelEntity);
-
-        updatePlayerLevel(receiver.getUserEntity());
-
-        userRepository.save(receiver.getUserEntity());
-
-        return CheckResponse.of(true, "경기 참가자 평가를 완료하였습니다.");
-    }
 
 
 
@@ -246,41 +200,6 @@ public class GameUserServiceImpl implements GameUserService {
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
     }
 
-    // 최근 10경기 평균으로 Level측정
-    private void updatePlayerLevel(UserEntity receiver) {
-
-        List<Long> recent10GamesIds = gameQueryRepository.findRecent10GamesByUser(receiver);
-
-        if (recent10GamesIds.size() < 10) {
-            receiver.updateLevel(GameUserLevel.NONE);
-            return;
-        }
-
-        List<GameAvgScoreDto> avgScoreByGames = levelQueryRepository.findAvgScoreByGames(
-                receiver.getUserId(),
-                recent10GamesIds
-        );
-
-        if (avgScoreByGames.size() < 5) {
-            receiver.updateLevel(GameUserLevel.NONE);
-            return;
-        }
-
-
-        double average = avgScoreByGames.stream()
-                .map(GameAvgScoreDto::getAvgScore)
-                .filter(Objects::nonNull)
-                .mapToDouble(Double::doubleValue)
-                .average()
-                .orElse(0.0);
-
-
-        GameUserLevel newLevel = GameUserLevel.fromScore(average);
-
-
-        receiver.updateLevel(newLevel);
-
-    }
 
 
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -78,7 +78,7 @@ public enum ErrorCode {
     CANNOT_EVALUATE_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 평가할 수 없습니다."),
     ALREADY_EVALUATED(HttpStatus.BAD_REQUEST, "이미 평가한 참가자입니다."),
     INVALID_LEVEL_SCORE(HttpStatus.BAD_REQUEST, "평가점수는 1 ~ 5점만 입력가능합니다."),
-
+    ONLY_EVALUATE_ACCEPT_USER(HttpStatus.BAD_REQUEST, "경기 수락자만 평가가 가능합니다."),
 
     // report
     ALREADY_REPORTED_USER(HttpStatus.BAD_REQUEST, "이미 신고받은 유저입니다."),

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -6,6 +6,7 @@ import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.service.EvaluationService;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
@@ -88,6 +89,8 @@ class GameUserServiceImplTest {
     private GameQueryRepository gameQueryRepository;
     @Autowired
     private ParticipantGameService participantGameService;
+    @Autowired
+    private EvaluationService evaluationService;
 
     @BeforeEach
     void setUp() {
@@ -615,7 +618,7 @@ class GameUserServiceImplTest {
         for (int i = 0; i < gameIds.size(); i++) {
 
 
-            gameUserService.evaluatePlayer(gameIds.get(i), creatorId, evaluator);
+            evaluationService.evaluatePlayer(gameIds.get(i), creatorId, evaluator);
 
         }
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- GameUserService 경기 참가 + 상태변경, 평가 생성 및 레벨 산정까지 함꼐 처리
- 서비스가 비대해지면서
   - 평가 로직  변경 시 영향이 넓음
   - 테스트가 참가 로직과 평가 로직이 얽혀 유지보수 어려움

### 🚀 TO-BE
✅ 평가 도메인 책임 분리 (Single Responsibility)
- EvaluationService
   - 단일 평가 생성/수정/삭제 및 평가 유효성 검증 담당
   - (예: 중복 평가 방지, 권한/참가 여부/경기 상태 검증, 입력 값 범위 검증 등)
- UserLevelService
   - 최근 10경기 기준 레벨 산정 로직 분리
   - “최근 10경기 중 평가 존재 경기 ≥ 5경기일 때만 평균으로 레벨 변경, 미  만이면 NONE 처리” 정책 반영
- GameUserService
   - 평가 요청을 직접 계산하지 않고, EvaluationService / UserLevelService로 위임

---

## ✅ 체크리스트
- [x] API 테스트: 평가 생성/조회 플로우 정상 동작 확인
- [x] 통합 테스트:
   - Evaluation 유효성 검증 케이스 통과
   - 레벨 산정 로직(최근 10경기, 최소 5경기 평가 조건) 정책 테스트 통과
   - 기존 참가/매칭 플로우 영향 없음 확인

---
