### PR TITLE
[refactor] : JWT 생성과 Redis 저장 책임 분리

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("api/v1/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 @Tag(name = "AUTH")
 public class AuthController {
@@ -46,9 +46,11 @@ public class AuthController {
             ) {
 
 
-        AuthTokenResponse token = authService.login(request.email(), request.password());
+        AuthTokenResponse response = authService.login(request.email(), request.password());
 
-        return tokenResponse(token, "로그인에 성공하였습니다.");
+        return ResponseEntity.ok(
+                CommonResponse.of("로그인에 성공하였습니다.", response)
+        );
 
     }
 
@@ -61,16 +63,18 @@ public class AuthController {
     @ApiResponse(responseCode = "400", description = "잘못된 요청",
     content = {@Content(mediaType = "application/json",
     schema = @Schema(implementation = ErrorResponse.class))})
-    @PostMapping("/token/reissue")
+    @PostMapping("/token/refresh")
     public ResponseEntity<CommonResponse<AuthTokenResponse>> reissue(
             @RequestBody @Valid TokenRefreshRequest request
             ) {
 
-        AuthTokenResponse token = authService.reissue(request.email(), request.refreshToken());
+        AuthTokenResponse response = authService.reissue(request.refreshToken());
 
 
 
-        return tokenResponse(token, "토큰 재발급에 성공하였습니다.");
+        return ResponseEntity.ok(
+                CommonResponse.of("토큰 재발급에 성공하였습니다.", response)
+        );
     }
 
     /**
@@ -81,7 +85,7 @@ public class AuthController {
     @ApiResponse(responseCode = "400", description = "잘못된 요청",
     content = {@Content(mediaType = "application/json",
     schema = @Schema(implementation = ErrorResponse.class))})
-    @PatchMapping("/logout")
+    @PostMapping("/logout")
     @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<CheckResponse> logoutUser(
             HttpServletRequest request, @AuthenticationPrincipal UserInfoDetails userInfoDetails
@@ -97,17 +101,6 @@ public class AuthController {
 
     }
 
-
-    private ResponseEntity<CommonResponse<AuthTokenResponse>> tokenResponse(AuthTokenResponse token, String message) {
-
-        HttpHeaders headers = new HttpHeaders();
-
-        headers.setBearerAuth(token.accessToken());
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(CommonResponse.of(message, token));
-    }
 
     private String resolveAccessToken(
             HttpServletRequest request

--- a/src/main/java/com/example/basketballmatching/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/TokenRefreshRequest.java
@@ -6,14 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 
 public record TokenRefreshRequest(
         @Schema(
-                description = "이메일",
-                example = "test@test.com"
-        )
-        @NotBlank(message = "이메일은 필수 입력값입니다.")
-        @Email(message = "이메일 형식으로 입력해주세요.")
-        String email,
-
-        @Schema(
                 description = "Refresh Token",
                 example = "eyJhbGciOiJIUzI1NiJ9..."
         )

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -21,9 +21,6 @@ import static com.example.basketballmatching.user.type.LoginProvider.LOCAL;
 @Slf4j
 public class AuthService {
 
-    private static final String REFRESH_TOKEN_PREFIX =
-            "refreshToken:";
-
     private static final String BLACKLIST_PREFIX =
             "blackList:";
 
@@ -34,10 +31,13 @@ public class AuthService {
     private final TokenProvider tokenProvider;
 
     private final RedisService redisService;
+
+    private final AuthTokenStore authTokenStore;
+
     private final UserSessionRevocationService userSessionRevocationService;
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AuthTokenResponse login(String email, String password) {
 
         log.info("[유저 로그인 시작]: {}", email);
@@ -55,14 +55,12 @@ public class AuthService {
         validatePassword(password, user);
 
         // 블랙리스트 유저 검사
-        validateNotBlackList(user.getEmail());
-
-        AuthTokenResponse response = issueTokens(user);
+        validateNotBlacklisted(user.getEmail());
 
 
         log.info("[유저 로그인 완료] email : {}", email);
 
-        return response;
+        return  issueTokens(user);
     }
 
 
@@ -80,30 +78,28 @@ public class AuthService {
 
         validateNotBlacklisted(email);
 
-        AuthTokenResponse response = issueTokens(user);
-
         log.info("[카카오 로그인 완료] email : {}", email);
 
-        return response;
+        return issueTokens(user);
     }
 
 
     @Transactional(readOnly = true)
-    public AuthTokenResponse reissue(String email, String refreshToken) {
+    public AuthTokenResponse reissue(String refreshToken) {
+
+        tokenProvider.validateRefreshToken(refreshToken);
+
+        String email = tokenProvider.getEmailFromToken(refreshToken);
 
         log.info("[토큰 재발급 시작]: {}", email);
 
-        String savedRefreshToken = redisService.getData("refreshToken:" + email);
 
+        String savedRefreshToken = authTokenStore.getRefreshToken(email);
 
         // 재발금 유효성 검사
-        validateReissue(email, refreshToken, savedRefreshToken);
+        validateReissue(refreshToken, savedRefreshToken);
 
         UserEntity user = getActiveUser(email);
-
-        // refreshToken 검증
-        tokenProvider.validateRefreshToken(refreshToken);
-
 
         String accessToken = issueAccessToken(user);
 
@@ -137,16 +133,6 @@ public class AuthService {
         }
     }
 
-    private void validateNotBlackList(String email) {
-
-        String data = redisService.getData("blackList:" + email);
-
-        if (data != null) {
-            throw new CustomException(BLACKLIST_USER);
-        }
-
-    }
-
     private void validatePassword(String password, UserEntity user) {
         if (password == null || !passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(PASSWORD_NOT_MATCH);
@@ -159,6 +145,8 @@ public class AuthService {
 
         String refreshToken = tokenProvider.createRefreshToken(user.getEmail());
 
+        authTokenStore.saveRefreshToken(user.getEmail(), refreshToken, tokenProvider.getRefreshTokenExpirationMillis());
+
         return AuthTokenResponse.of(accessToken, refreshToken, user);
     }
 
@@ -170,26 +158,20 @@ public class AuthService {
 
 
 
-
     private UserEntity getActiveUser(String email) {
         return userRepository.findByEmailAndDeletedDateTimeIsNull(email)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     }
 
-    private void validateReissue(String email, String refreshToken, String redisToken) {
-        if (redisToken == null) {
+    private void validateReissue(String refreshToken, String savedRefreshToken) {
+        if (savedRefreshToken == null) {
             throw new CustomException(NOT_FOUND_TOKEN);
         }
 
-        if (!redisToken.equals(refreshToken)) {
+        if (!savedRefreshToken.equals(refreshToken)) {
             throw new CustomException(INVALID_TOKEN);
         }
 
-        String userEmail = tokenProvider.parseToken(refreshToken).getSubject();
-
-        if (!userEmail.equals(email)) {
-            throw new CustomException(INVALID_TOKEN);
-        }
     }
 
     private void validateNotBlacklisted(String email) {

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthTokenStore.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthTokenStore.java
@@ -1,0 +1,59 @@
+package com.example.basketballmatching.auth.service;
+
+import com.example.basketballmatching.global.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokenStore {
+
+    private static final String REFRESH_TOKEN_PREFIX =
+            "refreshToken:";
+
+    private static final String REVOKED_ACCESS_TOKEN_PREFIX =
+            "logout:access:";
+
+    private static final String REVOKED_VALUE =
+            "LOGOUT";
+
+    private final RedisService redisService;
+
+    public void saveRefreshToken(String email, String refreshToken, long expirationMillis) {
+        redisService.setDataExpireMillis(
+                refreshTokenKey(email),
+                refreshToken,
+                expirationMillis
+        );
+    }
+
+    public String getRefreshToken(String email) {
+        return redisService.getData(refreshTokenKey(email));
+    }
+
+    public void deleteRefreshToken(String email) {
+        redisService.deleteData(refreshTokenKey(email));
+    }
+
+    public void revokeAccessToken(String accessToken, long expirationMillis) {
+        if (expirationMillis <= 0) {
+            return;
+        }
+
+        redisService.setDataExpireMillis(revokedAccessToken(accessToken), REVOKED_VALUE, expirationMillis);
+    }
+
+    public boolean isAccessTokenRevoked(String accessToken) {
+        return redisService.getData(revokedAccessToken(accessToken)) != null;
+    }
+
+    private String revokedAccessToken(String accessToken) {
+        return REVOKED_ACCESS_TOKEN_PREFIX + accessToken;
+    }
+
+    private String refreshTokenKey(String email) {
+
+        return REFRESH_TOKEN_PREFIX + email;
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/service/UserSessionRevocationService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/UserSessionRevocationService.java
@@ -1,29 +1,22 @@
 package com.example.basketballmatching.auth.service;
 
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.global.security.TokenProvider;
-import com.example.basketballmatching.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static com.example.basketballmatching.global.exception.ErrorCode.NOT_FOUND_TOKEN;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UserSessionRevocationService {
 
-    private static final String LOGOUT_ACCESS_PREFIX =
-            "logout:access:";
 
-    private static final String REFRESH_TOKEN_PREFIX =
-            "refreshToken:";
-
-    private final RedisService redisService;
 
     private final TokenProvider tokenProvider;
+    private final AuthTokenStore authTokenStore;
 
     public void revokeAll(String email, String accessToken) {
 
@@ -31,11 +24,9 @@ public class UserSessionRevocationService {
 
         long remainingTime = tokenProvider.getRemainingTime(accessToken);
 
-        if (remainingTime > 0) {
-            redisService.setDataExpireMillis(LOGOUT_ACCESS_PREFIX + accessToken, "LOGOUT", remainingTime);
-        }
+        authTokenStore.revokeAccessToken(accessToken, remainingTime);
 
-        redisService.deleteData(REFRESH_TOKEN_PREFIX + email);
+        authTokenStore.deleteRefreshToken(email);
 
         log.info("[사용자 토큰 폐기 완료] email={}", email);
 

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                                         "/api/v1/password-resets/email-verifications",
                                         "/api/v1/password-resets/email-verifications/confirm",
                                         "/api/v1/auth/login",
-                                        "/api/v1/auth/token/reissue"
+                                        "/api/v1/auth/token/refresh"
                                 ).permitAll()
                                 .requestMatchers(HttpMethod.GET,
                                         "/api/v1/users/availability/email",

--- a/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
+++ b/src/main/java/com/example/basketballmatching/global/security/AuthentificationFilter.java
@@ -1,6 +1,7 @@
 package com.example.basketballmatching.global.security;
 
 
+import com.example.basketballmatching.auth.service.AuthTokenStore;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.global.service.RedisService;
@@ -36,6 +37,8 @@ public class AuthentificationFilter extends OncePerRequestFilter {
 
     private final RedisService redisService;
 
+    private final AuthTokenStore authTokenStore;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
@@ -60,11 +63,9 @@ public class AuthentificationFilter extends OncePerRequestFilter {
             String email = tokenProvider.getEmailFromToken(token);
 
 
-            String logoutToken = redisService.getData("logout:access:" + token);
-
             String blackList = redisService.getData("blackList:" + email);
 
-            if (logoutToken != null) {
+            if (authTokenStore.isAccessTokenRevoked(token)) {
                 log.warn("[로그아웃 유저 접근]: {}", email);
 
                 setErrorResponse(response, LOGOUT_USER);

--- a/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/global/security/TokenProvider.java
@@ -1,7 +1,6 @@
 package com.example.basketballmatching.global.security;
 
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.type.UserType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -29,15 +28,14 @@ public class TokenProvider {
     private String secretKey;
 
     @Value("${spring.jwt.access-token-expiration}")
-    private Long access_token_expire;
+    private Long accessTokenExpirationMillis;
 
     @Value("${spring.jwt.refresh-token-expiration}")
-    private Long refresh_token_expire;
+    private Long refreshTokenExpirationMillis;
 
 
     private final UserInfoDetailsService userInfoDetailsService;
 
-    private final RedisService redisService;
 
 
     private Key key;
@@ -52,28 +50,30 @@ public class TokenProvider {
 
     public String createAccessToken(String email, String name, UserType userType) {
 
-        log.info("accessToken 생성 시작");
+        Claims claims = Jwts.claims().setSubject(email);
 
-        String accessToken = generateAccessToken(email, name, userType, access_token_expire);
+        claims.put("name", name);
+        claims.put("userType", userType);
 
-        return accessToken;
+        return createToken(claims, accessTokenExpirationMillis);
 
 
     }
 
     public String createRefreshToken(String email) {
 
-        log.info("refreshToken 생성 시작");
 
-        String refreshToken = generateRefreshToken(email, refresh_token_expire);
-
-
-
-        redisService.setDataExpireMillis("refreshToken:" + email, refreshToken, refresh_token_expire);
-
-        return refreshToken;
+        Claims claims = Jwts.claims()
+                .setSubject(email);
 
 
+        return createToken(claims, refreshTokenExpirationMillis);
+
+
+    }
+
+    public long getRefreshTokenExpirationMillis() {
+        return refreshTokenExpirationMillis;
     }
 
     public Claims parseToken(String token) {
@@ -137,41 +137,6 @@ public class TokenProvider {
 
 
 
-    private String generateAccessToken(String email, String name, UserType userType, long access_token_expire) {
-
-        Claims claims = Jwts.claims().setSubject(email);
-
-        claims.put("name", name);
-        claims.put("userType", String.valueOf(userType));
-
-
-        return returnToken(claims, access_token_expire);
-
-    }
-
-    private String generateRefreshToken(String email, long refresh_token_expire) {
-
-        Claims claims = Jwts.claims().setSubject(email);
-
-
-        return returnToken(claims, refresh_token_expire);
-
-    }
-
-    private String returnToken(Claims claims, long expireTime) {
-
-        var now = new Date();
-
-        var expireDate = new Date(now.getTime() + expireTime);
-
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(expireDate)
-                .signWith(key)
-                .compact();
-    }
-
     public void validateRefreshToken(String refreshToken) {
 
         if (refreshToken == null) {
@@ -192,6 +157,19 @@ public class TokenProvider {
         return parseToken(token).getExpiration().getTime() - System.currentTimeMillis();
     }
 
+
+    private String createToken(Claims claims, Long expirationMillis) {
+
+        Date issuedAt = new Date();
+        Date expiresAt = new Date(issuedAt.getTime() + expirationMillis);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiresAt)
+                .signWith(key)
+                .compact();
+    }
 
 
 

--- a/src/test/java/com/example/basketballmatching/user/service/UserWithdrawalServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/UserWithdrawalServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.example.basketballmatching.user.service;
 
+import com.example.basketballmatching.auth.service.AuthTokenStore;
 import com.example.basketballmatching.gameCreator.dto.GameCancelNotificationDto;
 import com.example.basketballmatching.gameCreator.dto.UserWithdrawalGameResultDto;
 import com.example.basketballmatching.gameCreator.service.UserWithdrawalGameService;
@@ -15,10 +16,8 @@ import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -71,6 +70,9 @@ class UserWithdrawalServiceIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private AuthTokenStore authTokenStore;
 
     /*
      * 경기 정리 로직은 gameCreator 도메인의 책임이다.
@@ -132,7 +134,11 @@ class UserWithdrawalServiceIntegrationTest extends IntegrationTestSupport {
 
         String refreshToken = tokenProvider.createRefreshToken(WITHDRAWAL_EMAIL);
 
-
+        authTokenStore.saveRefreshToken(
+                WITHDRAWAL_EMAIL,
+                refreshToken,
+                tokenProvider.getRefreshTokenExpirationMillis()
+        );
         String refreshTokenKey =
                 REFRESH_TOKEN_PREFIX + WITHDRAWAL_EMAIL;
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- `TokenProvider`가 JWT 생성과 Redis 저장을 함께 담당
- 토큰 Redis Key가 여러 클래스에 분산
- 토큰 재발급 시 이메일을 별도로 전달

### 🚀 TO-BE

- JWT 생성과 Redis 저장 책임 분리
- `AuthTokenStore`에서 Refresh Token 및 로그아웃 토큰 관리
- 인증 API URL 및 토큰 응답 방식 정리
- Refresh Token 기반 재발급 검증 적용

---

## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 관련 단위·통합 테스트 통과
- [x] 인증 토큰 저장·폐기 흐름 확인