### PR TITLE
[refactor] : 유저 도메인 리펙토링

### DIFF
--- a/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/SignUpDto.java
@@ -77,23 +77,6 @@ public class SignUpDto {
         @Schema(description = "로그인 타입", example = "LOCAL", defaultValue = "LOCAL")
         private LoginProvider loginProvider;
 
-        public static UserEntity toEntity(SignUpDto.Request request, String encodedPassword) {
-
-            return UserEntity.builder()
-                    .email(request.getEmail())
-                    .password(encodedPassword)
-                    .nickname(request.getNickname())
-                    .name(request.getName())
-                    .birth(request.getBirth())
-                    .phone(request.getPhone())
-                    .address(request.getAddress())
-                    .position(request.getPosition())
-                    .userType(UserType.USER)
-                    .genderType(request.genderType)
-                    .loginProvider(LoginProvider.LOCAL)
-                    .build();
-        }
-
 
 
     }

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -83,26 +83,26 @@ public class UserEntity extends BaseEntity {
         this.deletedDateTime = deletedDateTime;
     }
 
-    public void editUserInfo(EditUserDto editUserDto) {
+    public void editUserInfo(String nickname, String phone, String address, GenderType genderType, Position position) {
 
-        if (editUserDto.getNickname() != null) {
-            this.nickname = editUserDto.getNickname();
+        if (nickname != null) {
+            this.nickname = nickname;
         }
 
-        if (editUserDto.getPhone() != null) {
-            this.phone = editUserDto.getPhone();
+        if (phone != null) {
+            this.phone = phone;
         }
 
-        if (editUserDto.getAddress() != null) {
-            this.address = editUserDto.getAddress();
+        if (address != null) {
+            this.address = address;
         }
 
-        if (editUserDto.getPosition() != null) {
-            this.position = editUserDto.getPosition();
+        if (position != null) {
+            this.position = position;
         }
 
-        if (editUserDto.getGenderType() != null) {
-            this.genderType = editUserDto.getGenderType();
+        if (genderType != null) {
+            this.genderType = genderType;
         }
 
     }
@@ -110,6 +110,24 @@ public class UserEntity extends BaseEntity {
     public void setPassword(String password) {
 
         this.password = password;
+
+    }
+
+    public static UserEntity create(String email, String password, String nickname, String name, LocalDate birth, String phone, String address, Position position, GenderType genderType) {
+
+        return UserEntity.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .name(name)
+                .birth(birth)
+                .phone(phone)
+                .address(address)
+                .position(position)
+                .userType(UserType.USER)
+                .genderType(genderType)
+                .loginProvider(LoginProvider.LOCAL)
+                .build();
 
     }
 

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -74,7 +74,17 @@ public class UserServiceImpl implements UserService {
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        UserEntity userEntity = SignUpDto.Request.toEntity(request, encodedPassword);
+        UserEntity userEntity = UserEntity.create(
+                request.getEmail(),
+                encodedPassword,
+                request.getNickname(),
+                request.getName(),
+                request.getBirth(),
+                request.getPhone(),
+                request.getAddress(),
+                request.getPosition(),
+                request.getGenderType()
+        );
 
 
         userEntity.setEmailAuth();
@@ -82,9 +92,11 @@ public class UserServiceImpl implements UserService {
 
         userRepository.save(userEntity);
 
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
         log.info("유저 회원가입 완료");
 
-        return CommonResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(userEntity)));
+        return CommonResponse.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(userDto));
     }
 
 
@@ -161,7 +173,13 @@ public class UserServiceImpl implements UserService {
             }
         }
 
-        userEntity.editUserInfo(editUserDto);
+        userEntity.editUserInfo(
+                editUserDto.getNickname(),
+                editUserDto.getPhone(),
+                editUserDto.getAddress(),
+                editUserDto.getGenderType(),
+                editUserDto.getPosition()
+        );
 
         UserDto userDto = UserDto.fromEntity(userEntity);
 
@@ -222,7 +240,6 @@ public class UserServiceImpl implements UserService {
 
         userEntity.setPassword(encodedPassword);
 
-        userRepository.save(userEntity);
 
         redisService.deleteData("password:change:" + email);
 
@@ -252,7 +269,6 @@ public class UserServiceImpl implements UserService {
 
         userEntity.setPassword(encodedPassword);
 
-        userRepository.save(userEntity);
 
         log.info("[비밀번호 변경 완료] userId : {}", userId);
 
@@ -287,7 +303,6 @@ public class UserServiceImpl implements UserService {
 
         userEntity.setDeletedDateTime(now);
 
-        userRepository.save(userEntity);
 
 
         return CheckResponse.of(true, "회원탈퇴에 성공하였습니다.");


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- UserEntity가 SignUpDto, EditUserDto등 API DTO에 직접 의존하고 있었다.
- DTO 내부에 toEntity() 메서드가 존재하여 DTO가 엔티티 생성 책임을 보유하고 있음.
- UserServiceImpl 내부에서 엔티티 상태 변경와 DTO 해석이 일부 혼재되어 계층 경계가 불명확한 구조

### 🚀 TO-BE
- DTO -> Entity 생성 책임 제거
   - SignUpDto.Request.toEntity() 삭제
   - UserEntity.create(...) 정적 팩토리 메서드 도입
   - 엔티티가 API DTO 타입을 직접 참조하지 않도록 구조 개선
- 수정 로직 DTO 의존 제거
   - editUserInfo(EditUserDto) → editUserInfo(nickname, phone, address, genderType, position) 형태로 변경
   - 엔티티가 DTO를 직접 알지 않도록 계층 분리 강화

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)


---
