### PR TITLE
[test] : Auth 단위 테스트 및 CI 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  user-tests:
-    name: User Unit & Integration Tests
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: |
+          ./gradlew clean test --no-daemon \
+            --tests "com.example.basketballmatching.user.service.UserServiceUnitTest" \
+            --tests "com.example.basketballmatching.user.service.UserWithdrawalServiceTest" \
+            --tests "com.example.basketballmatching.auth.service.AuthServiceUnitTest" \
+            --tests "com.example.basketballmatching.auth.service.UserSessionRevocationServiceUnitTest" \
+            --tests "com.example.basketballmatching.global.security.AuthenticationFilterUnitTest"
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-report
+          path: build/reports/tests/test/
+          if-no-files-found: ignore
+
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -38,26 +74,25 @@ jobs:
       - name: Grant execute permission
         run: chmod +x gradlew
 
-      - name: Run User tests
+      - name: Run integration tests
         run: |
-          ./gradlew clean test \
-            --tests "com.example.basketballmatching.user.service.UserServiceUnitTest" \
-            --tests "com.example.basketballmatching.user.service.UserWithdrawalServiceTest" \
+          ./gradlew clean test --no-daemon \
             --tests "com.example.basketballmatching.user.service.UserServiceIntegrationTest" \
             --tests "com.example.basketballmatching.user.service.UserWithdrawalServiceIntegrationTest"
 
-      - name: Upload test report
+      - name: Upload integration test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: user-test-report
+          name: integration-test-report
           path: build/reports/tests/test/
           if-no-files-found: ignore
 
   build:
     name: Build Application
     needs:
-      - user-tests
+      - unit-tests
+      - integration-tests
 
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -77,4 +112,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build executable JAR
-        run: ./gradlew clean bootJar -x test
+        run: ./gradlew clean bootJar -x test --no-daemon

