### PR TITLE
[test] : 경기 참가자 API 단위테스트 작성

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.APPLY;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -49,9 +51,21 @@ public class ParticipantGameEntity extends BaseEntity {
     @JoinColumn(nullable = false)
     private UserEntity userEntity;
 
+    public static ParticipantGameEntity createApply(GameEntity gameEntity, UserEntity userEntity) {
+
+        return ParticipantGameEntity.builder()
+                .participantGameStatus(APPLY)
+                .gameEntity(gameEntity)
+                .userEntity(userEntity)
+                .build();
+
+
+    }
+
     public ParticipantGameEntity toGameCreatorEntity(
             GameEntity gameEntity, UserEntity userEntity
     ) {
+
 
         return ParticipantGameEntity.builder()
                 .participantGameStatus(ParticipantGameStatus.ACCEPT)
@@ -61,11 +75,17 @@ public class ParticipantGameEntity extends BaseEntity {
                 .build();
     }
 
+    public void reApply() {
+        this.canceledDateTime = null;
+        this.participantGameStatus = ParticipantGameStatus.APPLY;
+
+    }
+
+
     public void setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime acceptDateTime) {
         this.participantGameStatus = participantGameStatus;
         this.acceptDateTime = acceptDateTime;
     }
-
 
     public void setParticipantGameStatusAndRejectDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime rejectDateTime) {
         this.participantGameStatus = participantGameStatus;

--- a/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/repository/ParticipantGameRepository.java
@@ -30,5 +30,6 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
     List<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatusIn(Long userId, List<ParticipantGameStatus> statuses);
 
+    boolean existsByUserEntity_UserIdAndGameEntity_GameIdAndParticipantGameStatus(Long userId,Long gameId, ParticipantGameStatus participantGameStatus);
 
 }

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -72,7 +72,6 @@ public class GameUserServiceImpl implements GameUserService {
         participantGameRepository.save(entity);
 
 
-
         gameEntity.increaseParticipantCount();
 
 
@@ -214,7 +213,6 @@ public class GameUserServiceImpl implements GameUserService {
 
         if (Objects.equals(userEntity.getUserId(), gameEntity.getUserEntity().getUserId())) {
             throw new CustomException(NOT_APPLY_GAME_CREATOR);
-
         }
 
         if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(),gameEntity.getGameId())) {

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -59,30 +59,32 @@ public class GameUserServiceImpl implements GameUserService {
 
         GameEntity gameEntity = getGameWithLock(gameId);
 
-        validateParticipantInfo(userEntity, gameEntity);
+        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+                .orElse(null);
+
+        validateParticipantInfo(userEntity, gameEntity, participantGameEntity);
+
+        if (participantGameEntity == null) {
+
+            participantGameEntity = ParticipantGameEntity.createApply(gameEntity, userEntity);
 
 
+            participantGameRepository.save(participantGameEntity);
 
-        ParticipantGameEntity entity = ParticipantGameEntity.builder()
-                .participantGameStatus(APPLY)
-                .gameEntity(gameEntity)
-                .userEntity(userEntity)
-                .build();
-
-        participantGameRepository.save(entity);
+            gameEntity.increaseParticipantCount();
 
 
-        gameEntity.increaseParticipantCount();
+        } else if (participantGameEntity.getParticipantGameStatus().equals(CANCEL)) {
+
+            participantGameEntity.reApply();
+            gameEntity.increaseParticipantCount();
+        }
 
 
+        ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(participantGameEntity);
 
 
-
-
-        ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(entity);
-
-
-        log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, entity.getParticipantGameId());
+        log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, participantGameEntity.getParticipantGameId());
 
         return CommonResponse.of("경기 신청이 완료되었습니다.", participantDto);
     }
@@ -101,7 +103,6 @@ public class GameUserServiceImpl implements GameUserService {
         ParticipantGameEntity participantGameEntity = getParticipantGame(userId, gameId);
 
 
-
         LocalDateTime now = LocalDateTime.now();
 
         if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
@@ -117,18 +118,13 @@ public class GameUserServiceImpl implements GameUserService {
         }
 
 
-
         participantGameEntity.setParticipantGameStatusAndCanceledDateTime(CANCEL, now);
-
-        gameEntity.decreaseParticipantCount();
-        gameRepository.save(gameEntity);
 
 
 
 
         return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
     }
