### PR TITLE
[refactor] : 예외 처리 개선 및 에러 응답 표준화

### DIFF
--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // jwt
-    // JWT
+
+    // JWT (인증 실패 = 401 / 권한 부족  = 403)
     NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 갱신해주세요."),
@@ -19,77 +19,76 @@ public enum ErrorCode {
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
 
-    // user
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    // user (리소스 없음 = 404, 중복 = 409, 입력 검증 = 400)
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
+    ALREADY_VERIFIED_EMAIL(HttpStatus.CONFLICT, "이미 인증된 이메일입니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행해주세요."),
     INVALID_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
     LOGOUT_USER(HttpStatus.BAD_REQUEST, "로그아웃 유저입니다"),
     PROVIDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "로그인 방식이 일치하지 않습니다."),
-    // validation
+
+    // validation (입력 검증 = 400)
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
     PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요."),
     FUTURE_DATE(HttpStatus.BAD_REQUEST, "현재 시각 이후로 입력해주세요."),
 
-    // OAuth2
+    // OAuth2(입력 검증 = 400, 외부 연동 실패 = 502)
     OAUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "OAUTH2 토큰이 존재하지 않습니다."),
     OAUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, "요청 검증 상태가 유효하지 않습니다."),
     OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 토큰 발급에 실패하였습니다."),
     OAUTH_USERINFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 요청에 실패하였습니다."),
     OAUTH_USERINFO_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 응답 파싱에 실패하였습니다."),
 
-    // game
-
+    // game (입력 검증 = 400/ 리소스 없음 = 404/ 권한 부족 =  403/ 중복 = 409)
     INVALID_GAME_TIME(HttpStatus.BAD_REQUEST, "시작/종료 시간이 유효하지 않습니다."),
     GAME_TIME_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "경기시간은 1시간 이상 2시간 이하입니다."),
-    PLACE_SCHEDULE_OVERLAP(HttpStatus.BAD_REQUEST, "해당 장소에 겹치는 경기가 존재합니다."),
+    PLACE_SCHEDULE_OVERLAP(HttpStatus.CONFLICT, "해당 장소에 겹치는 경기가 존재합니다."),
     INVALID_HEADCOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 인원수입니다."),
-    GAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "경기를 찾을 수 없습니다."),
-    NOT_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자가 아닙니다."),
-    UPDATE_GAME_HEAD_COUNT(HttpStatus.BAD_REQUEST, "경기 인원 수를 변경해주세요.")
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다."),
+    NOT_GAME_CREATOR(HttpStatus.FORBIDDEN, "경기 생성자가 아닙니다."),
+    UPDATE_GAME_HEAD_COUNT(HttpStatus.BAD_REQUEST, "경기 인원 수를 변경해주세요."),
 
-    // participant
-    , ALREADY_APPLY_GAME_USER(HttpStatus.BAD_REQUEST, "이미 참가 신청한 유저입니다."),
-    FULL_HEADCOUNT_GAME(HttpStatus.BAD_REQUEST, "남은 신청 자리가 없습니다."),
-    NOT_ALLOWED_TO_JOIN(HttpStatus.BAD_REQUEST, "경기 참가를 요청할 수 없습니다."),
-    NOT_ALLOWED_CANCEL(HttpStatus.BAD_REQUEST, "경기 취소를 요청할 수 없습니다."),
-    ONLY_FEMALE_GAME(HttpStatus.BAD_REQUEST, "여성 유저만 신청가능합니다."),
-    ONLY_MALE_GAME(HttpStatus.BAD_REQUEST, "남성 유저만 신청가능합니다."),
+    // participant (입력 검증 = 400/ 리소스 없음 = 404/ 권한 부족 =  403/ 중복 = 409)
+    ALREADY_APPLY_GAME_USER(HttpStatus.CONFLICT, "이미 참가 신청한 유저입니다."),
+    FULL_HEADCOUNT_GAME(HttpStatus.CONFLICT, "남은 신청 자리가 없습니다."),
+    NOT_ALLOWED_TO_JOIN(HttpStatus.FORBIDDEN, "경기 참가를 요청할 수 없습니다."),
+    NOT_ALLOWED_CANCEL(HttpStatus.FORBIDDEN, "경기 취소를 요청할 수 없습니다."),
+    ONLY_FEMALE_GAME(HttpStatus.FORBIDDEN, "여성 유저만 신청가능합니다."),
+    ONLY_MALE_GAME(HttpStatus.FORBIDDEN, "남성 유저만 신청가능합니다."),
     NOT_APPLY_USER(HttpStatus.BAD_REQUEST, "경기 참가 신청을 한 유저가 아닙니다."),
