### PR TITLE
[refactor] : 경기 참가 도메인 리펙토링

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -47,7 +47,7 @@ public class GameEntity extends BaseEntity {
 
     @Builder.Default
     @Column(nullable = false)
-    private int participantCount = 1;
+    private int participantCount = 0;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/GameEntity.java
@@ -161,6 +161,10 @@ public class GameEntity extends BaseEntity {
         this.participantCount--;
     }
 
+    public void setStatue(GameStatus status) {
+        this.gameStatus = status;
+    }
+
     // 테스트용
     public void setDeletedDateTime(LocalDateTime deletedDateTime) {
         this.deletedDateTime = deletedDateTime;

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -54,14 +54,14 @@ public class ParticipantGameEntity extends BaseEntity {
     private UserEntity userEntity;
 
     public static ParticipantGameEntity createApply(GameEntity gameEntity, UserEntity userEntity) {
-
-        gameEntity.increaseParticipantCount();
-        return ParticipantGameEntity.builder()
-                .participantGameStatus(APPLY)
-                .applyDateTime(LocalDateTime.now())
+        ParticipantGameEntity participantGameEntity = ParticipantGameEntity.builder()
                 .gameEntity(gameEntity)
                 .userEntity(userEntity)
                 .build();
+
+        participantGameEntity.transitionTo(APPLY, LocalDateTime.now());
+
+        return participantGameEntity;
 
 
     }
@@ -70,14 +70,13 @@ public class ParticipantGameEntity extends BaseEntity {
             GameEntity gameEntity, UserEntity userEntity
     ) {
 
-        gameEntity.increaseParticipantCount();
-
-        return ParticipantGameEntity.builder()
-                .participantGameStatus(ParticipantGameStatus.ACCEPT)
+        ParticipantGameEntity participantGameEntity = ParticipantGameEntity.builder()
                 .gameEntity(gameEntity)
                 .userEntity(userEntity)
-                .acceptDateTime(LocalDateTime.now())
                 .build();
+
+        participantGameEntity.transitionTo(ACCEPT, LocalDateTime.now());
+        return participantGameEntity;
     }
 
     public void reApply() {
@@ -116,7 +115,9 @@ public class ParticipantGameEntity extends BaseEntity {
 
         ParticipantGameStatus oldStatus = participantGameStatus;
 
-        validateTransition(oldStatus, newStatus);
+        if (oldStatus != null) {
+            validateTransition(oldStatus, newStatus);
+        }
 
         boolean wasOccupied = isOccupied(oldStatus);
         boolean willOccupied = isOccupied(newStatus);
@@ -183,19 +184,7 @@ public class ParticipantGameEntity extends BaseEntity {
 
 
 
-    public void setBlackUserStatus(ParticipantGameStatus participantGameStatus, LocalDateTime localDateTime) {
 
-        if (participantGameStatus.equals(ParticipantGameStatus.ACCEPT)) {
-            this.participantGameStatus = ParticipantGameStatus.KICKOUT;
-            this.kickoutDateTime = localDateTime;
-        }
-
-        if (participantGameStatus.equals(ParticipantGameStatus.APPLY)) {
-            this.participantGameStatus = ParticipantGameStatus.CANCEL;
-            this.canceledDateTime = localDateTime;
-        }
-
-    }
 
 
 }

--- a/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/entity/ParticipantGameEntity.java
@@ -3,6 +3,7 @@ package com.example.basketballmatching.gameCreator.entity;
 
 import com.example.basketballmatching.global.entity.BaseEntity;
 import com.example.basketballmatching.gameCreator.type.ParticipantGameStatus;
+import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.APPLY;
+import static com.example.basketballmatching.gameCreator.type.ParticipantGameStatus.*;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Entity
 @AllArgsConstructor
@@ -29,13 +31,13 @@ public class ParticipantGameEntity extends BaseEntity {
     @Column(nullable = false)
     private ParticipantGameStatus participantGameStatus;
 
+    private LocalDateTime applyDateTime;
+
     private LocalDateTime acceptDateTime;
 
     private LocalDateTime rejectDateTime;
 
     private LocalDateTime canceledDateTime;
-
-    private LocalDateTime withDrawDateTime;
 
     private LocalDateTime kickoutDateTime;
 
@@ -53,8 +55,10 @@ public class ParticipantGameEntity extends BaseEntity {
 
     public static ParticipantGameEntity createApply(GameEntity gameEntity, UserEntity userEntity) {
 
+        gameEntity.increaseParticipantCount();
         return ParticipantGameEntity.builder()
                 .participantGameStatus(APPLY)
+                .applyDateTime(LocalDateTime.now())
                 .gameEntity(gameEntity)
                 .userEntity(userEntity)
                 .build();
@@ -62,10 +66,11 @@ public class ParticipantGameEntity extends BaseEntity {
 
     }
 
-    public static ParticipantGameEntity toGameCreatorEntity(
+    public static ParticipantGameEntity createCreator(
             GameEntity gameEntity, UserEntity userEntity
     ) {
 
+        gameEntity.increaseParticipantCount();
 
         return ParticipantGameEntity.builder()
                 .participantGameStatus(ParticipantGameStatus.ACCEPT)
@@ -77,42 +82,106 @@ public class ParticipantGameEntity extends BaseEntity {
 
     public void reApply() {
         this.canceledDateTime = null;
-        this.participantGameStatus = ParticipantGameStatus.APPLY;
+        transitionTo(APPLY, LocalDateTime.now());
+
+    }
+
+    public void accept(LocalDateTime now) {
+
+        transitionTo(ACCEPT, now);
+    }
+
+    public void cancel(LocalDateTime now) {
+        transitionTo(CANCEL, now);
+    }
+
+    public void reject(LocalDateTime now) {
+
+        transitionTo(REJECT, now);
+    }
+
+    public void kickout(LocalDateTime now) {
+
+        transitionTo(KICKOUT, now);
+    }
+
+    public void delete(LocalDateTime now) {
+        transitionTo(DELETE, now);
+    }
+
+
+
+
+    private void transitionTo(ParticipantGameStatus newStatus, LocalDateTime now) {
+
+        ParticipantGameStatus oldStatus = participantGameStatus;
+
+        validateTransition(oldStatus, newStatus);
+
+        boolean wasOccupied = isOccupied(oldStatus);
+        boolean willOccupied = isOccupied(newStatus);
+
+        if (!wasOccupied && willOccupied) {
+            gameEntity.increaseParticipantCount();
+        }
+
+        if (wasOccupied && !willOccupied) {
+            gameEntity.decreaseParticipantCount();
+        }
+
+        participantGameStatus = newStatus;
+
+        applyTimestamp(newStatus, now);
 
     }
 
 
-    public void setParticipantGameStatusAndAcceptDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime acceptDateTime) {
-        this.participantGameStatus = participantGameStatus;
-        this.acceptDateTime = acceptDateTime;
+    private boolean isOccupied(ParticipantGameStatus status) {
+        return status == APPLY || status == ACCEPT;
     }
 
-    public void setParticipantGameStatusAndRejectDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime rejectDateTime) {
-        this.participantGameStatus = participantGameStatus;
-        this.rejectDateTime = rejectDateTime;
-        this.getGameEntity().decreaseParticipantCount();
+    private void validateTransition(ParticipantGameStatus oldStatue, ParticipantGameStatus newStatus) {
+
+        if (oldStatue == newStatus) {
+            throw new CustomException(ALREADY_PRECESSED_STATUS);
+        }
+
+        switch (oldStatue) {
+            case APPLY -> {
+                if (newStatus != ACCEPT && newStatus != REJECT && newStatus != CANCEL && newStatus != DELETE) {
+                    throw new CustomException(INVALID_STATUS_TRANSITION);
+                }
+            }
+            case ACCEPT -> {
+                if (newStatus != CANCEL && newStatus != KICKOUT && newStatus != DELETE) {
+                    throw new CustomException(INVALID_STATUS_TRANSITION);
+                }
+            }
+            case CANCEL -> {
+                if (newStatus != APPLY && newStatus != DELETE) {
+                    throw new CustomException(INVALID_STATUS_TRANSITION);
+                }
+            }
+            case REJECT, KICKOUT, DELETE -> {
+                throw new CustomException(ALREADY_FINAL_STATUS);
+            }
+        }
+
     }
 
-    public void setParticipantGameStatusAndCanceledDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime canceledDateTime) {
-        this.participantGameStatus = participantGameStatus;
-        this.canceledDateTime = canceledDateTime;
-        this.getGameEntity().decreaseParticipantCount();
-
+    private void applyTimestamp(ParticipantGameStatus status, LocalDateTime now) {
+        switch (status) {
+            case APPLY -> applyDateTime = now;
+            case ACCEPT -> acceptDateTime = now;
+            case REJECT -> rejectDateTime = now;
+            case CANCEL -> canceledDateTime = now;
+            case KICKOUT -> kickoutDateTime = now;
+            case DELETE -> deletedDateTime = now;
+        }
     }
 
-    public void setParticipantGameStatusAndKickoutDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime kickoutDateTime) {
-        this.participantGameStatus = participantGameStatus;
-        this.kickoutDateTime = kickoutDateTime;
-        this.getGameEntity().decreaseParticipantCount();
 
-    }
 
-    public void setParticipantGameStatusAndDeletedDateTime(ParticipantGameStatus participantGameStatus, LocalDateTime deletedDateTime) {
-        this.participantGameStatus = participantGameStatus;
-        this.deletedDateTime = deletedDateTime;
-        this.getGameEntity().decreaseParticipantCount();
-
-    }
 
     public void setBlackUserStatus(ParticipantGameStatus participantGameStatus, LocalDateTime localDateTime) {
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/GameServiceImpl.java
@@ -100,7 +100,7 @@ public class GameServiceImpl implements GameService {
 
                     gameRepository.save(gameEntity);
 
-                    ParticipantGameEntity participantGameEntity = ParticipantGameEntity.toGameCreatorEntity(gameEntity, userEntity);
+                    ParticipantGameEntity participantGameEntity = ParticipantGameEntity.createCreator(gameEntity, userEntity);
 
                     participantGameRepository.save(participantGameEntity);
 

--- a/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameCreator/service/impl/ParticipantGameServiceImpl.java
@@ -148,8 +148,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         // 경기 참가자 상태 유효성 검사
         validateGameStatusInAcceptAndReject(participantGameEntity.getParticipantGameStatus());
 
-        participantGameEntity.setParticipantGameStatusAndAcceptDateTime(ACCEPT, now);
 
+        participantGameEntity.accept(now);
 
         updateGameUserLevel(gameEntity);
 
@@ -200,10 +200,8 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         LocalDateTime now = validateStartDateTime(gameEntity);
 
 
-        participantGameEntity.setParticipantGameStatusAndRejectDateTime(REJECT, now);
 
-        gameEntity.setGameStatus(RECRUITING);
-
+        participantGameEntity.reject(now);
 
         notificationService.send(NotificationType.REJECT_GAME, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에 참가가 거절되었습니다.");
 
@@ -245,14 +243,13 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         LocalDateTime now = validateStartDateTime(gameEntity);
 
-        participantGameEntity.setParticipantGameStatusAndKickoutDateTime(KICKOUT, now);
 
+        participantGameEntity.kickout(now);
 
 
         gameRepository.save(participantGameEntity.getGameEntity());
 
         updateGameUserLevel(gameEntity);
-        gameEntity.setGameStatus(RECRUITING);
 
         notificationService.send(NotificationType.KICKED_OUT, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에서 강퇴당하였습니다.");
 
@@ -297,7 +294,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
         // 조회 유저 상태 DELETE로 변경
         participantGameEntityList.forEach(participantGame ->
-                participantGame.setParticipantGameStatusAndDeletedDateTime(DELETE, now));
+                participantGame.delete(now));
 
         // 삭제 알림 전송
         participantGameEntityList

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -76,14 +76,13 @@ public class GameUserServiceImpl implements GameUserService {
             gameEntity.increaseParticipantCount();
 
             if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
-                gameEntity.setGameStatus(GameStatus.CLOSED);
+                gameEntity.setStatue(GameStatus.CLOSED);
             }
 
 
         } else if (participantGameEntity.getParticipantGameStatus().equals(CANCEL)) {
 
             participantGameEntity.reApply();
-            gameEntity.increaseParticipantCount();
         }
 
         ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(participantGameEntity);
@@ -117,12 +116,17 @@ public class GameUserServiceImpl implements GameUserService {
             throw new CustomException(ALREADY_CANCELED_USER);
         }
 
+        if (participantGameEntity.getParticipantGameStatus().equals(KICKOUT)) {
+            throw new CustomException(ALREADY_KICKOUT_USER);
+        }
+
+
         if (!participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
             throw new CustomException(NOT_ACCEPT_USER);
         }
 
 
-        participantGameEntity.setParticipantGameStatusAndCanceledDateTime(CANCEL, now);
+        participantGameEntity.cancel(now);
 
 
 

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/impl/GameUserServiceImpl.java
@@ -15,6 +15,7 @@ import com.example.basketballmatching.gameUsers.service.GameUserService;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
@@ -42,6 +43,7 @@ public class GameUserServiceImpl implements GameUserService {
 
     private final GameRepository gameRepository;
     private final GameQueryRepository gameQueryRepository;
+    private final RedisService redisService;
 
 
     /**
@@ -56,6 +58,12 @@ public class GameUserServiceImpl implements GameUserService {
         UserEntity userEntity = getUser(userId);
 
         GameEntity gameEntity = getGameWithLock(gameId);
+
+        String data = redisService.getData("blackList:" + userEntity.getEmail());
+
+        if (data != null) {
+            throw new CustomException(BLACKLIST_USER);
+        }
 
         if (gameEntity.getGameStatus().equals(GameStatus.CLOSED)) {
             throw new CustomException(CLOSED_GAME);
@@ -73,7 +81,6 @@ public class GameUserServiceImpl implements GameUserService {
 
             participantGameRepository.save(participantGameEntity);
 
-            gameEntity.increaseParticipantCount();
 
             if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
                 gameEntity.setStatue(GameStatus.CLOSED);

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -74,6 +74,9 @@ public enum ErrorCode {
     NOT_DELETE_GAME(HttpStatus.FORBIDDEN, "경기를 삭제할 수 없습니다."),
     NOT_APPLY_GAME_CREATOR(HttpStatus.BAD_REQUEST, "경기 생성자는 참가신청을 할 수 없습니다."),
     CLOSED_GAME(HttpStatus.BAD_REQUEST, "모집 마감된 경기입니다."),
+    ALREADY_PRECESSED_STATUS(HttpStatus.BAD_REQUEST, "이미 변경된 상태입니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 상태변경입니다."),
+    ALREADY_FINAL_STATUS(HttpStatus.BAD_REQUEST, "이미 적용된 상태변경입니다."),
 
     // level
     NOT_GAME_ENDED(HttpStatus.CONFLICT, "아직 경기가 종료되지 않았습니다."),

--- a/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/user/service/impl/UserServiceImpl.java
@@ -326,12 +326,12 @@ public class UserServiceImpl implements UserService {
         participantGameEntities.forEach(
                 participantGameEntity -> {
                     if (participantGameEntity.getParticipantGameStatus().equals(APPLY)) {
-                        participantGameEntity.setParticipantGameStatusAndCanceledDateTime(CANCEL, now);
+                        participantGameEntity.cancel(now);
 
                     }
 
                     if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
-                        participantGameEntity.setParticipantGameStatusAndKickoutDateTime(KICKOUT, now);
+                        participantGameEntity.kickout(now);
 
 
                     }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
1️⃣ participantCount 증가/ 감소 책임 분산
- apply, cancel, kickout 등 각 메서드에서 increase메서드 호출
- 상태 변경 로직과 인원 증감 로직이 분리되어 있어 중복 및 정합성 문제 발생 가능


### 🚀 TO-BE
1️⃣ 상태 전이 책임 transitionTo() 메서드로 통합
- 모든 상태 변경(`apply`, `accept`, `cancel`, `kickout`, `delete`)이 `transitionTo()`를 통해 수행되도록 수정
- participantCount 증감 로직을 `transitionTo()` 내부로 일원화  
- 상태 변경과 인원 증감을 하나의 흐름으로 통합하여 도메인 책임 명확화  

---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)
---