--- a/src/test/java/com/example/basketballmatching/auth/service/AuthServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/AuthServiceUnitTest.java
@@ -1,0 +1,354 @@
+package com.example.basketballmatching.auth.service;
+
+import com.example.basketballmatching.auth.dto.AuthTokenResponse;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.security.TokenProvider;
+import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 단위 테스트")
+class AuthServiceUnitTest {
+
+    private static final Long USER_ID = 1L;
+
+    private static final String EMAIL =
+            "test@test.com";
+
+    private static final String NAME =
+            "테스트회원";
+
+    private static final String NICKNAME =
+            "테스트";
+
+    private static final String PASSWORD =
+            "Password1234!";
+
+    private static final String ENCODED_PASSWORD =
+            "encoded-password";
+
+    private static final String ACCESS_TOKEN =
+            "access-token";
+
+    private static final String REFRESH_TOKEN =
+            "refresh-token";
+
+    private static final String OTHER_REFRESH_TOKEN =
+            "other-refresh-token";
+
+    private static final long REFRESH_TOKEN_EXPIRATION =
+            1_209_600_000L;
+
+    private static final String BLACKLIST_KEY =
+            "blackList:" + EMAIL;
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private AuthTokenStore authTokenStore;
+
+    @Mock
+    private UserSessionRevocationService
+            userSessionRevocationService;
+
+    @InjectMocks
+    private AuthService authService;
+
+
+    @Nested
+    @DisplayName("로컬 로그인")
+    class LocalLogin {
+
+        @Test
+        @DisplayName("로그인 성공 시 토큰 발급 및 RefreshToken 저장")
+        void login_success() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.LOCAL);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD))
+                    .thenReturn(true);
+
+            stubTokenIssuance();
+
+            // when
+
+            AuthTokenResponse response = authService.login(EMAIL, PASSWORD);
+
+            // then
+
+            assertAll(
+                    () -> assertEquals(ACCESS_TOKEN, response.accessToken()),
+                    () -> assertEquals(REFRESH_TOKEN, response.refreshToken()),
+                    () -> assertEquals(USER_ID, response.user().userId()),
+                    () -> assertEquals(EMAIL, response.user().email())
+            );
+
+            verify(redisService).getData(BLACKLIST_KEY);
+
+            verify(authTokenStore).saveRefreshToken(EMAIL, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION);
+
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 예외 발생")
+        void login_fail_passwordNotMatch() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.LOCAL);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD))
+                    .thenReturn(false);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(EMAIL, PASSWORD));
+
+            // then
+
+            assertEquals(PASSWORD_NOT_MATCH, exception.getErrorCode());
+
+            verifyNoInteractions(redisService, tokenProvider, authTokenStore);
+
+        }
+
+        @Test
+        @DisplayName("카카오 가입 유저 접근 시 예외 발생")
+        void login_fail_providerNotMatch() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.KAKAO);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(EMAIL, PASSWORD));
+            // then
+
+            assertEquals(PROVIDER_NOT_MATCH, exception.getErrorCode());
+
+            verifyNoInteractions(passwordEncoder, redisService, authTokenStore, tokenProvider);
+
+        }
+
+        @Test
+        @DisplayName("블랙리스트 유저 접근 시 예외 발생")
+        void login_fail_blacklistedUser() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.LOCAL);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD))
+                    .thenReturn(true);
+
+            when(redisService.getData(BLACKLIST_KEY))
+                    .thenReturn("BLACKLIST");
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(EMAIL, PASSWORD));
+
+            // then
+
+            assertEquals(BLACKLIST_USER, exception.getErrorCode());
+
+            verifyNoInteractions(tokenProvider, authTokenStore);
+
+        }
+
+    }
+
+    @Nested
+    @DisplayName("카카오 로그인")
+    class KakaoLogin {
+        @Test
+        @DisplayName("카카오 로그인 성공")
+        void loginWithKakao_success() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.KAKAO);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            stubTokenIssuance();
+
+            // when
+
+            AuthTokenResponse response = authService.loginWithKakao(EMAIL);
+
+            // then
+
+            assertEquals(ACCESS_TOKEN, response.accessToken());
+
+            assertEquals(REFRESH_TOKEN, response.refreshToken());
+
+            verifyNoInteractions(passwordEncoder);
+
+            verify(authTokenStore).saveRefreshToken(EMAIL, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION);
+
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 및 로그아웃")
+    class ReissueAndLogout {
+
+        @Test
+        @DisplayName("저장된 RefreshToken 일치 시 AccessToken 재발급")
+        void reissue_success() {
+            // given
+
+            UserEntity user = createUser(LoginProvider.LOCAL);
+
+            when(tokenProvider.getEmailFromToken(REFRESH_TOKEN))
+                    .thenReturn(EMAIL);
+
+            when(authTokenStore.getRefreshToken(EMAIL))
+                    .thenReturn(REFRESH_TOKEN);
+
+            when(userRepository.findByEmailAndDeletedDateTimeIsNull(EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            when(tokenProvider.createAccessToken(EMAIL, NAME, UserType.USER))
+                    .thenReturn(ACCESS_TOKEN);
+            // when
+
+            AuthTokenResponse response = authService.reissue(REFRESH_TOKEN);
+
+            // then
+
+            verify(tokenProvider).validateRefreshToken(REFRESH_TOKEN);
+
+            assertEquals(ACCESS_TOKEN, response.accessToken());
+            assertEquals(REFRESH_TOKEN, response.refreshToken());
+
+            verify(tokenProvider, never()).createRefreshToken(EMAIL);
+
+            verify(authTokenStore, never()).saveRefreshToken(anyString(), anyString(), anyLong());
+        }
+
+        @Test
+        @DisplayName("저장된 RefreshToken이 일치하지 않으면 예외 발생")
+        void reissue_fail_tokenNotMatch() {
+            // given
+
+            when(tokenProvider.getEmailFromToken(REFRESH_TOKEN))
+                    .thenReturn(EMAIL);
+
+            when(authTokenStore.getRefreshToken(EMAIL))
+                    .thenReturn(OTHER_REFRESH_TOKEN);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> authService.reissue(REFRESH_TOKEN));
+
+            // then
+
+            assertEquals(INVALID_TOKEN, exception.getErrorCode());
+
+            verify(tokenProvider).validateRefreshToken(REFRESH_TOKEN);
+
+            verifyNoInteractions(userRepository);
+
+            verify(tokenProvider, never()).createAccessToken(anyString(), anyString(), any(UserType.class));
+
+        }
+
+        @Test
+        @DisplayName("로그아웃 성공")
+        void logout_success() {
+            // given
+
+
+            // when
+
+            authService.logoutUser(EMAIL, ACCESS_TOKEN);
+
+            // then
+
+            verify(userSessionRevocationService)
+                    .revokeAll(EMAIL, ACCESS_TOKEN);
+
+        }
+
+    }
+
+    private void stubTokenIssuance() {
+        when(tokenProvider.createAccessToken(EMAIL, NAME, UserType.USER))
+                .thenReturn(ACCESS_TOKEN);
+
+        when(tokenProvider.createRefreshToken(EMAIL))
+                .thenReturn(REFRESH_TOKEN);
+
+        when(tokenProvider.getRefreshTokenExpirationMillis())
+                .thenReturn(REFRESH_TOKEN_EXPIRATION);
+    }
+
+
+    private UserEntity createUser(
+            LoginProvider loginProvider
+    ) {
+        return UserEntity.builder()
+                .userId(USER_ID)
+                .email(EMAIL)
+                .password(ENCODED_PASSWORD)
+                .nickname(NICKNAME)
+                .name(NAME)
+                .birth(LocalDate.of(
+                        1995,
+                        1,
+                        1
+                ))
+                .phone("010-1234-5678")
+                .address("서울특별시")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .genderType(GenderType.MALE)
+                .loginProvider(loginProvider)
+                .build();
+    }
+}

