### PR TITLE
[refactor] : 경기 검색 정렬 Redis 캐싱 적용

### DIFF
--- a/src/main/java/com/example/basketballmatching/BasketballMatchingApplication.java
+++ b/src/main/java/com/example/basketballmatching/BasketballMatchingApplication.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication

--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/GameSearchCacheDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/GameSearchCacheDto.java
@@ -1,0 +1,17 @@
+package com.example.basketballmatching.gameCreator.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameSearchCacheDto<T> implements Serializable {
+    private List<T> content;
+    private long totalElement;
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameSearchCacheService.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameSearchCacheService.java
@@ -1,0 +1,47 @@
+package com.example.basketballmatching.gameCreator.service.impl;
+
+import com.example.basketballmatching.gameCreator.dto.GameSearchCacheDto;
+import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
+import com.example.basketballmatching.gameCreator.type.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameSearchCacheService {
+
+    private final GameQueryRepository gameQueryRepository;
+
+    @Cacheable(
+            cacheNames = "gameSearch",
+            key = "#version + ':' + #date + ':' + #cityName + ':' + #matchFormat + ':' + #fieldStatus + ':' + #matchGenderType + ':' + #gameStatus + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + #pageable.sort.toString()",
+            unless = "#result == null || #result.getContent() == null || #result.getContent().isEmpty()"
+    )
+
+    public GameSearchCacheDto<SearchGameDto> searchGameCached(
+            long version,
+            LocalDate date,
+            CityName cityName,
+            MatchFormat matchFormat,
+            FieldStatus fieldStatus,
+            MatchGenderType matchGenderType,
+            GameStatus gameStatus,
+            Pageable pageable
+    ) {
+        log.info("[DB 조회 수행] version={}, date={}, city={}, page={}, size={}, sort={}",
+                version, date, cityName, pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+        Page<SearchGameDto> searchGameDtos = gameQueryRepository.searchByKeyword(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageable);
+
+        return new GameSearchCacheDto<>(searchGameDtos.getContent(), searchGameDtos.getTotalElements());
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -1,10 +1,7 @@
 package com.example.basketballmatching.gameCreator.service.impl;
 
 
-import com.example.basketballmatching.gameCreator.dto.CreateGameDto;
-import com.example.basketballmatching.gameCreator.dto.EditGameDto;
-import com.example.basketballmatching.gameCreator.dto.GameDto;
-import com.example.basketballmatching.gameCreator.dto.SearchGameDto;
+import com.example.basketballmatching.gameCreator.dto.*;
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.PlaceLockEntity;
 import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
@@ -12,6 +9,8 @@ import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.PlaceLockRepository;
 import com.example.basketballmatching.gameCreator.service.GameService;
 import com.example.basketballmatching.gameCreator.type.*;
+import com.example.basketballmatching.global.cache.event.GameSearchCacheBumpEvent;
+import com.example.basketballmatching.global.cache.version.GameSearchCacheVersionService;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
@@ -20,7 +19,9 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,12 @@ public class GameServiceImpl implements GameService {
     private final GameQueryRepository gameQueryRepository;
     private final ParticipantGameRepository participantGameRepository;
     private final PlaceLockRepository placeLockRepository;
+
+    private final GameSearchCacheVersionService versionService;
+    private final GameSearchCacheService cacheService;
+
+    private final ApplicationEventPublisher eventPublisher;
+
 
     /**
      * 경기 생성
@@ -74,6 +81,8 @@ public class GameServiceImpl implements GameService {
 
         participantGameRepository.save(participantGameEntity);
 
+
+        eventPublisher.publishEvent(new GameSearchCacheBumpEvent());
 
         log.info("[경기 생성 완료] gameId = {}", gameEntity.getGameId());
 
@@ -111,16 +120,20 @@ public class GameServiceImpl implements GameService {
 
         log.info("[경기 검색 정렬 시작] date : {}", date);
 
-        Page<SearchGameDto> responses = gameQueryRepository.searchByKeyword(date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageable);
+        long version = versionService.getVersion();
 
 
-        if (responses.isEmpty()) {
-            return CommonResponse.of("경기 검색결과가 없습니다.", responses);
+        GameSearchCacheDto<SearchGameDto> searchGameCached = cacheService.searchGameCached(
+                version, date, cityName, matchFormat, fieldStatus, matchGenderType, gameStatus, pageable
+        );
+
+        if (searchGameCached.getContent().isEmpty()) {
+            return CommonResponse.of("경기 검색결과가 없습니다.", new PageImpl<>(searchGameCached.getContent(), pageable, searchGameCached.getTotalElement()));
         }
 
         log.info("[경기 검색 정렬 완료] date : {}", date);
 
-        return CommonResponse.of("경기 검색이 완료되었습니다.", responses);
+        return CommonResponse.of("경기 검색이 완료되었습니다.", new PageImpl<>(searchGameCached.getContent(), pageable, searchGameCached.getTotalElement()));
     }
 
     /**
@@ -143,6 +156,7 @@ public class GameServiceImpl implements GameService {
 
         gameEntity.editGameInfo(request);
 
+        eventPublisher.publishEvent(new GameSearchCacheBumpEvent());
 
         log.info("[경기 수정 완료] gameId : {}", gameId);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -7,10 +7,10 @@ import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.service.ParticipantGameService;
-import com.example.basketballmatching.gameCreator.type.GameStatus;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
-import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.cache.event.GameSearchCacheBumpEvent;
 import com.example.basketballmatching.global.dto.CheckResponse;
+import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.notifications.service.NotificationService;
 import com.example.basketballmatching.notifications.type.NotificationType;
@@ -18,7 +18,7 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -43,6 +43,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     private final UserRepository userRepository;
 
     private final NotificationService notificationService;
+
+    private final ApplicationEventPublisher eventPublisher;
+
 
 
     /**
@@ -113,7 +116,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse acceptGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[참가자 경기 수락 시작] participantId : {}, gameId : {}", participantUserId, gameId);
@@ -150,6 +152,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
+
         log.info("[참가자 경기 수락 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "경기 수락이 완료되었습니다.");
@@ -164,7 +167,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse rejectGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[경기 참가자 거절 시작] participantId : {}, gameId : {}", participantUserId, gameId);
@@ -198,6 +200,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
+
+
         log.info("[경기 참가자 거절 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "경기 거절을 완료하였습니다.");
@@ -211,7 +215,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse kickOutGameUser(Long participantUserId, Long userId, Long gameId) {
 
         log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantUserId, gameId);
@@ -244,6 +247,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
+
         log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantUserId, gameId);
 
         return CheckResponse.of(true, "참가자 강퇴를 완료하였습니다.");
@@ -258,7 +262,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
      */
     @Override
     @Transactional
-    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse deleteGame(Long userId, Long gameId) {
 
         log.info("[경기 삭제 시작] userId : {}, gameId : {}", userId, gameId);
@@ -300,6 +303,9 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         gameEntity.setDeletedDateTime(now);
 
         gameRepository.save(gameEntity);
+
+
+        eventPublisher.publishEvent(new GameSearchCacheBumpEvent());
 
         log.info("[경기 삭제 완료] userId : {}, gameId : {}", userId, gameId);
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.gameUsers.service.impl;
 
 import com.example.basketballmatching.gameCreator.entity.GameEntity;
 import com.example.basketballmatching.gameCreator.entity.ParticipantGameEntity;
+import com.example.basketballmatching.gameCreator.repository.GameQueryRepository;
 import com.example.basketballmatching.gameCreator.repository.GameRepository;
 import com.example.basketballmatching.gameCreator.repository.ParticipantGameRepository;
 import com.example.basketballmatching.gameCreator.type.MatchGenderType;
@@ -18,7 +19,6 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,13 +37,10 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final ParticipantGameRepository participantGameRepository;
 
-
-    private final GameUserCacheService gameUserCacheService;
-
-
     private final UserRepository userRepository;
 
     private final GameRepository gameRepository;
+    private final GameQueryRepository gameQueryRepository;
 
 
     /**
@@ -80,7 +77,6 @@ public class GameUserServiceImpl implements GameUserService {
             gameEntity.increaseParticipantCount();
         }
 
-
         ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(participantGameEntity);
 
 
@@ -95,7 +91,6 @@ public class GameUserServiceImpl implements GameUserService {
      */
     @Override
     @Transactional
-    @CacheEvict(cacheNames = "myCurrentGameList", allEntries = true)
     public CheckResponse cancelGame(Long userId, Long gameId) {
 
         GameEntity gameEntity = getGameWithLock(gameId);
@@ -123,6 +118,7 @@ public class GameUserServiceImpl implements GameUserService {
 
 
 
+
         return CheckResponse.of(true, "경기 취소가 완료되었습니다.");
     }
 
@@ -134,10 +130,10 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional(readOnly = true)
     public CommonResponse<List<CurrentGameListDto>> getMyCurrentGameList(Long userId, Pageable pageable) {
 
-        getUser(userId);
+        UserEntity userEntity = getUser(userId);
 
 
-        List<CurrentGameListDto> currentGameList = gameUserCacheService.getMyCurrentGameListCached(userId, pageable);
+        List<CurrentGameListDto> currentGameList = gameQueryRepository.getCurrentGameList(userEntity.getUserId(), pageable);
 
         return CommonResponse.of("현재 예정된 게임 조회가 완료되었습니다.", currentGameList);
     }
@@ -149,10 +145,10 @@ public class GameUserServiceImpl implements GameUserService {
     @Transactional(readOnly = true)
     public CommonResponse<List<LastGameListDto>> getMyLastGameList(Long userId, Pageable pageable) {
 
-        getUser(userId);
+        UserEntity userEntity = getUser(userId);
 
 
-        List<LastGameListDto> lastGameList = gameUserCacheService.getMyLastGameListCached(userId, pageable);
+        List<LastGameListDto> lastGameList = gameQueryRepository.getLastGameList(userEntity.getUserId(), pageable);
 
         return CommonResponse.of("지난 게임 조회가 완료되었습니다.", lastGameList);
     }

--- a/src/main/java/com/example/basketballmatching/global/cache/event/GameSearchCacheBumpEvent.java
+++ b/src/main/java/com/example/basketballmatching/global/cache/event/GameSearchCacheBumpEvent.java
@@ -1,0 +1,4 @@
+package com.example.basketballmatching.global.cache.event;
+
+public record GameSearchCacheBumpEvent() {
+}

--- a/src/main/java/com/example/basketballmatching/global/cache/listener/GameSearchCacheBumpListener.java
+++ b/src/main/java/com/example/basketballmatching/global/cache/listener/GameSearchCacheBumpListener.java
@@ -1,0 +1,25 @@
+package com.example.basketballmatching.global.cache.listener;
+
+import com.example.basketballmatching.global.cache.event.GameSearchCacheBumpEvent;
+import com.example.basketballmatching.global.cache.version.GameSearchCacheVersionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameSearchCacheBumpListener {
+
+    private final GameSearchCacheVersionService versionService;
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(GameSearchCacheBumpEvent gameSearchCacheBumpEvent) {
+        long newVersion = versionService.bump();
+
+        log.info("[검색 캐시 버전 Bump] newVersion = {}", newVersion);
+    }
+}

--- a/src/main/java/com/example/basketballmatching/global/cache/version/GameSearchCacheVersionService.java
+++ b/src/main/java/com/example/basketballmatching/global/cache/version/GameSearchCacheVersionService.java
@@ -1,0 +1,55 @@
+package com.example.basketballmatching.global.cache.version;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GameSearchCacheVersionService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String VERSION_KEY = "cache:gameSearch:version";
+
+
+    public long getVersion() {
+
+        String version = redisTemplate.opsForValue().get(VERSION_KEY);
+
+        if (version == null) {
+            redisTemplate.opsForValue().set(VERSION_KEY, "1");
+            return 1L;
+        }
+
+        try {
+
+            long parsed = Long.parseLong(version);
+
+            if (parsed < 1L) {
+                redisTemplate.opsForValue().set(VERSION_KEY, "1");
+                return 1L;
+            }
+
+
+        } catch (NumberFormatException e) {
+            redisTemplate.opsForValue().set(VERSION_KEY, "1");
+            return 1L;
+        }
+
+        return Long.parseLong(version);
+    }
+
+    public long bump() {
+        Long version = redisTemplate.opsForValue().increment(VERSION_KEY);
+
+        if (version == null || version < 1L) {
+            redisTemplate.opsForValue().set(VERSION_KEY, "1");
+            return 1L;
+        }
+
+        return version;
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/RedisCacheConfig.java
@@ -1,8 +1,7 @@
 package com.example.basketballmatching.global.config;
 
-import com.example.basketballmatching.user.dto.UserDto;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +10,6 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -25,12 +23,18 @@ public class RedisCacheConfig {
 
 
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory cf, ObjectMapper objectMapper) {
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
 
 
-        ObjectMapper cacheMapper = objectMapper.copy()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        ObjectMapper cacheMapper = new ObjectMapper();
+
+        cacheMapper.registerModule(new JavaTimeModule());
+        cacheMapper.findAndRegisterModules();
+        cacheMapper.activateDefaultTyping(
+                cacheMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
 
 
         var key = RedisSerializationContext.SerializationPair
@@ -44,19 +48,10 @@ public class RedisCacheConfig {
                 .serializeValuesWith(value)
                 .disableCachingNullValues()
                 .entryTtl(Duration.ofMinutes(3));
-        Jackson2JsonRedisSerializer<UserDto> userDtoSer = new Jackson2JsonRedisSerializer<>(cacheMapper, UserDto.class);
-
-
-
-        var userDtoValuePair = RedisSerializationContext.SerializationPair
-                .fromSerializer(userDtoSer);
 
         Map<String, RedisCacheConfiguration> cacheConfig = new HashMap<>();
-        cacheConfig.put("userDto", defaultConfig
-                        .serializeValuesWith(userDtoValuePair)
-                .entryTtl(Duration.ofMinutes(10)));
-        cacheConfig.put("myCurrentGameList", defaultConfig.entryTtl(Duration.ofMinutes(2)));
-        cacheConfig.put("myLastGameList", defaultConfig.entryTtl(Duration.ofMinutes(5)));
+
+        cacheConfig.put("gameSearch", defaultConfig.entryTtl(Duration.ofSeconds(60)));
 
         return RedisCacheManager.builder(cf)
                 .cacheDefaults(defaultConfig)

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -45,7 +45,7 @@ public class UserServiceImpl implements UserService {
 
     private final RedisService redisService;
 
-    private final UserCacheService userCacheService;
+
 
     private final TokenProvider tokenProvider;
 
@@ -131,7 +131,9 @@ public class UserServiceImpl implements UserService {
 
         log.info("[유저 정보 조회 시작] userId : {}", userId);
 
-        UserDto userDto = userCacheService.getUserDtoCached(userId);
+        UserEntity userEntity = getUser(userId);
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
 
         return CommonResponse.of("회원정보 조회에 성공하였습니다.", userDto);
     }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- **경기 검색 정렬** 조회 요청은 빈번하게 발생할 수 있다. 사용자가 매번 경기 검색 조회를 할 때마다 DB에 접근하면, 사용자가 많아질 경우 DB에 큰 부하가 가해져 서비스 성능이 저하될 가능성이 있다.
- 따라서 DB부하를 줄이고 응답을 빠르게 만들기 위해 캐싱을 도입하게 되었다.

### 🚀 TO-BE
✅ Redis 캐싱 적용
- Look Aside 캐싱 전략
   - 경기 조회 시 Redis를 조회하여 데이터가 존재하지 않는다면 DB에 접근해 데이터를 캐싱 후 다음 조회 때부터 레디스에서 값을 읽어오도록 구현하였다.
   - key : version + ":" + (필터들) + ":" + page + ":" + size + ":" + sort

- Versioned Key 무효화 전략
   - 경기 생성 / 삭제 / 수정 이벤트 발생 시, 기존 캐시 데이터를 직접 삭제하지 않고 version 값을 INCR하는 방식으로 캐시를 무효화하였다.
   - 캐싱 도입후 응답 시간이 314ms에서 62ms로 감소하였다.

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)

---
