### PR TITLE
[refactor] : 현재 및 지난 게임 조회 Redis 캐시 적용

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -18,6 +18,7 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -112,6 +113,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse acceptGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantUserId, gameId);
@@ -162,6 +164,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse rejectGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantUserId, gameId);
@@ -208,6 +211,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse kickOutGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantUserId, gameId);
@@ -254,6 +258,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse deleteGame(Long userId, Long gameId) {
 
         log.info("[경기 삭제 시작] userId : {}, gameId : {}", userId, gameId);

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserCacheService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserCacheService.java
@@ -1,0 +1,63 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
+import com.example.basketballmatching.gameUsers.dto.CurrentGameListDto;
+import com.example.basketballmatching.gameUsers.dto.LastGameListDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameUserCacheService {
+
+
+    private final GameQueryRepository gameQueryRepository;
+
+
+    @Cacheable(
+            cacheNames = "myCurrentGameList",
+            key = "T(String).valueOf(#userId)"
+            + " + ':' + #pageable.pageNumber"
+            + " + ':' + #pageable.pageSize"
+            + " + ':' + #pageable.sort.toString()",
+            unless = "#result == null || #result.isEmpty()"
+    )
+    @Transactional(readOnly = true)
+    public List<CurrentGameListDto> getMyCurrentGameListCached(Long userId, Pageable pageable) {
+
+        log.info("[현재 예정 게임 리스트 조회 캐싱] userId = {}, page = {}, size = {}, sort = {}",
+                userId, pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+
+
+        return gameQueryRepository.getCurrentGameList(userId,pageable);
+    }
+
+
+    @Cacheable(
+            cacheNames = "myLastGameList",
+            key = "T(String).valueOf(#userId)"
+            + " + ':' + #pageable.pageNumber"
+            + " + ':' + #pageable.pageSize"
+            + " + ':' + #pageable.sort.toString()",
+            unless = "#result == null || #result.isEmpty()"
+    )
+    @Transactional(readOnly = true)
+    public List<LastGameListDto> getMyLastGameListCached(Long userId, Pageable pageable) {
+
+        log.info("[지난 게임 리스트 조회 캐싱] userId = {}, page = {}, size = {}, sort = {}",
+                userId, pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+
+        return gameQueryRepository.getLastGameList(userId, pageable);
+
+    }
+
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -19,6 +19,7 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +39,8 @@ public class GameUserServiceImpl implements GameUserService {
     private final ParticipantGameRepository participantGameRepository;
 
     private final GameQueryRepository gameQueryRepository;
+
+    private final GameUserCacheService gameUserCacheService;
 
 
     private final UserRepository userRepository;
@@ -93,6 +96,7 @@ public class GameUserServiceImpl implements GameUserService {
      */
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse cancelGame(Long userId, Long gameId) {
 
         GameEntity gameEntity = getGameWithLock(gameId);
@@ -140,7 +144,7 @@ public class GameUserServiceImpl implements GameUserService {
         getUser(userId);
 
 
-        List<CurrentGameListDto> currentGameList = gameQueryRepository.getCurrentGameList(userId, pageable);
+        List<CurrentGameListDto> currentGameList = gameUserCacheService.getMyCurrentGameListCached(userId, pageable);
 
         return CommonResponse.of("현재 예정된 게임 조회가 완료되었습니다.", currentGameList);
     }
@@ -155,8 +159,7 @@ public class GameUserServiceImpl implements GameUserService {
         getUser(userId);
 
 
-        List<LastGameListDto> lastGameList = gameQueryRepository.getLastGameList(userId, pageable);
-
+        List<LastGameListDto> lastGameList = gameUserCacheService.getMyLastGameListCached(userId, pageable);
 
         return CommonResponse.of("지난 게임 조회가 완료되었습니다.", lastGameList);
     }

--- a/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
@@ -55,7 +55,8 @@ public class RedisCacheConfig {
         cacheConfig.put("userDto", defaultConfig
                         .serializeValuesWith(userDtoValuePair)
                 .entryTtl(Duration.ofMinutes(10)));
-
+        cacheConfig.put("myCurrentGameList", defaultConfig.entryTtl(Duration.ofMinutes(2)));
+        cacheConfig.put("myLastGameList", defaultConfig.entryTtl(Duration.ofMinutes(5)));
 
         return RedisCacheManager.builder(cf)
                 .cacheDefaults(defaultConfig)
@@ -64,5 +65,7 @@ public class RedisCacheConfig {
 
 
     }
+
+
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 현재 및 지난경기 조회 요청이 들어올 때마다 DB 조회 발생
- 조회 경기수가 늘어나면 동일한 쿼리가 반복 실행될 가능성이 큼

### 🚀 TO-BE
✅ Redis 기반 조회 캐싱 적용
- **현재 예정  경기** : myCurrentGameList
- **지난 경기** : myLastGameList
- 캐시 키를 `userId:page:size:sort` 조합으로 생성하여 페이지/정렬별 캐시 분리
- **상태 변경 시 캐시 무효화(Evict) 적용**
  - 참가 상태가 바뀌는 시점(수락/거절/강퇴/취소/삭제 등)에 **myCurrentGameList** 캐시 삭제로 일관성 유지
- **TTL 적용으로 자동 만료 처리**
  - 종료 처리 API를 별도로 만들지 않는 대신, 개키 TTL을 짧게 가져가도록 설정
  

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)
- [x] 성능/보안/예외 처리 검토 완료

---