--- a/src/test/java/com/example/basketballmatching/auth/service/UserSessionRevocationServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/UserSessionRevocationServiceUnitTest.java
@@ -1,0 +1,85 @@
+package com.example.basketballmatching.auth.service;
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.global.security.TokenProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserSessionRevocationService 단위 테스트")
+class UserSessionRevocationServiceUnitTest {
+    private static final String EMAIL =
+            "test@test.com";
+
+    private static final String ACCESS_TOKEN =
+            "access-token";
+
+    private static final long REMAINING_TIME =
+            300_000L;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private AuthTokenStore authTokenStore;
+
+    @InjectMocks
+    private UserSessionRevocationService userSessionRevocationService;
+
+    @Test
+    @DisplayName("사용자 세션 폐기 시 AccessToken을 제거하고 RefreshToken 제거")
+    void revokeAll_success() {
+        // given
+
+        when(tokenProvider.getRemainingTime(ACCESS_TOKEN))
+                .thenReturn(REMAINING_TIME);
+
+        // when
+        userSessionRevocationService.revokeAll(EMAIL, ACCESS_TOKEN);
+
+        // then
+
+        InOrder inOrder = inOrder(authTokenStore);
+
+        inOrder.verify(authTokenStore)
+                .revokeAccessToken(ACCESS_TOKEN, REMAINING_TIME);
+
+        inOrder.verify(authTokenStore)
+                .deleteRefreshToken(EMAIL);
+
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "   "})
+    @DisplayName("AccessToken이 존재하지 않을 시 예외 발생")
+    void revokeAll_fail_accessTokenNotFound(String accessToken) {
+        // given
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> userSessionRevocationService.revokeAll(EMAIL, accessToken));
+
+        // then
+
+        assertEquals(NOT_FOUND_TOKEN, exception.getErrorCode());
+
+        verifyNoInteractions(tokenProvider, authTokenStore);
+
+    }
+
+}