-    ALREADY_START_GAME(HttpStatus.BAD_REQUEST, "이미 시작한 경기입니다."),
-    PARTICIPANT_NOT_FOUND(HttpStatus.BAD_REQUEST, "경기 참가자를 찾을 수 없습니다."),
-    ALREADY_ACCEPT_USER(HttpStatus.BAD_REQUEST, "이미 수락된 참가자입니다."),
+    ALREADY_START_GAME(HttpStatus.CONFLICT, "이미 시작한 경기입니다."),
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "경기 참가자를 찾을 수 없습니다."),
+    ALREADY_ACCEPT_USER(HttpStatus.CONFLICT, "이미 수락된 참가자입니다."),
     NOT_REJECT_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 거절할 수 없습니다."),
-    ALREADY_REJECT_USER(HttpStatus.BAD_REQUEST, "이미 거절된 참가자입니다."),
+    ALREADY_REJECT_USER(HttpStatus.CONFLICT, "이미 거절된 참가자입니다."),
     NOT_ACCEPT_USER(HttpStatus.BAD_REQUEST, "수락된 참가자가 아닙니다."),
-    ALREADY_CANCELED_USER(HttpStatus.BAD_REQUEST, "이미 취소한 참가자입니다."),
+    ALREADY_CANCELED_USER(HttpStatus.CONFLICT, "이미 취소한 참가자입니다."),
     NOT_KICKOUT_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 강퇴할 수 없습니다."),
-    ALREADY_KICKOUT_USER(HttpStatus.BAD_REQUEST, "이미 강퇴한 참가자입니다."),
-    NOT_DELETE_GAME(HttpStatus.BAD_REQUEST, "경기를 삭제할 수 없습니다."),
+    ALREADY_KICKOUT_USER(HttpStatus.CONFLICT, "이미 강퇴한 참가자입니다."),
+    NOT_DELETE_GAME(HttpStatus.FORBIDDEN, "경기를 삭제할 수 없습니다."),
     NOT_APPLY_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 참가신청을 할 수 없습니다."),
 
 
     // level
-    NOT_GAME_ENDED(HttpStatus.BAD_REQUEST, "아직 경기가 종료되지 않았습니다."),
+    NOT_GAME_ENDED(HttpStatus.CONFLICT, "아직 경기가 종료되지 않았습니다."),
     CANNOT_EVALUATE_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 평가할 수 없습니다."),
-    ALREADY_EVALUATED(HttpStatus.BAD_REQUEST, "이미 평가한 참가자입니다."),
+    ALREADY_EVALUATED(HttpStatus.CONFLICT, "이미 평가한 참가자입니다."),
     INVALID_LEVEL_SCORE(HttpStatus.BAD_REQUEST, "평가점수는 1 ~ 5점만 입력가능합니다."),
-    ONLY_EVALUATE_ACCEPT_USER(HttpStatus.BAD_REQUEST, "경기 수락자만 평가가 가능합니다."),
+    ONLY_EVALUATE_ACCEPT_USER(HttpStatus.FORBIDDEN, "경기 수락자만 평가가 가능합니다."),
 
     // report
-    ALREADY_REPORTED_USER(HttpStatus.BAD_REQUEST, "이미 신고받은 유저입니다."),
-    NOT_FOUND_REPORT(HttpStatus.BAD_REQUEST, "신고내역을 찾을 수 없습니다."),
-    ALREADY_CHECK_REPORT(HttpStatus.BAD_REQUEST, "이미 처리된 신고내역입니다."),
+    ALREADY_REPORTED_USER(HttpStatus.CONFLICT, "이미 신고받은 유저입니다."),
+    NOT_FOUND_REPORT(HttpStatus.NOT_FOUND, "신고내역을 찾을 수 없습니다."),
+    ALREADY_CHECK_REPORT(HttpStatus.CONFLICT, "이미 처리된 신고내역입니다."),
 
 
     // blackList