-
 
 
     /**
@@ -162,9 +158,6 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
-
-
-
     @Override
     @Transactional(readOnly = true)
     public CommonResponse<GameUserLevelDto> getMyGameUserLevel(Long userId) {
@@ -178,7 +171,6 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
-
     private UserEntity getUser(Long userId) {
         return userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -189,11 +181,6 @@ public class GameUserServiceImpl implements GameUserService {
                 .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
     }
 
-    private GameEntity getGame(Long gameId) {
-        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
-    }
-
 
     private GameEntity getGameWithLock(Long gameId) {
         return gameRepository.findByGameIdWithLock(gameId)
@@ -201,13 +188,7 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
-
-
-
-
-
-
-    private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity) {
+    private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity, ParticipantGameEntity participantGameEntity) {
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -215,9 +196,22 @@ public class GameUserServiceImpl implements GameUserService {
             throw new CustomException(NOT_APPLY_GAME_CREATOR);
         }
 
-        if (participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(userEntity.getUserId(),gameEntity.getGameId())) {
-            throw new CustomException(ALREADY_APPLY_GAME_USER);
+        if (participantGameEntity != null) {
+
+            if (participantGameEntity.getParticipantGameStatus().equals(KICKOUT)) {
+                throw new CustomException(NOT_APPLY_KICKOUT_USER);
+            }
+
+            if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
+                throw new CustomException(ALREADY_ACCEPT_USER);
+            }
+
+            if (participantGameEntity.getParticipantGameStatus().equals(APPLY)) {
+                throw new CustomException(ALREADY_APPLY_GAME_USER);
+            }
+
         }
+
 
         if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
             throw new CustomException(FULL_HEADCOUNT_GAME);
@@ -228,7 +222,7 @@ public class GameUserServiceImpl implements GameUserService {
         }
 
         if (gameEntity.getMatchGenderType().equals(MatchGenderType.FEMALE_ONLY) &&
-        userEntity.getGenderType().equals(GenderType.MALE)) {
+                userEntity.getGenderType().equals(GenderType.MALE)) {
             throw new CustomException(ONLY_FEMALE_GAME);
         }
 
@@ -237,7 +231,6 @@ public class GameUserServiceImpl implements GameUserService {
                 userEntity.getGenderType().equals(GenderType.FEMALE)) {
             throw new CustomException(ONLY_MALE_GAME);
         }
-
 
 
     }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     ONLY_FEMALE_GAME(HttpStatus.FORBIDDEN, "여성 유저만 신청가능합니다."),
     ONLY_MALE_GAME(HttpStatus.FORBIDDEN, "남성 유저만 신청가능합니다."),
     NOT_APPLY_USER(HttpStatus.BAD_REQUEST, "경기 참가 신청을 한 유저가 아닙니다."),
+    NOT_APPLY_KICKOUT_USER(HttpStatus.BAD_REQUEST, "강퇴당한 유저는 신청 불가입니다."),
     ALREADY_START_GAME(HttpStatus.CONFLICT, "이미 시작한 경기입니다."),
     PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "경기 참가자를 찾을 수 없습니다."),
     ALREADY_ACCEPT_USER(HttpStatus.CONFLICT, "이미 수락된 참가자입니다."),

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpUnitTest.java
@@ -1,0 +1,181 @@
+package com.example.basketballmatching.gameUsers.service.impl;
+
+
+import com.example.basketballmatching.gameCreator.entity.GameEntity;
+import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameRepository;
+import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
+import com.example.basketballmatching.gameCreator.type.FieldStatus;
+import com.example.basketballmatching.gameCreator.type.MatchFormat;
+import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GameUserServiceImpUnitTest {
+
+
+    @Mock
+    private ParticipantGameRepository participantGameRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @InjectMocks
+    private GameUserServiceImpl gameUserService;
+
+    private UserEntity creator;
+
+
+    private UserEntity participant;
+
+    private GameEntity gameEntity;
+
+    @BeforeEach
+    public void setUp() {
+        creator = UserEntity.builder()
+                .userId(1L)
+                .emailAuth(true)
+                .userType(UserType.USER)
+                .build();
+
+        participant = UserEntity.builder()
+                .userId(2L)
+                .emailAuth(true)
+                .genderType(GenderType.MALE)
+                .userType(UserType.USER)
+                .build();
+
+        gameEntity = GameEntity.builder()
+                .gameId(1L)
+                .title("주말 3대3 같이 하실 분")
+                .content("초보~중수 환영 / 즐겜 / 노쇼 금지")
+                .headCount(6) // 3vs3 최소 6
+                .fieldStatus(FieldStatus.OUTDOOR) // 예시 (실제 enum에 맞게)
+                .matchGenderType(MatchGenderType.MIXED) // 예시
+                .startDateTime(LocalDateTime.of(2025, 12, 20, 19, 0))
+                .endDateTime(LocalDateTime.of(2025, 12, 20, 20, 30))
+                .placeName("잠실종합운동장 농구장")
+                .address("서울특별시 송파구 올림픽로 25") // CityName.getCityName(address)에서 뽑을 주소
+                .latitude(37.515)   // 예시
+                .longitude(127.073) // 예시
+                .matchFormat(MatchFormat.THREE_ON_THREE)
+                .userEntity(creator)
+                .build();
+    }
+
+    @Test
+    @DisplayName("경기 참가 테스트")
+    void applyGameTest() {
+        // given
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(participant.getUserId()))
+                .thenReturn(Optional.of(participant));
+
+        when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
+                .thenReturn(Optional.of(gameEntity));
+
+        when(participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId()))
+                .thenReturn(false);
+
+        when(participantGameRepository.save(any(ParticipantGameEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+
+
+
+        // when
+
+        CommonResponse<ApplyGameUserDto> commonResponse = gameUserService.applyGame(gameEntity.getGameId(), participant.getUserId());
+
+        // then
+
+        ArgumentCaptor<ParticipantGameEntity> participantCaptor = ArgumentCaptor.forClass(ParticipantGameEntity.class);
+
+
+
+        verify(userRepository).findByUserIdAndDeletedDateTimeIsNull(participant.getUserId());
+        verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
+        verify(participantGameRepository).existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId());
+        verify(participantGameRepository).save(participantCaptor.capture());
+
+        ParticipantGameEntity savedParticipant = participantCaptor.getValue();
+
+        assertEquals("경기 신청이 완료되었습니다.", commonResponse.getMessage());
+        assertEquals(participant.getUserId(), commonResponse.getData().getUserId());
+        assertEquals(gameEntity.getGameId(), commonResponse.getData().getGameId());
+
+        assertEquals(gameEntity.getGameId(), savedParticipant.getGameEntity().getGameId());
+        assertEquals(participant.getUserId(), savedParticipant.getUserEntity().getUserId());
+
+        verifyNoMoreInteractions(userRepository, gameRepository, participantGameRepository);
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 실패 테스트 - 경기 시작 시간 30분전 참가 신청 불가")
+    void applyGameFailTest_NOT_ALLOWED_TO_JOIN() {
+        // given
+
+        LocalDateTime now = LocalDateTime.now();
+
+        gameEntity.setStartDateTime(now.plusMinutes(30));
+        gameEntity.setEndDateTime(now.plusMinutes(70));
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(participant.getUserId()))
+                .thenReturn(Optional.of(participant));
+
+        when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
+                .thenReturn(Optional.of(gameEntity));
+
+        when(participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId()))
+                .thenReturn(false);
+
+
+        // when
+
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameEntity.getGameId(), participant.getUserId()));
+
+
+        // then
+
+        verify(userRepository).findByUserIdAndDeletedDateTimeIsNull(participant.getUserId());
+        verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
+        verify(participantGameRepository).existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId());
+        verify(participantGameRepository, never()).save(any());
+
+        assertEquals(ErrorCode.NOT_ALLOWED_TO_JOIN, exception.getErrorCode());
+
+        verifyNoMoreInteractions(userRepository, gameRepository, participantGameRepository);
+
+    }
+
+}

--- a/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpUnitTest.java
@@ -8,7 +8,9 @@ import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepo
 import com.example.basketballmatching.gameCreator.type.FieldStatus;
 import com.example.basketballmatching.gameCreator.type.MatchFormat;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
+import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
 import com.example.basketballmatching.gameUsers.dto.ApplyGameUserDto;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
@@ -30,8 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
@@ -103,8 +104,8 @@ class GameUserServiceImpUnitTest {
         when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
                 .thenReturn(Optional.of(gameEntity));
 
-        when(participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId()))
-                .thenReturn(false);
+        when(participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId()))
+                .thenReturn(Optional.empty());
 
         when(participantGameRepository.save(any(ParticipantGameEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -123,7 +124,7 @@ class GameUserServiceImpUnitTest {
 
         verify(userRepository).findByUserIdAndDeletedDateTimeIsNull(participant.getUserId());
         verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
-        verify(participantGameRepository).existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId());
+        verify(participantGameRepository).findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId());
         verify(participantGameRepository).save(participantCaptor.capture());
 
         ParticipantGameEntity savedParticipant = participantCaptor.getValue();
@@ -155,8 +156,8 @@ class GameUserServiceImpUnitTest {
         when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
                 .thenReturn(Optional.of(gameEntity));
 
-        when(participantGameRepository.existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId()))
-                .thenReturn(false);
+        when(participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId()))
+                .thenReturn(Optional.empty());
 
 
         // when
@@ -169,7 +170,7 @@ class GameUserServiceImpUnitTest {
 
         verify(userRepository).findByUserIdAndDeletedDateTimeIsNull(participant.getUserId());
         verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
-        verify(participantGameRepository).existsByUserEntity_UserIdAndGameEntity_GameId(participant.getUserId(), gameEntity.getGameId());
+        verify(participantGameRepository).findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId());
         verify(participantGameRepository, never()).save(any());
 
         assertEquals(ErrorCode.NOT_ALLOWED_TO_JOIN, exception.getErrorCode());
@@ -177,5 +178,109 @@ class GameUserServiceImpUnitTest {
         verifyNoMoreInteractions(userRepository, gameRepository, participantGameRepository);
 
     }
+
+    @Test
+    @DisplayName("경기 참가 실패 테스트 - 경기 개설자 참가 신청 시 참가 신청 불가")
+    void applyGameFailTest_NOT_APPLY_GAME_CREATOR() {
+        // given
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(creator.getUserId()))
+                .thenReturn(Optional.of(creator));
+
+        when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
+                .thenReturn(Optional.of(gameEntity));
+
+        when(participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), creator.getUserId()))
+                .thenReturn(Optional.empty());
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.applyGame(gameEntity.getGameId(), creator.getUserId()));
+
+        // then
+
+        verify(userRepository).findByUserIdAndDeletedDateTimeIsNull(creator.getUserId());
+        verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
+        verify(participantGameRepository).findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), creator.getUserId());
+        verify(participantGameRepository, never()).save(any());
+
+        assertEquals(ErrorCode.NOT_APPLY_GAME_CREATOR, exception.getErrorCode());
+
+        verifyNoMoreInteractions(userRepository, participantGameRepository, gameRepository);
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 테스트")
+    void cancelGame() {
+        // given
+
+        ParticipantGameEntity applyUser = ParticipantGameEntity.createApply(gameEntity, participant);
+
+        applyUser.setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus.ACCEPT, LocalDateTime.now());
+
+        when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
+                .thenReturn(Optional.of(gameEntity));
+
+        when(participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(
+                gameEntity.getGameId(), participant.getUserId()
+        )).thenReturn(Optional.of(applyUser));
+
+
+        // when
+
+        CheckResponse checkResponse = gameUserService.cancelGame(participant.getUserId(), gameEntity.getGameId());
+
+
+
+        // then
+
+        assertTrue(checkResponse.isSuccess());
+        assertEquals("경기 취소가 완료되었습니다.", checkResponse.getMessage());
+
+        assertEquals(ParticipantGameStatus.CANCEL, applyUser.getParticipantGameStatus());
+
+        verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
+        verify(participantGameRepository).findByGameEntity_GameIdAndUserEntity_UserId(
+                gameEntity.getGameId(), participant.getUserId()
+        );
+        verifyNoMoreInteractions(gameRepository, participantGameRepository);
+
+
+    }
+
+    @Test
+    @DisplayName("경기 취소 실패 테스트 - 이미 취소한 유저 취소 불가")
+    void cancelGameFailTest_ALREADY_CANCELED_USER() {
+        // given
+        ParticipantGameEntity applyUser = ParticipantGameEntity.createApply(gameEntity, participant);
+
+        applyUser.setParticipantGameStatusAndCanceledDateTime(ParticipantGameStatus.CANCEL, LocalDateTime.now());
+
+        when(gameRepository.findByGameIdWithLock(gameEntity.getGameId()))
+                .thenReturn(Optional.of(gameEntity));
+
+        when(participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(
+                gameEntity.getGameId(), participant.getUserId()
+        )).thenReturn(Optional.of(applyUser));
+
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameUserService.cancelGame(participant.getUserId(), gameEntity.getGameId()));
+
+        // then
+
+        verify(gameRepository).findByGameIdWithLock(gameEntity.getGameId());
+        verify(participantGameRepository).findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participant.getUserId());
+
+        assertEquals(ErrorCode.ALREADY_CANCELED_USER, exception.getErrorCode());
+
+        verifyNoMoreInteractions(gameRepository, participantGameRepository);
+
+
+    }
+
+
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 참가자 API **통합테스트** 로만 존재

### 🚀 TO-BE
✅ 경기 참가 로직 리펙토링
- 경기 참가 신청 로직의 흐름을 정리하고, 참가자 상태에 따라 동작을 명확히 분기함
- 참가 로직에서 **객체 생성 책임을 엔티티 정적 팩토리**로 분리

✅ 경기 참가/ 취소 단위 테스트 추가 및 수정
- Mockito 기반으로 서비스 로직을 빠르게 검증
- 성공 케이스와 실패케이스 작성

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)

---