--- a/src/test/java/com/example/basketballmatching/global/security/AuthenticationFilterUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/global/security/AuthenticationFilterUnitTest.java
@@ -1,0 +1,240 @@
+package com.example.basketballmatching.global.security;
+
+import com.example.basketballmatching.auth.service.AuthTokenStore;
+import com.example.basketballmatching.blackList.service.BlackListStore;
+import com.example.basketballmatching.global.exception.CustomException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationFilterUnitTest {
+
+    private static final String ACCESS_TOKEN =
+            "access-token";
+
+    private static final String EMAIL =
+            "test@test.com";
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private AuthTokenStore authTokenStore;
+
+    @Mock
+    private BlackListStore blackListStore;
+
+    @Mock
+    private SecurityErrorResponseWriter errorResponseWriter;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private AuthenticationFilter authenticationFilter;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 존재하지 않을 시 Fiter 실행")
+    void doFilter_withoutAuthorizationHeader() throws Exception {
+        // given
+
+
+        // when
+        authenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+
+        verify(filterChain).doFilter(request, response);
+
+        verifyNoInteractions(tokenProvider, authTokenStore, blackListStore, errorResponseWriter);
+
+    }
+
+    @Test
+    @DisplayName("AccessToken 검증 성공 시 인증 정보 저장")
+    void doFilter_withValidAccessToken() throws Exception{
+        // given
+
+        setAuthorization();
+
+        when(tokenProvider.getEmailFromToken(ACCESS_TOKEN))
+                .thenReturn(EMAIL);
+
+        when(authTokenStore.isAccessTokenRevoked(ACCESS_TOKEN))
+                .thenReturn(false);
+
+        when(blackListStore.isBlacklisted(EMAIL))
+                .thenReturn(false);
+
+        when(tokenProvider.getAuthentication(ACCESS_TOKEN))
+                .thenReturn(authentication);
+
+        // when
+
+        authenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+
+        verify(tokenProvider).validateToken(ACCESS_TOKEN);
+
+        assertSame(authentication, SecurityContextHolder.getContext().getAuthentication());
+
+        verify(filterChain).doFilter(request, response);
+
+        verifyNoInteractions(errorResponseWriter);
+
+    }
+
+    @Test
+    @DisplayName("로그아웃 처리된 유저 접근 시 401 예외 발생")
+    void doFilter_withRevokedAccessToken() throws Exception{
+        // given
+
+        setAuthorization();
+
+        when(tokenProvider.getEmailFromToken(ACCESS_TOKEN))
+                .thenReturn(EMAIL);
+
+        when(authTokenStore.isAccessTokenRevoked(ACCESS_TOKEN))
+                .thenReturn(true);
+
+        // when
+
+        authenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+
+        verify(errorResponseWriter).write(response, LOGOUT_USER);
+
+        verifyNoInteractions(blackListStore);
+        verify(filterChain, never()).doFilter(request, response);
+
+    }
+
+    @Test
+    @DisplayName("블랙리스트 사용자 접근 시 403 예외 발생")
+    void doFilter_withBlacklistUser() throws Exception{
+        // given
+        setAuthorization();
+
+        when(tokenProvider.getEmailFromToken(ACCESS_TOKEN))
+                .thenReturn(EMAIL);
+
+        when(authTokenStore.isAccessTokenRevoked(ACCESS_TOKEN))
+                .thenReturn(false);
+
+        when(blackListStore.isBlacklisted(EMAIL))
+                .thenReturn(true);
+
+        // when
+
+        authenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+
+        verify(errorResponseWriter).write(response, BLACKLIST_USER);
+
+        verify(filterChain, never()).doFilter(request, response);
+
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 접근 시 인증실패 예외 발생")
+    void doFilter_withInvalidAccessToken() throws Exception{
+        // given
+
+        setAuthorization();
+
+        doThrow(
+                new CustomException(INVALID_TOKEN)
+        ).when(tokenProvider).validateToken(ACCESS_TOKEN);
+
+        // when
+
+        authenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+
+        verify(errorResponseWriter).write(response, INVALID_TOKEN);
+        verifyNoInteractions(authTokenStore, blackListStore);
+
+        verify(filterChain, never()).doFilter(request, response);
+
+    }
+
+
+    @Test
+    @DisplayName("인증 이후 발생한 예외 처리는 Filter가 처리하지 않는다.")
+    void doFilter_NotCatchFilter() throws Exception{
+        // given
+
+        setAuthorization();
+
+        when(tokenProvider.getEmailFromToken(ACCESS_TOKEN))
+                .thenReturn(EMAIL);
+
+        when(authTokenStore.isAccessTokenRevoked(ACCESS_TOKEN))
+                .thenReturn(false);
+
+        when(blackListStore.isBlacklisted(EMAIL))
+                .thenReturn(false);
+
+        when(tokenProvider.getAuthentication(ACCESS_TOKEN))
+                .thenReturn(authentication);
+
+        doThrow(
+                new ServletException("downstream error")
+        ).when(filterChain).doFilter(request, response);
+
+        // when
+
+        // then
+
+        assertThrows(ServletException.class, () -> authenticationFilter.doFilter(request, response, filterChain));
+
+        verifyNoInteractions(errorResponseWriter);
+
+    }
+
+    private void setAuthorization() {
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN);
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- Auth 리팩터링 이후 단위 테스트 부재
- CI에서 User 테스트만 실행
- 단위·통합 테스트가 하나의 CI Job에 혼재

### 🚀 TO-BE

- Auth 서비스 및 인증 필터 단위 테스트 추가
- CI에서 User·Auth 단위 테스트 실행
- 단위 테스트와 Testcontainers 통합 테스트 Job 분리

---

## ✅ 체크리스트

- [x] Auth 단위 테스트 통과
- [x] User 테스트 통과
- [x] CI 테스트 단계 분리