### PR TITLE
[test] : 유저 api 단위테스트

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/GameRepository.java
@@ -4,7 +4,6 @@ import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,6 +28,21 @@ public interface GameRepository extends JpaRepository<GameEntity, Long> {
                                         @Param("startDateTime") LocalDateTime startDateTime,
                                         @Param("endDateTime") LocalDateTime endDateTime);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query ("""
+        select g
+        from GameEntity g
+        where g.deletedDateTime is null 
+        and g.placeName = :placeName
+        and g.address = :address
+        and g.startDateTime < :endDateTime
+        and g.endDateTime > :startDateTime
+""")
+    List<GameEntity> findByOverlapPlace(@Param("placeName") String placeName,
+                                        @Param("address") String address,
+                                        @Param("startDateTime") LocalDateTime startDateTime,
+                                        @Param("endDateTime") LocalDateTime endDateTime);
+
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select g from GameEntity g where g.gameId = :gameId and g.deletedDateTime is NULL ")
@@ -40,6 +54,7 @@ public interface GameRepository extends JpaRepository<GameEntity, Long> {
     List<GameEntity> findByUserEntity_UserIdAndDeletedDateTimeIsNull(Long userId);
 
 
+    long countByPlaceNameAndAddressAndStartDateTimeAndEndDateTime(String placeName, String address, LocalDateTime start, LocalDateTime end);
 
     Optional<GameEntity> findByTitle(String title);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -6,8 +6,10 @@ import com.example.basketballmatching.gameCreator.dto.EditGameDto;
 import com.example.basketballmatching.gameCreator.dto.GameDto;
 import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.PlaceLockEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.PlaceLockRepository;
 import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
 import com.example.basketballmatching.global.dto.CommonResponse;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
@@ -38,6 +41,7 @@ public class GameServiceImpl implements GameService {
     private final GameRepository gameRepository;
     private final GameQueryRepository gameQueryRepository;
     private final ParticipantGameRepository participantGameRepository;
+    private final PlaceLockRepository placeLockRepository;
 
     /**
      * 경기 생성
@@ -48,10 +52,20 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 생성 시작] userId = {} title = {}", userId, request.getTitle());
 
+        String lockKey = request.getPlaceName() + "|" + request.getAddress();
+
+
+        placeLockRepository.ensureExists(lockKey);
+
+        placeLockRepository.lockByKey(lockKey)
+                .orElseThrow(() -> new CustomException(LOCK_BY_GAME));
+
         UserEntity userEntity = getUser(userId);
 
         // 경기 생성 유효성 검사
         validateCreateGame(request);
+
+
 
         GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
 
@@ -208,16 +222,12 @@ public class GameServiceImpl implements GameService {
             }
         }
 
-        boolean exists = gameRepository.existsBySamePlaceAtSameTime(
-                request.getPlaceName(),
-                request.getAddress(),
-                request.getStartDateTime(),
-                request.getEndDateTime()
-        );
+        boolean exists = gameRepository.existsBySamePlaceAtSameTime(request.getPlaceName(), request.getAddress(), request.getStartDateTime(), request.getEndDateTime());
 
         if (exists) {
             throw new CustomException(PLACE_SCHEDULE_OVERLAP);
         }
+
 
     }
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -38,7 +38,6 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final ParticipantGameRepository participantGameRepository;
 
-    private final GameQueryRepository gameQueryRepository;
 
     private final GameUserCacheService gameUserCacheService;
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -54,5 +54,4 @@ public class SecurityConfig {
     }
 
 
-
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다."),
     NOT_GAME_CREATOR(HttpStatus.FORBIDDEN, "경기 생성자가 아닙니다."),
     UPDATE_GAME_HEAD_COUNT(HttpStatus.BAD_REQUEST, "경기 인원 수를 변경해주세요."),
+    LOCK_BY_GAME(HttpStatus.BAD_REQUEST, "잠시 후에 다시 시도해주세요."),
 
     // participant (입력 검증 = 400/ 리소스 없음 = 404/ 권한 부족 =  403/ 중복 = 409)
     ALREADY_APPLY_GAME_USER(HttpStatus.CONFLICT, "이미 참가 신청한 유저입니다."),

--- a/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
+++ b/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
@@ -26,7 +26,7 @@ import static com.example.basketballmatching.global.exception.ErrorCode.*;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class AuthentificationFilter  extends OncePerRequestFilter {
+public class AuthentificationFilter extends OncePerRequestFilter {
 
     public static final String TOKEN_HEADER = "Authorization";
     public static final String TOKEN_PREFIX = "Bearer ";
@@ -46,49 +46,50 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
             return;
         }
 
-        String email = tokenProvider.parseToken(token).getSubject();
-
-
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
 
         try {
 
 
+            tokenProvider.validateToken(token);
 
-            if (tokenProvider.validateToken(token)) {
-
-                String logoutToken = redisService.getData("logout:access:" + token);
-
-                String blackList = redisService.getData("blackList:" + email);
-
-                if (logoutToken != null) {
-                    log.warn("[로그아웃 유저 접근]: {}", email );
-
-                    setErrorResponse(response, LOGOUT_USER);
-                    return;
-                }
-
-                if (blackList != null) {
-                    log.warn("[블랙리스트 유저 접근]: {}", email);
-
-                    setErrorResponse(response, BLACKLIST_USER);
-                    return;
-                }
+            String email = tokenProvider.getEmailFromToken(token);
 
 
+            String logoutToken = redisService.getData("logout:access:" + token);
 
-                Authentication authentication = tokenProvider.getAuthentication(token);
+            String blackList = redisService.getData("blackList:" + email);
 
-                log.info("인증 객체 principal: {}", authentication.getPrincipal());
+            if (logoutToken != null) {
+                log.warn("[로그아웃 유저 접근]: {}", email);
 
-                if (authentication != null) {
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
-
-
-                filterChain.doFilter(request, response);
-
+                setErrorResponse(response, LOGOUT_USER);
+                return;
             }
+
+            if (blackList != null) {
+                log.warn("[블랙리스트 유저 접근]: {}", email);
+
+                setErrorResponse(response, BLACKLIST_USER);
+                return;
+            }
+
+
+            Authentication authentication = tokenProvider.getAuthentication(token);
+
+
+            if (authentication != null) {
+                log.info("인증 객체 principal: {}", authentication.getPrincipal());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+
+            filterChain.doFilter(request, response);
+
 
         } catch (CustomException e) {
             log.warn("JWT 검증 실패: {}", e.getErrorCode().getErrorMessage());
@@ -99,8 +100,6 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
             setErrorResponse(response, INTERNAL_SERVER_ERROR);
             return;
         }
-
-
 
 
     }
@@ -116,7 +115,7 @@ public class AuthentificationFilter  extends OncePerRequestFilter {
         return null;
     }
 
-    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(errorCode.getStatusCode());
 

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -105,7 +105,7 @@ public class TokenProvider {
         );
     }
 
-    public boolean validateToken(String token) {
+    public void validateToken(String token) {
 
         try {
 
@@ -113,11 +113,15 @@ public class TokenProvider {
                     .build()
                     .parseClaimsJws(token);
 
-            return !claims.getBody().getExpiration().before(new Date());
+            if (claims.getBody().getExpiration().before(new Date())) {
+                throw new CustomException(EXPIRED_TOKEN);
+            }
 
         } catch (IllegalArgumentException e) {
             throw new CustomException(NOT_FOUND_TOKEN);
         } catch (MalformedJwtException e) {
+            throw new CustomException(INVALID_TOKEN);
+        } catch (UnsupportedJwtException e) {
             throw new CustomException(UNSUPPORTED_TOKEN);
         } catch (ExpiredJwtException e) {
             throw new CustomException(EXPIRED_TOKEN);

--- a/src/main/java/com/example/basketballmatching/global/service/MailService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/MailService.java
@@ -8,6 +8,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -75,7 +76,7 @@ public class MailService {
 
             log.info("이메일 인증번호 전송완료.");
 
-        } catch (MessagingException e) {
+        } catch (MessagingException  | MailException e) {
             log.error("이메일 전송 오류 : {}", e.getMessage());
             throw new CustomException(INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/example/basketballmatching/global/service/MailService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/MailService.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
@@ -37,7 +38,6 @@ public class MailService {
 
 
     @Async
-    @Transactional
     public void sendAuthMail(String email) {
 
         String code = createRandomCode();
@@ -85,7 +85,6 @@ public class MailService {
     }
 
     @Async
-    @Transactional
     public void sendPasswordAuthCode(String email) {
 
         UserEntity userEntity = userRepository.findByEmail(email)
@@ -156,7 +155,7 @@ public class MailService {
 
     private String createRandomCode() {
 
-        Random random = new Random();
+        SecureRandom random = new SecureRandom();
 
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/EditUserDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,8 @@ public class EditUserDto {
 
 
     @Schema(name = "닉네임", example = "커리", defaultValue = "커리")
+    @Size(min = 2, max = 12, message = "닉네임은 2~12자여야 합니다.")
+    @Pattern(regexp = "^(?!\\s*$).+", message = "닉네임은 공백만 입력할 수 없습니다.")
     private String nickname;
 
     @Schema(description = "휴대폰 번호", example = "010-1111-0000")

--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -7,10 +7,7 @@ import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -45,17 +42,19 @@ public class SignUpDto {
 
         @Schema(description = "닉네임", example = "커리")
         @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 12, message = "닉네임은 2~12자여야 합니다.")
         private String nickname;
 
         @Schema(description = "이름", example = "서장훈")
         @NotBlank(message = "이름을 입력해주세요.")
         private String name;
 
-        @Schema(description = "생년월일", example = "19970101")
+        @Schema(description = "생년월일", example = "1997-01-01")
         @JsonFormat(
             shape = JsonFormat.Shape.STRING,
                 pattern = "yyyy-MM-dd"
         )
+        @NotNull(message = "생년월일을 입력해주세요.")
         private LocalDate birth;
 
         @Schema(description = "휴대폰 번호", example = "010-1111-0000")
@@ -114,7 +113,7 @@ public class SignUpDto {
         @Schema(description = "이름", example = "서장훈")
         private String name;
 
-        @Schema(description = "생년월일", example = "19970101")
+        @Schema(description = "생년월일", example = "1997-01-01")
         private LocalDate birth;
 
         @Schema(description = "휴대폰 번호", example = "010-1111-0000")

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -9,6 +9,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
+
     boolean existsByNickname(String nickname);
 
     Optional<UserEntity> findByEmailAndDeletedDateTimeIsNull(String email);

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -126,7 +126,7 @@ public class UserServiceImpl implements UserService {
      * 회원 정보 조회
      */
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse<UserDto> getUserInfo(Long userId) {
 
         log.info("[유저 정보 조회 시작] userId : {}", userId);
@@ -151,10 +151,12 @@ public class UserServiceImpl implements UserService {
 
         UserEntity userEntity = getUser(userId);
 
-        boolean exists = userRepository.existsByNickname(editUserDto.getNickname());
 
-        if (editUserDto.getNickname() != null && exists) {
-            throw new CustomException(ALREADY_EXIST_NICKNAME);
+        if (editUserDto.getNickname() != null) {
+            boolean exists = userRepository.existsByNicknameAndUserIdNot(editUserDto.getNickname(), userEntity.getUserId());
+            if (exists) {
+                throw new CustomException(ALREADY_EXIST_NICKNAME);
+            }
         }
 
         userEntity.editUserInfo(editUserDto);

--- a/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/impl/AuthServiceImplTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local-test")
+@ActiveProfiles("test-only")
 class AuthServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImplTest.java
@@ -1,20 +1,17 @@
 package com.example.basketballmatching.blackList.service.impl;
 
 import com.example.basketballmatching.blackList.dto.BlackListDto;
-import com.example.basketballmatching.blackList.entity.BlackListEntity;
 import com.example.basketballmatching.blackList.repository.BlackListRepository;
 import com.example.basketballmatching.blackList.service.BlackListService;
 import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
-import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.report.dto.CreateReportDto;
 import com.example.basketballmatching.report.entity.ReportEntity;

--- a/src/test/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImplTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local-test")
+@ActiveProfiles("test-only")
 class BlackListServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImplTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local-test")
+@ActiveProfiles("test-only")
 class GameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImplTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local-test")
+@ActiveProfiles("test-only")
 class ParticipantGameServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImplTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local-test")
+@ActiveProfiles("test-only")
 class GameUserServiceImplTest {
 
     @Autowired

--- a/src/test/java/com/example/basketballmatching/global/service/MailServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/global/service/MailServiceUnitTest.java
@@ -1,0 +1,165 @@
+package com.example.basketballmatching.global.service;
+
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.repository.UserRepository;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.util.Properties;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.INVALID_CODE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceUnitTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private RedisService redisService;
+
+
+
+    @InjectMocks
+    private MailService mailService;
+
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 테스트 - 전송 호출 확인 및 Redis 인증 코드 저장 확인")
+    void sendAuthMailTest() {
+        // given
+
+        String email = "test@test.com";
+
+        Session session = Session.getInstance(new Properties());
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+
+        mailService.sendAuthMail(email);
+        verify(javaMailSender).send(mimeMessage);
+
+
+        // then
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> ttlCaptor = ArgumentCaptor.forClass(Long.class);
+
+        verify(redisService).setDataExpireMinutes(keyCaptor.capture(), codeCaptor.capture(), ttlCaptor.capture());
+
+        assertEquals("email:auth:" + email, keyCaptor.getValue());
+        assertEquals(3L, ttlCaptor.getValue());
+
+        String code = codeCaptor.getValue();
+
+        assertNotNull(code);
+        assertEquals(6, code.length());
+
+
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 실패 테스트 - 메일 전송 실패")
+    void sendAuthMailFailTest_Mail_Exception() {
+        // given
+
+        String email = "test@test.com";
+
+        Session session = Session.getInstance(new Properties());
+        MimeMessage mimeMessage = new MimeMessage(session);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+
+        doThrow(new MailSendException("smtp fail")).when(javaMailSender).send(mimeMessage);
+
+        // then
+
+        CustomException exception = assertThrows(CustomException.class, () -> mailService.sendAuthMail(email));
+
+        verify(redisService, never()).setDataExpireMinutes(anyString(), anyString(), anyLong());
+        assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.getErrorCode());
+
+
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 테스트")
+    void verifyEmailAuthTest() {
+        // given
+
+        String email = "test@test.com";
+        String code = "123456";
+
+        when(redisService.getData("email:auth:" + email)).thenReturn(code);
+
+
+
+        // when
+
+        CheckResponse checkResponse = mailService.verifyEmailAuth(email, code);
+        // then
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> ttlCaptor = ArgumentCaptor.forClass(Long.class);
+
+
+        verify(redisService).deleteData("email:auth:" + email);
+        verify(redisService).setDataExpireMinutes(keyCaptor.capture(), valueCaptor.capture(), ttlCaptor.capture());
+
+
+
+        assertTrue(checkResponse.isSuccess());
+        assertEquals("이메일 인증에 성공하였습니다.", checkResponse.getMessage());
+
+        assertEquals("email:auth:verified:" + email, keyCaptor.getValue());
+        assertEquals(code, valueCaptor.getValue());
+        assertEquals(10L, ttlCaptor.getValue());
+
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 실패 테스트 - Redis에 저장된 코드가 없는 경우")
+    void verifyEmailAuthFailTest_INVALID_CODE() {
+        // given
+
+        String email = "test@test.com";
+        String code = "123456";
+
+        when(redisService.getData("email:auth:" + email)).thenReturn(null);
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> mailService.verifyEmailAuth(email, code));
+
+
+        // then
+
+        assertEquals(INVALID_CODE, exception.getErrorCode());
+
+        verify(redisService, never()).deleteData(anyString());
+        verify(redisService, never()).setDataExpireMinutes(anyString(), anyString(), anyLong());
+
+    }
+
+
+}

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
@@ -1,20 +1,29 @@
 package com.example.basketballmatching.user.service.impl;
 
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
-import com.example.basketballmatching.user.service.UserService;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.ALREADY_EXIST_EMAIL;
-import static org.mockito.Mockito.when;
+import java.time.LocalDate;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -23,6 +32,12 @@ class UserServiceImplUnitTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private UserServiceImpl userService;
@@ -79,9 +94,150 @@ class UserServiceImplUnitTest {
 
         // when
 
+        when(userRepository.existsByNickname(nickname)).thenReturn(false);
+
+        CheckResponse checkResponse = userService.checkNickname(nickname);
+
         // then
+        assertEquals(true, checkResponse.isSuccess());
+        assertEquals("사용가능한 닉네임입니다.", checkResponse.getMessage());
+
 
     }
 
+    @Test
+    @DisplayName("닉네임 중복 확인 실패 테스트")
+    void checkNicknameFailTest_ALREADY_EXIST_NICKNAME() {
+        // given
+
+        String nickname = "test";
+
+
+        // when
+        when(userRepository.existsByNickname(nickname)).thenReturn(true);
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.checkNickname(nickname));
+
+        // then
+
+        assertEquals(ALREADY_EXIST_NICKNAME, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 테스트")
+    void signUpTest() {
+        // given
+        SignUpDto.Request req = SignUpDto.Request.builder()
+                .email("test@test.com")
+                .password("Test@1234")
+                .checkPassword("Test@1234")
+                .nickname("커리")
+                .name("서장훈")
+                .birth(LocalDate.of(1997,1,1))
+                .phone("010-1111-0000")
+                .address("서울")
+                .position(Position.NONE)
+                .genderType(GenderType.MALE)
+                .build();
+
+        when(userRepository.existsByEmail(req.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(req.getNickname())).thenReturn(false);
+        when(redisService.getData("email:auth:verified:" + req.getEmail())).thenReturn("123456");
+
+        when(passwordEncoder.encode(req.getPassword())).thenReturn("ENCODED");
+
+        ArgumentCaptor<UserEntity> userCaptor = ArgumentCaptor.forClass(UserEntity.class);
+
+        when(userRepository.save(userCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+
+        // when
+        CommonResponse<SignUpDto.Response> commonResponse = userService.signUp(req);
+
+
+        // then
+        verify(redisService).deleteData("email:auth:verified:" + req.getEmail());
+        verify(passwordEncoder).encode(req.getPassword());
+        verify(userRepository).save(any(UserEntity.class));
+
+        UserEntity saved = userCaptor.getValue();
+
+        assertEquals(req.getEmail(), saved.getEmail());
+        assertEquals("ENCODED",saved.getPassword());
+        assertEquals(req.getNickname(), saved.getNickname());
+
+
+        assertEquals("회원가입에 성공하였습니다.", commonResponse.getMessage());
+        assertNotNull(commonResponse.getData());
+
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 실패 테스트 - 이메일 중복")
+    void signUpFailTest_ALREADY_EXIST_EMAIL() {
+        // given
+
+        SignUpDto.Request req = SignUpDto.Request.builder()
+                .email("test@test.com")
+                .password("Test@1234")
+                .checkPassword("Test@1234")
+                .nickname("커리")
+                .name("서장훈")
+                .birth(LocalDate.of(1997,1,1))
+                .phone("010-1111-0000")
+                .address("서울")
+                .position(Position.NONE)
+                .genderType(GenderType.MALE)
+                .build();
+
+        when(userRepository.existsByEmail(req.getEmail())).thenReturn(true);
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.signUp(req));
+
+        // then
+
+        assertEquals(ALREADY_EXIST_EMAIL, exception.getErrorCode());
+        verify(redisService, never()).getData(any());
+        verify(userRepository, never()).save(any());
+        verify(passwordEncoder, never()).encode(anyString());
+
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 실패 테스트 - Redis의 값이 저장되어있지 않은 경우")
+    void signUpFailTest_EMAIL_NOT_VERIFIED() {
+        // given
+        SignUpDto.Request req = SignUpDto.Request.builder()
+                .email("test@test.com")
+                .password("Test@1234")
+                .checkPassword("Test@1234")
+                .nickname("커리")
+                .name("서장훈")
+                .birth(LocalDate.of(1997,1,1))
+                .phone("010-1111-0000")
+                .address("서울")
+                .position(Position.NONE)
+                .genderType(GenderType.MALE)
+                .build();
+
+        when(redisService.getData("email:auth:verified:" + req.getEmail())).thenReturn(null);
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.signUp(req));
+
+        // then
+
+        assertEquals(EMAIL_NOT_VERIFIED, exception.getErrorCode());
+        verify(redisService).getData("email:auth:verified:" + req.getEmail());
+        verify(redisService, never()).deleteData("email:auth:verified:" + req.getEmail());
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(userRepository, never()).save(any(UserEntity.class));
+
+    }
 
 }

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
@@ -1,0 +1,87 @@
+package com.example.basketballmatching.user.service.impl;
+
+import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.ALREADY_EXIST_EMAIL;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplUnitTest {
+
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("이메일 중복 확인")
+    void checkEmailTest() {
+        // given
+
+        String email = "test@test.com";
+
+        when(userRepository.existsByEmail(email)).thenReturn(false);
+
+
+        // when
+
+        CheckResponse checkResponse = userService.checkEmail(email);
+
+
+        // then
+
+        assertEquals(true, checkResponse.isSuccess());
+        assertEquals("사용가능한 이메일입니다.", checkResponse.getMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("이매일 중복 확인 실패 테스트")
+    void checkEmailFailTest_ALREADY_EXIST_EMAIL() {
+        // given
+
+        String email = "test@test.com";
+
+
+        // when
+        when(userRepository.existsByEmail(email)).thenReturn(true);
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.checkEmail(email));
+
+        // then
+
+        assertEquals(ALREADY_EXIST_EMAIL, exception.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인 테스트")
+    void checkNicknameTest() {
+        // given
+
+        String nickname = "test";
+
+
+        // when
+
+        // then
+
+    }
+
+
+}

--- a/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/impl/UserServiceImplUnitTest.java
@@ -1,14 +1,23 @@
 package com.example.basketballmatching.user.service.impl;
 
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.security.TokenProvider;
 import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.dto.ChangePasswordDto;
+import com.example.basketballmatching.user.dto.EditUserDto;
 import com.example.basketballmatching.user.dto.SignUpDto;
+import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +28,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,8 +51,25 @@ class UserServiceImplUnitTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private ParticipantGameRepository participantGameRepository;
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @Mock
+    private GameQueryRepository gameQueryRepository;
+
     @InjectMocks
     private UserServiceImpl userService;
+
+    @InjectMocks
+    private UserCacheService userCacheService;
+
+
 
     @Test
     @DisplayName("이메일 중복 확인")
@@ -240,4 +269,265 @@ class UserServiceImplUnitTest {
 
     }
 
+
+    @Test
+    @DisplayName("회원 정보 조회 테스트")
+    void getUserInfoTest() {
+        // given
+
+        Long userId = 1L;
+
+        UserEntity userEntity = UserEntity.builder()
+                .userId(1L)
+                .email("test@test.com")
+                .nickname("커리")
+                .name("testName")
+                .birth(LocalDate.parse("1997-01-01"))
+                .phone("010-0000-0000")
+                .address("testAddress")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .genderType(GenderType.MALE)
+                .build();
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)).thenReturn(Optional.of(userEntity));
+
+
+        // when
+
+        UserDto userDto = userCacheService.getUserDtoCached(userId);
+
+
+        // then
+
+
+        assertNotNull(userDto);
+        verify(userRepository, times(1)).findByUserIdAndDeletedDateTimeIsNull(userId);
+
+
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 실패 테스트 - USER_NOT_FOUND")
+    void getUserInfoFailTest() {
+        // given
+
+        Long userId = 1L;
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> userCacheService.getUserDtoCached(userId));
+
+        // then
+
+        assertEquals(USER_NOT_FOUND, exception.getErrorCode());
+
+    }
+
+
+    @Test
+    @DisplayName("회원 정보 수정 테스트")
+    void editUserInfoTest() {
+        // given
+
+        Long userId = 1L;
+
+        UserEntity userEntity = UserEntity.builder()
+                .userId(1L)
+                .email("test@test.com")
+                .nickname("커리")
+                .name("testName")
+                .birth(LocalDate.parse("1997-01-01"))
+                .phone("010-0000-0000")
+                .address("testAddress")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .genderType(GenderType.MALE)
+                .build();
+
+        EditUserDto editUserDto = EditUserDto.builder()
+                .nickname("커리2")
+                .position(Position.CENTER)
+                .build();
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)).thenReturn(Optional.of(userEntity));
+        when(userRepository.existsByNicknameAndUserIdNot(editUserDto.getNickname(), userId)).thenReturn(false);
+
+        // when
+
+        CommonResponse<UserDto> commonResponse = userService.editUserInfo(userId, editUserDto);
+
+        // then
+
+        assertEquals("회원정보 수정이 완료되었습니다.", commonResponse.getMessage());
+        assertNotNull(commonResponse.getData());
+
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 실패 테스트 - 중복 닉네임 존재")
+    void editUserInfoFailTest_ALREADY_EXIST_NICKNAME() {
+        // given
+
+        Long userId = 1L;
+
+        UserEntity userEntity = UserEntity.builder()
+                .userId(1L)
+                .email("test@test.com")
+                .nickname("커리2")
+                .name("testName")
+                .birth(LocalDate.parse("1997-01-01"))
+                .phone("010-0000-0000")
+                .address("testAddress")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .genderType(GenderType.MALE)
+                .build();
+
+        EditUserDto editUserDto = EditUserDto.builder()
+                .nickname("커리2")
+                .position(Position.CENTER)
+                .build();
+
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)).thenReturn(Optional.of(userEntity));
+        when(userRepository.existsByNicknameAndUserIdNot(editUserDto.getNickname(), userId)).thenReturn(true);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> userService.editUserInfo(userId, editUserDto));
+
+        // then
+
+        assertEquals(ALREADY_EXIST_NICKNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 테스트")
+    void changePasswordTest() {
+        // given
+
+        Long userId = 1L;
+
+        UserEntity userEntity = UserEntity.builder()
+                .userId(1L)
+                .password("ENCODED_OLD")
+                .build();
+
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("old@123")
+                .newPassword("test@12")
+                .newCheckPassword("test@12")
+                .build();
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)).thenReturn(Optional.of(userEntity));
+        when(passwordEncoder.matches("old@123", "ENCODED_OLD")).thenReturn(true);
+
+        when(passwordEncoder.encode("test@12"))
+                .thenReturn("ENCODED_NEW");
+        ArgumentCaptor<UserEntity> captor = ArgumentCaptor.forClass(UserEntity.class);
+
+        when(userRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+
+        CheckResponse checkResponse = userService.changePassword(userId, changePasswordDto);
+
+        // then
+
+
+
+        verify(passwordEncoder).encode("test@12");
+        verify(userRepository).save(any(UserEntity.class));
+
+        assertEquals("ENCODED_NEW", captor.getValue().getPassword());
+        assertEquals("비밀번호 변경을 완료하였습니다.", checkResponse.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("회원 탈퇴 테스트")
+    void deleteUserTest() {
+        // given
+
+        Long userId = 1L;
+        String token = "accessToken";
+        long remainingMills = 10_000L;
+
+        UserEntity userEntity = UserEntity.builder()
+                .userId(userId)
+                .email("test@test.com")
+                .build();
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)).thenReturn(Optional.of(userEntity));
+        when(tokenProvider.getRemainingTime(token)).thenReturn(remainingMills);
+
+        when(gameRepository.findByUserEntity_UserIdAndDeletedDateTimeIsNull(userId))
+                .thenReturn(List.of());
+
+        when(participantGameRepository.findByUserEntity_UserIdAndParticipantGameStatusIn(eq(userId), eq(List.of(ParticipantGameStatus.ACCEPT, ParticipantGameStatus.APPLY))))
+                .thenReturn(List.of());
+
+
+        ArgumentCaptor<UserEntity> captor = ArgumentCaptor.forClass(UserEntity.class);
+
+        when(userRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+
+        CheckResponse checkResponse = userService.deleteUser(userId, token);
+
+        // then
+
+        verify(tokenProvider).getRemainingTime(token);
+
+        verify(redisService).setDataExpireMillis(
+                "logout:access:" + token,
+                "LOGOUT",
+                remainingMills
+        );
+
+        verify(redisService).deleteData("refreshToken:" + userEntity.getEmail());
+
+        UserEntity saved = captor.getValue();
+
+        assertNotNull(saved.getDeletedDateTime());
+
+        assertTrue(checkResponse.isSuccess());
+        assertEquals("회원탈퇴에 성공하였습니다.", checkResponse.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패 테스트 - 토큰이 null인 경우")
+    void deleteUserFailTest_NOT_FOUND_TOKEN() {
+        // given
+        Long userId = 1L;
+
+        UserEntity user = UserEntity.builder()
+                .userId(userId)
+                .email("test@test.com")
+                .build();
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(userId))
+                .thenReturn(Optional.of(user));
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> userService.deleteUser(userId, null));
+
+        // then
+
+        assertEquals(NOT_FOUND_TOKEN, exception.getErrorCode());
+
+        verifyNoInteractions(tokenProvider, redisService);
+        verifyNoInteractions(gameRepository, participantGameRepository, gameQueryRepository);
+        verify(userRepository, never()).save(any(UserEntity.class));
+    }
+
+
+
 }
+


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS



### 🚀 TO-BE
- `UserServiceImpl` 중심의 **단위 테스트(Mockito + JUnit5)** 추가로 핵심 유저 기능을 자동 검증하도록 개선
- 대표 성공/실패 케이스를 포함해, 예외 코드(`ErrorCode`) 기반으로 기대 동작을 명확히 고정
- Redis/TokenProvider/Repository 호출 여부를 `verify()`로 검증하여 부작용(side-effect)도 테스트로 커버

###🧪 테스트 범위

### ✅ 포함된 테스트
- 이메일 중복 확인: 성공 / 실패(ALREADY_EXIST_EMAIL)
- 닉네임 중복 확인: 성공 / 실패(ALREADY_EXIST_NICKNAME)
- 회원가입: 성공 / 실패(이메일 중복, EMAIL_NOT_VERIFIED)
- 회원 정보 조회: 성공 / 실패(USER_NOT_FOUND)  
  - 캐시 서비스(`UserCacheService`) 조회 로직 포함
- 회원 정보 수정: 성공 / 실패(중복 닉네임)
- 비밀번호 변경: 성공
- 회원 탈퇴: 성공 / 실패(NOT_FOUND_TOKEN)  
  - 토큰 만료시간 조회 및 Redis 로그아웃 처리 검증 포함
---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (단위 테스트 기반)
- [x] 예외 처리(ErrorCode) 기대값 검증 완료

---
