### PR TITLE
[feat] : OAuth 추가정보 회원가입 흐름 구현

### DIFF
--- a/src/main/java/com/example/basketballmatching/auth/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/controller/OAuth2Controller.java
@@ -3,6 +3,7 @@ package com.example.basketballmatching.auth.oauth2.controller;
 
 import com.example.basketballmatching.auth.dto.AuthTokenResponse;
 import com.example.basketballmatching.auth.oauth2.dto.OAuthCallbackResponse;
+import com.example.basketballmatching.auth.oauth2.dto.OAuthSignUpRequest;
 import com.example.basketballmatching.auth.oauth2.dto.OAuthTicketRequest;
 import com.example.basketballmatching.auth.oauth2.service.OAuthService;
 import com.example.basketballmatching.global.dto.CommonResponse;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -69,5 +71,26 @@ public class OAuth2Controller {
         return ResponseEntity.ok(
                 CommonResponse.of("OAuth 로그인에 성공하였습니다.", response)
         );
+    }
+
+    @Operation(summary = "OAuth 추가정보 회원가입")
+    @ApiResponse(responseCode = "200", description = "OAuth 회원가입 및 서비스 토큰 발급 성공")
+    @ApiResponse(responseCode = "400", description = "회원가입 입력값 오류",
+    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 OAuth Ticket",
+    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "409", description = "이메일, 닉네임 또는 OAuth 계정 중복",
+    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponse<AuthTokenResponse>> signup(
+            @Valid @RequestBody OAuthSignUpRequest request
+            ) {
+
+        AuthTokenResponse response = oAuthService.signUp(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        CommonResponse.of("OAuth 회원가입이 완료되었습니다.", response)
+                );
     }
 }

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/repository/OAuthAccountRepository.java
@@ -23,4 +23,7 @@ public interface OAuthAccountRepository extends JpaRepository<OAuthAccountEntity
             @Param("providerUserId") String providerUserId
     );
 
+    boolean existsByProviderAndProviderUserId(OAuthProvider provider, String providerUserId);
+
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthAccountService.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthAccountService.java
@@ -2,10 +2,14 @@ package com.example.basketballmatching.auth.oauth2.service;
 
 import com.example.basketballmatching.auth.oauth2.domain.OAuthAccountEntity;
 import com.example.basketballmatching.auth.oauth2.dto.OAuthAccountDecision;
+import com.example.basketballmatching.auth.oauth2.dto.OAuthSignUpRequest;
+import com.example.basketballmatching.auth.oauth2.dto.OAuthTicketPayload;
 import com.example.basketballmatching.auth.oauth2.repository.OAuthAccountRepository;
+import com.example.basketballmatching.auth.oauth2.type.OAuthProvider;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.domain.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.LoginProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +62,65 @@ public class OAuthAccountService {
 
         return OAuthAccountDecision.login(user.getEmail());
 
+    }
+
+    @Transactional
+    public String completeSignUp(OAuthTicketPayload payload, OAuthSignUpRequest request) {
+
+        validateSignUpPayload(payload);
+        validateSignUpAvailability(payload, request.nickname());
+
+        LoginProvider loginProvider = convertLoginProvider(payload.provider());
+
+        UserEntity user = UserEntity.createOAuth(
+                payload.email(),
+                request.nickname(),
+                request.name(),
+                request.birth(),
+                request.phone(),
+                request.address(),
+                request.position(),
+                request.genderType(),
+                loginProvider
+        );
+
+        UserEntity savedUser = userRepository.save(user);
+
+        OAuthAccountEntity oAuthAccount = OAuthAccountEntity.create(user, payload.provider(), payload.providerUserId());
+
+        oAuthAccountRepository.save(oAuthAccount);
+
+        return savedUser.getEmail();
+
+
+    }
+
+    private void validateSignUpPayload(OAuthTicketPayload payload) {
+        if (payload.provider() == null || !StringUtils.hasText(payload.providerUserId())
+        || !StringUtils.hasText(payload.email())) {
+            throw new CustomException(OAUTH_TICKET_INVALID);
+        }
+
+    }
+
+    private void validateSignUpAvailability(OAuthTicketPayload payload, String nickname) {
+        if (oAuthAccountRepository.existsByProviderAndProviderUserId(payload.provider(), payload.providerUserId())) {
+            throw new CustomException(OAUTH_ACCOUNT_ALREADY_EXISTS);
+        }
+
+        if (userRepository.existsByEmail(payload.email())) {
+            throw new CustomException(ALREADY_EXIST_EMAIL);
+        }
+
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CustomException(ALREADY_EXIST_NICKNAME);
+        }
+    }
+
+    private LoginProvider convertLoginProvider(OAuthProvider provider) {
+        return switch (provider) {
+            case KAKAO -> LoginProvider.KAKAO;
+        };
     }
 
 