-    ALREADY_BLACK_USER(HttpStatus.BAD_REQUEST, "이미 블랙리스트 등록된 유저입니다."),
-    BLACKLIST_USER(HttpStatus.BAD_REQUEST, "블랙리스트 유저입니다.")
-    ;
+    ALREADY_BLACK_USER(HttpStatus.CONFLICT, "이미 블랙리스트 등록된 유저입니다."),
+    BLACKLIST_USER(HttpStatus.FORBIDDEN, "블랙리스트 유저입니다.");
 
 
 

--- a/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.exception.dto.FieldErrorDetail;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,8 +12,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
@@ -34,7 +33,10 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 
 
-        log.warn("CustomException 발생 : {}", e.getErrorCode().getHttpStatus());
+        log.warn("CustomException: code={}, status={}, message={}",
+                e.getErrorCode().name(),
+                e.getErrorCode().getHttpStatus(),
+                e.getMessage());
 
 
         return new ResponseEntity<>(ErrorResponse.of(e.getErrorCode()), e.getErrorCode().getHttpStatus());
@@ -44,25 +46,43 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
 
-        log.warn("MethodArgumentNotValidException 발생 : {}", e.getMessage());
-
         List<FieldErrorDetail> details = e.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(error -> FieldErrorDetail.of(
                         error.getField(),
-                        error.getCode(),
+                        Optional.ofNullable(error.getCode()).orElse("NotBlank"),
                         error.getDefaultMessage()
                 )).toList();
 
-        String firstCode = Optional.ofNullable(e.getBindingResult().getFieldErrors().get(0).getCode())
+        String firstCode = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(FieldError::getCode)
+                .filter(code -> code != null && !code.isBlank())
                 .orElse("NotBlank");
 
         ErrorCode errorCode = map(firstCode);
 
+        log.warn("Validation failed: repCode={}, detailsSize={}", firstCode, details.size());
+
 
         return new ResponseEntity<>(ErrorResponse.of(errorCode, details), errorCode.getHttpStatus());
     }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+
+        log.error("[Unhandled exception]", e);
+
+        return new ResponseEntity<>(
+                ErrorResponse.of(INTERNAL_SERVER_ERROR),
+                INTERNAL_SERVER_ERROR.getHttpStatus()
+        );
+
+    }
+
 
     private static ErrorCode map(String validationCode) {
         return CODE_MAP.getOrDefault(validationCode, INVALID_INPUT);


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- ErrorCode의 대부분이 HttpStatus.BAD_REQUEST(400)로 설정되어 있어, 에러 상황의 의미가 상태코드에 반영되지 않음
- 전역 예외 처리(GlobalExceptionHandler)
   - MethodArgumentNotValidException 처리에서 대표 코드 추출 시 리스트 인덱스 접근 위험이 있었다(빈 리스트/ 코드 null)
   - 예상하지 못한 예외에 대한 fallback 처리/ 스택트레이스 로깅이 부족하여 디버깅이 어려울 수 있음

### 🚀 TO-BE
✅ 상태코드 변경
- ErrorCode의 HttpStatus를 의미에 맞게 재정리
   - NOT_FOUND 등 리소스 미존재 → 404 NOT_FOUND
   - ALREADY_*, 중복/충돌/이미 처리됨 등 → 409 CONFLICT
   - 권한/정책으로 금지되는 행위 → 403 FORBIDDEN
   - 입력값/검증 실패 → 400 BAD_REQUEST
   - 외부 연동 실패(OAuth2 등) → 502 BAD_GATEWAY 유지

✅ GlobalExceptionHandler 개선
- MethodArgumentNotValidException 처리 로직을 안전하게 개선(대표 코드 추출 시 findFirst() 기반 + null/blank 방어)
- CustomException/Validation 실패에 대해 핵심 정보(에러코드/상태코드/메시지/상세 개수) 로그 강화
- @ExceptionHandler(Exception.class) 추가로 Unhandled 예외 fallback 처리 및 스택트레이스 로깅 적용

---

## ✅ 체크리스트
- [ ] 코드 빌드 및 테스트 통과
- [ ] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)
- [ ] 관련 문서(README, API 명세) 업데이트
- [ ] 성능/보안/예외 처리 검토 완료

---
