### PR TITLE
[refactor] : 카카오 고유 ID 기반 계정 식별 구조 추가

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/oauth2/domain/OAuthAccountEntity.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/domain/OAuthAccountEntity.java
@@ -1,0 +1,70 @@
+package com.example.basketballmatching.auth.oauth2.domain;
+
+import com.example.basketballmatching.auth.oauth2.type.OAuthProvider;
+import com.example.basketballmatching.global.entity.BaseEntity;
+import com.example.basketballmatching.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "oauth_account_entity",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_oauth_provider_user",
+                        columnNames = {
+                                "provider",
+                                "provider_user_id"
+                        }
+                ),
+                @UniqueConstraint(
+                        name = "uq_oauth_user_provider",
+                        columnNames = {
+                                "user_id",
+                                "provider"
+                        }
+                )
+        }
+)
+public class OAuthAccountEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long oauthAccountId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity userEntity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuthProvider provider;
+
+    @Column(nullable = false)
+    private String providerUserId;
+
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OAuthAccountEntity(UserEntity userEntity, OAuthProvider provider, String providerUserId) {
+        this.userEntity = userEntity;
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+
+    }
+
+
+    public static OAuthAccountEntity create(UserEntity userEntity, OAuthProvider provider, String providerUserId) {
+
+        return OAuthAccountEntity.builder()
+                .userEntity(userEntity)
+                .provider(provider)
+                .providerUserId(providerUserId)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/repository/OAuthAccountRepository.java
@@ -1,0 +1,26 @@
+package com.example.basketballmatching.auth.oauth2.repository;
+
+import com.example.basketballmatching.auth.oauth2.domain.OAuthAccountEntity;
+import com.example.basketballmatching.auth.oauth2.type.OAuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccountEntity, Long> {
+
+
+    @Query("""
+            select oauthAccount
+            from OAuthAccountEntity oauthAccount
+            join fetch oauthAccount.userEntity
+            where oauthAccount.provider = :provider
+            and oauthAccount.providerUserId = :providerUserId
+            """)
+    Optional<OAuthAccountEntity> findWithUserByProviderAndProviderUserId(
+            @Param("provider")OAuthProvider provider,
+            @Param("providerUserId") String providerUserId
+    );
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthAccountService.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthAccountService.java
@@ -1,0 +1,101 @@
+package com.example.basketballmatching.auth.oauth2.service;
+
+import com.example.basketballmatching.auth.oauth2.domain.OAuthAccountEntity;
+import com.example.basketballmatching.auth.oauth2.dto.KakaoDto;
+import com.example.basketballmatching.auth.oauth2.repository.OAuthAccountRepository;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.example.basketballmatching.auth.oauth2.type.OAuthProvider.KAKAO;
+import static com.example.basketballmatching.user.type.LoginProvider.LOCAL;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthAccountService {
+
+    private final OAuthAccountRepository oAuthAccountRepository;
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public String findOrCreateKakaoUserEmail(Long kakaoUserId, String email, String nickname) {
+
+        validateKakaoUserId(kakaoUserId);
+
+        String providerUserId = String.valueOf(kakaoUserId);
+
+        Optional<OAuthAccountEntity> oAuthAccount = oAuthAccountRepository.findWithUserByProviderAndProviderUserId(KAKAO, providerUserId);
+
+        if (oAuthAccount.isPresent()) {
+            UserEntity user = validateActiveUser(oAuthAccount.get().getUserEntity());
+
+            return user.getEmail();
+        }
+
+        UserEntity user = linkOrCreateKakaoUser(providerUserId, email, nickname);
+
+        return user.getEmail();
+
+    }
+
+    private UserEntity linkOrCreateKakaoUser(String providerUserId, String email, String nickname) {
+
+        UserEntity user = userRepository.findByEmail(email)
+                .map(this::validateLinkableUser)
+                .orElseGet(() -> createTemporaryKakaoUser(email, nickname));
+
+        OAuthAccountEntity oAuthAccount = OAuthAccountEntity.create(user, KAKAO, providerUserId);
+
+
+        oAuthAccountRepository.save(oAuthAccount);
+
+        return user;
+    }
+
+    private UserEntity createTemporaryKakaoUser(String email, String nickname) {
+
+        KakaoDto.Request request = KakaoDto.Request.builder()
+                .email(email)
+                .name(nickname)
+                .nickname(nickname)
+                .build();
+
+        UserEntity user = KakaoDto.Request.toEntity(request);
+
+        return userRepository.save(user);
+    }
+
+    private UserEntity validateLinkableUser(UserEntity userEntity) {
+        validateActiveUser(userEntity);
+
+        if (userEntity.getLoginProvider().equals(LOCAL)) {
+            throw new CustomException(ErrorCode.OAUTH_ACCOUNT_LINK_REQUIRED);
+        }
+
+        return userEntity;
+    }
+
+    private UserEntity validateActiveUser(UserEntity userEntity) {
+
+        if (userEntity.getDeletedDateTime() != null) {
+            throw new CustomException(ErrorCode.OAUTH_WITHDRAWN_USER);
+        }
+
+        return userEntity;
+
+    }
+
+
+    private void validateKakaoUserId(Long kakaoUserId) {
+        if (kakaoUserId == null) {
+            throw new CustomException(ErrorCode.OAUTH_PROVIDER_ID_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthService.java
@@ -10,9 +10,9 @@ import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.OAUTH_CODE_NOT_FOUND;
-import static com.example.basketballmatching.global.exception.ErrorCode.OAUTH_USERINFO_RESPONSE_PARSE_ERROR;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -20,6 +20,8 @@ import static com.example.basketballmatching.global.exception.ErrorCode.OAUTH_US
 public class OAuthService {
 
     private final KakaoOAuthClient kakaoOAuthClient;
+
+    private final OAuthAccountService oAuthAccountService;
 
     private final UserRepository userRepository;
 
@@ -34,38 +36,52 @@ public class OAuthService {
 
     public AuthTokenResponse kakaoLogin(String authorizationCode) {
 
-        if (authorizationCode == null || authorizationCode.isBlank()) {
-            throw new CustomException(OAUTH_CODE_NOT_FOUND);
-        }
+        validateAuthorizationCode(authorizationCode);
 
         KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthClient.getUserInfo(authorizationCode);
 
-        KakaoUserInfoResponse.KakaoAccount account = kakaoUserInfo.kakaoAccount();
+        KakaoUserInfoResponse.KakaoAccount account = requireKakaoAccount(kakaoUserInfo);
 
-        if (account == null) {
+
+        String email = requireEmail(account);
+        String nickname= requireNickname(account);
+
+        String loginEmail = oAuthAccountService.findOrCreateKakaoUserEmail(kakaoUserInfo.id(), email, nickname);
+
+
+        return authService.loginWithKakao(loginEmail);
+    }
+
+    private String requireEmail(KakaoUserInfoResponse.KakaoAccount account) {
+
+        if (!StringUtils.hasText(account.email())) {
+            throw new CustomException(OAUTH_EMAIL_NOT_FOUND);
+        }
+
+        return account.email();
+    }
+
+    private static String requireNickname(KakaoUserInfoResponse.KakaoAccount account) {
+
+        if (account.profile() == null || !StringUtils.hasText(account.profile().nickname())) {
             throw new CustomException(OAUTH_USERINFO_RESPONSE_PARSE_ERROR);
         }
 
-        String email = account.email();
-        String nickname = extractNickname(account);
+        return account.profile().nickname();
+    }
 
-        if (!userRepository.existsByEmail(email)) {
-            KakaoDto.Request request =
-                    KakaoDto.Request.builder()
-                            .email(email)
-                            .name(nickname)
-                            .nickname(nickname)
-                            .build();
-
-            userRepository.save(
-                    KakaoDto.Request.toEntity(
-                            request
-                    )
-            );
+    private KakaoUserInfoResponse.KakaoAccount requireKakaoAccount(KakaoUserInfoResponse kakaoUserInfo) {
+        if (kakaoUserInfo.kakaoAccount() == null) {
+            throw new CustomException(OAUTH_USERINFO_RESPONSE_PARSE_ERROR);
         }
 
+        return kakaoUserInfo.kakaoAccount();
+    }
 
-        return authService.loginWithKakao(email);
+    private static void validateAuthorizationCode(String authorizationCode) {
+        if (!StringUtils.hasText(authorizationCode)) {
+            throw new CustomException(OAUTH_CODE_NOT_FOUND);
+        }
     }
 
     private String extractNickname(KakaoUserInfoResponse.KakaoAccount account) {

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/type/OAuthProvider.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/type/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.example.basketballmatching.auth.oauth2.type;
+
+public enum OAuthProvider {
+
+    KAKAO
+}

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 토큰 발급에 실패하였습니다."),
     OAUTH_USERINFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 요청에 실패하였습니다."),
     OAUTH_USERINFO_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 응답 파싱에 실패하였습니다."),
+    OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "카카오 계정의 이메일 제공 동의가 필요합니다."),
 
 
     // game (입력 검증 = 400/ 리소스 없음 = 404/ 권한 부족 =  403/ 중복 = 409)

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -18,6 +18,9 @@ UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByUserIdAndDeletedDateTimeIsNull(Long userId);
 
+    Optional<UserEntity> findByEmail(String email);
+
+
 
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 카카오 이메일을 기준으로 사용자 식별
- OAuth 계정과 내부 사용자의 연결 정보가 없음
- 동일 이메일의 LOCAL/KAKAO 계정 충돌 가능

### 🚀 TO-BE

- 카카오 고유 ID 기반 사용자 식별
- `OAuthAccountEntity`로 내부 사용자와 카카오 계정 연결
- 중복 OAuth 계정 연결을 DB 제약조건으로 방지
- 탈퇴 회원 및 LOCAL 계정 충돌 검증 추가
- 카카오 외부 통신과 DB 계정 처리 책임 분리

---

## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 기존 카카오 로그인 확인
- [x] OAuth 계정 연결 데이터 저장 확인
- [ ] OAuth 전체 테스트 작성
- [ ] 일회용 Ticket 로그인 흐름 구현