--- a/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/oauth2/service/OAuthService.java
@@ -3,10 +3,7 @@ package com.example.basketballmatching.auth.oauth2.service;
 import com.example.basketballmatching.auth.dto.AuthTokenResponse;
 import com.example.basketballmatching.auth.oauth2.client.KakaoOAuthClient;
 import com.example.basketballmatching.auth.oauth2.client.dto.KakaoUserInfoResponse;
-import com.example.basketballmatching.auth.oauth2.dto.OAuthAccountDecision;
-import com.example.basketballmatching.auth.oauth2.dto.OAuthCallbackResponse;
-import com.example.basketballmatching.auth.oauth2.dto.OAuthTicketPayload;
-import com.example.basketballmatching.auth.oauth2.dto.OAuthTicketRequest;
+import com.example.basketballmatching.auth.oauth2.dto.*;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import static com.example.basketballmatching.auth.oauth2.type.OAuthFlowType.LOGIN;
+import static com.example.basketballmatching.auth.oauth2.type.OAuthFlowType.SIGNUP;
 import static com.example.basketballmatching.auth.oauth2.type.OAuthProvider.KAKAO;
 import static com.example.basketballmatching.global.exception.ErrorCode.OAUTH_CODE_NOT_FOUND;
 import static com.example.basketballmatching.global.exception.ErrorCode.OAUTH_USERINFO_RESPONSE_PARSE_ERROR;
@@ -71,6 +69,16 @@ public class OAuthService {
         OAuthTicketPayload payload = oAuthTicketStore.consume(request.ticket(), LOGIN);
 
         return authService.loginWithKakao(payload.email());
+    }
+
+    public AuthTokenResponse signUp(OAuthSignUpRequest request) {
+
+        OAuthTicketPayload payload = oAuthTicketStore.consume(request.ticket(), SIGNUP);
+
+        String email = oAuthAccountService.completeSignUp(payload, request);
+
+
+        return authService.loginWithKakao(email);
     }
 
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     OAUTH_USERINFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 요청에 실패하였습니다."),
     OAUTH_USERINFO_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 응답 파싱에 실패하였습니다."),
     OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "카카오 계정의 이메일 제공 동의가 필요합니다."),
+    OAUTH_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입 또는 연결된 소셜 계정입니다."),
 
 
     // game (입력 검증 = 400/ 리소스 없음 = 404/ 권한 부족 =  403/ 중복 = 409)

--- a/src/main/java/com/example/basketballmatching/user/domain/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/domain/UserEntity.java
@@ -130,6 +130,24 @@ public class UserEntity extends BaseEntity {
 
     }
 
+    public static UserEntity createOAuth(String email, String nickname, String name, LocalDate birth, String phone, String address, Position position, GenderType genderType, LoginProvider loginProvider) {
+
+        return UserEntity.builder()
+                .email(email)
+                .password(null)
+                .nickname(nickname)
+                .name(name)
+                .birth(birth)
+                .phone(phone)
+                .address(address)
+                .position(position)
+                .userType(UserType.USER)
+                .genderType(genderType)
+                .loginProvider(loginProvider)
+                .emailAuth(true)
+                .build();
+    }
+
     public void withdraw(LocalDateTime withdrawnAt) {
         if (deletedDateTime != null) {
             return;


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 신규 OAuth 사용자의 추가정보 회원가입 처리 미구현
- OAuth 인증 후 발급된 SIGNUP Ticket을 사용할 API 부재

### 🚀 TO-BE

- OAuth 추가정보 회원가입 API 구현
- SIGNUP Ticket 검증 및 일회성 소비
- 사용자와 OAuth 계정을 하나의 트랜잭션으로 저장
- 이메일·닉네임·소셜 계정 중복 검증
- 회원가입 완료 후 Access/Refresh Token 발급

---

## ✅ 체크리스트

- [x] 코드 컴파일 성공
- [x] OAuth 회원가입 API 테스트 완료
- [x] Ticket 재사용 방지 확인
- [ ] OAuth 단위 테스트 작성
- [ ] OAuth 통합 테스트 작성