### PR TITLE
[refactor] : 경기 생성 도메인 리펙토링

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/dto/CreateGameDto.java
@@ -72,28 +72,6 @@ public class CreateGameDto {
         @NotNull(message = "성별을 입력해주세요.")
         private MatchGenderType matchGenderType;
 
-        public static GameEntity toEntity(CreateGameDto.Request request, UserEntity userEntity) {
-
-            return GameEntity.builder()
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .headCount(request.getHeadCount())
-                    .fieldStatus(request.getFieldStatus())
-                    .matchGenderType(request.getMatchGenderType())
-                    .startDateTime(request.getStartDateTime())
-                    .endDateTime(request.getEndDateTime())
-                    .placeName(request.getPlaceName())
-                    .address(request.getAddress())
-                    .latitude(request.getLatitude())
-                    .longitude(request.getLongitude())
-                    .cityName(CityName.getCityName(request.getAddress()))
-                    .matchFormat(request.getMatchFormat())
-                    .gameStatus(GameStatus.RECRUITING)
-                    .userEntity(userEntity)
-                    .build();
-
-
-        }
 
     }
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -30,7 +30,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Setter
 public class GameEntity extends BaseEntity {
 
     @Id
@@ -99,26 +98,26 @@ public class GameEntity extends BaseEntity {
     @JoinColumn(nullable = false)
     private UserEntity userEntity;
 
-    public void editGameInfo(EditGameDto editGameDto) {
+    public void editGameInfo(String title, String content, Integer headCount, MatchFormat matchFormat, MatchGenderType matchGenderType) {
 
-        if (editGameDto.getTitle() != null) {
-            this.title = editGameDto.getTitle();
+        if (title != null) {
+            this.title = title;
         }
 
-        if (editGameDto.getContent() != null) {
-            this.content = editGameDto.getContent();
+        if (content != null) {
+            this.content = content;
         }
 
-        if (editGameDto.getHeadCount() > 0) {
-            this.headCount = editGameDto.getHeadCount();
+        if (headCount > 0) {
+            this.headCount = headCount;
         }
 
-        if (editGameDto.getMatchFormat() != null) {
-            this.matchFormat = editGameDto.getMatchFormat();
+        if (matchFormat != null) {
+            this.matchFormat = matchFormat;
         }
 
-        if (editGameDto.getMatchGenderType() != null) {
-            this.matchGenderType = editGameDto.getMatchGenderType();
+        if (matchGenderType != null) {
+            this.matchGenderType = matchGenderType;
         }
 
 
@@ -126,6 +125,33 @@ public class GameEntity extends BaseEntity {
 
 
     }
+
+    public static GameEntity create(String title, String content, Integer headCount, FieldStatus fieldStatus, MatchFormat matchFormat
+    , MatchGenderType matchGenderType, LocalDateTime startDateTime, LocalDateTime endDateTime, String placeName, String address, CityName cityName, Double latitude, Double longitude, UserEntity userEntity) {
+
+        return GameEntity.builder()
+                .title(title)
+                .content(content)
+                .headCount(headCount)
+                .fieldStatus(fieldStatus)
+                .matchGenderType(matchGenderType)
+                .startDateTime(startDateTime)
+                .endDateTime(endDateTime)
+                .placeName(placeName)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .cityName(cityName)
+                .matchFormat(matchFormat)
+                .gameStatus(GameStatus.RECRUITING)
+                .userEntity(userEntity)
+                .build();
+    }
+
+    public void setGameUserLevel(GameUserLevel gameUserLevel) {
+        this.gameUserLevel = gameUserLevel;
+    }
+
 
     public void increaseParticipantCount() {
         this.participantCount++;

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -62,7 +62,7 @@ public class ParticipantGameEntity extends BaseEntity {
 
     }
 
-    public ParticipantGameEntity toGameCreatorEntity(
+    public static ParticipantGameEntity toGameCreatorEntity(
             GameEntity gameEntity, UserEntity userEntity
     ) {
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -77,8 +77,22 @@ public class GameServiceImpl implements GameService {
 
                     UserEntity userEntity = getUser(userId);
 
-
-                    GameEntity gameEntity = CreateGameDto.Request.toEntity(request, userEntity);
+                    GameEntity gameEntity = GameEntity.create(
+                            request.getTitle(),
+                            request.getContent(),
+                            request.getHeadCount(),
+                            request.getFieldStatus(),
+                            request.getMatchFormat(),
+                            request.getMatchGenderType(),
+                            request.getStartDateTime(),
+                            request.getEndDateTime(),
+                            request.getPlaceName(),
+                            request.getAddress(),
+                            CityName.getCityName(request.getAddress()),
+                            request.getLatitude(),
+                            request.getLongitude(),
+                            userEntity
+                    );
 
                     GameUserLevel gameUserLevel = userEntity.getGameUserLevel();
 
@@ -86,7 +100,7 @@ public class GameServiceImpl implements GameService {
 
                     gameRepository.save(gameEntity);
 
-                    ParticipantGameEntity participantGameEntity = new ParticipantGameEntity().toGameCreatorEntity(gameEntity, userEntity);
+                    ParticipantGameEntity participantGameEntity = ParticipantGameEntity.toGameCreatorEntity(gameEntity, userEntity);
 
                     participantGameRepository.save(participantGameEntity);
 
@@ -164,7 +178,7 @@ public class GameServiceImpl implements GameService {
         validateEditGame(request, gameEntity, userEntity);
 
 
-        gameEntity.editGameInfo(request);
+        gameEntity.editGameInfo(request.getTitle(), request.getContent(), request.getHeadCount(), request.getMatchFormat(), request.getMatchGenderType());
 
 
         log.info("[경기 수정 완료] gameId : {}", gameId);


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- GameEntity 생성/수정 시, 서비스 계층에서 DTO를 직접 전달하거나
필드 변경 로직이 일부 분산되어 있었다.

### 🚀 TO-BE
- 생성 책임을 엔티티로 이동
   - GameEntity.create(...) 정적 팩토리 메서드 도입
- 수정 로직 DTO 의존 제거
   - 엔티티가 API DTO 타입을 직접 참조하지 않도록 계층 분리

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)


---
