### PR TITLE
[refactor] : 경기 조회 로직 N+1 문제 수정

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameQueryRepository.java
@@ -95,20 +95,22 @@ public class GameQueryRepository {
 
         QParticipantGameEntity participantGame = QParticipantGameEntity.participantGameEntity;
 
-        BooleanBuilder builder = new BooleanBuilder();
+        QGameEntity gameEntity = QGameEntity.gameEntity;
 
         LocalDateTime now = LocalDateTime.now();
 
-        builder.and(participantGame.userEntity.userId.eq(userId));
-        builder.and(participantGame.participantGameStatus.in(ACCEPT, APPLY));
-        builder.and(participantGame.gameEntity.startDateTime.after(now));
 
 
         List<ParticipantGameEntity> gameEntities = jpaQueryFactory
                 .select(participantGame)
                 .from(participantGame)
-                .where(builder)
-                .orderBy(participantGame.gameEntity.startDateTime.asc())
+                .join(participantGame.gameEntity, gameEntity)
+                .fetchJoin()
+                .where(
+                        participantGame.userEntity.userId.eq(userId),
+                        participantGame.participantGameStatus.in(ACCEPT, APPLY),
+                        participantGame.gameEntity.startDateTime.after(now))
+                .orderBy(gameEntity.startDateTime.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -122,20 +124,23 @@ public class GameQueryRepository {
     public List<LastGameListDto> getLastGameList(Long userId, Pageable pageable) {
 
         QParticipantGameEntity participantGameEntity = QParticipantGameEntity.participantGameEntity;
-
-        BooleanBuilder builder = new BooleanBuilder();
+        QGameEntity gameEntity = QGameEntity.gameEntity;
 
         LocalDateTime now = LocalDateTime.now();
 
-        builder.and(participantGameEntity.userEntity.userId.eq(userId));
-        builder.and(participantGameEntity.participantGameStatus.eq(ACCEPT));
-        builder.and(participantGameEntity.gameEntity.endDateTime.before(now));
+
 
         List<ParticipantGameEntity> lastGameList = jpaQueryFactory
                 .select(participantGameEntity)
                 .from(participantGameEntity)
-                .where(builder)
-                .orderBy(participantGameEntity.gameEntity.endDateTime.desc())
+                .join(participantGameEntity.gameEntity, gameEntity)
+                .fetchJoin()
+                .where(
+                        participantGameEntity.userEntity.userId.eq(userId),
+                        participantGameEntity.participantGameStatus.eq(ACCEPT),
+                        participantGameEntity.gameEntity.endDateTime.before(now)
+                )
+                .orderBy(gameEntity.endDateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/UserLevelService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/UserLevelService.java
@@ -5,7 +5,6 @@ import com.example.basketballmatching.gameUsers.dto.GameAvgScoreDto;
 import com.example.basketballmatching.gameUsers.repository.LevelQueryRepository;
 import com.example.basketballmatching.gameUsers.type.GameUserLevel;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserCacheService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserCacheService.java
@@ -1,0 +1,34 @@
+package com.example.basketballmatching.user.service.impl;
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserCacheService {
+
+    private final UserRepository userRepository;
+
+
+
+    @Cacheable(cacheNames = "userDto", key = "#userId", unless = "#result == null")
+    @Transactional(readOnly = true)
+    public UserDto getUserDtoCached(Long userId) {
+
+        log.info("[유저 캐시 정보 조회] userId : {}", userId);
+
+        UserEntity userEntity = userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        return UserDto.fromEntity(userEntity);
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 현재 예정 경기/ 지난 경기 조회 시 ParticipantGameEntity 목록을 조회한 후, DTO 변환 과정에서 GameEntity를 접근하면서 N+1 쿼리 발생
   - API 테스트 과정 중 참가 엔티티 N건 조회 후, 각 row마다 game_entity를 추가 조회하는 쿼리가 반복 실행됨.

### 🚀 TO-BE
✅ QueryDsl 조회 로직 수정
- QueryDSL 조회 로직에 join(...).fetchJoin() 적용하여 연관된 GameEntity를 한 번에 조회
   - ParticipantGameEntity + GameEntity를 단일 쿼리로 가져와 DTO 매핑 시 추가 쿼리 제거
- API 테스트 시 Hibernate SQL 로그에서 game_entity where game_id=? 형태의 반복 쿼리(추가 조회)가 발생하지 않음을 확인

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] API 테스트

---
