### PR TITLE
[chore] : 로컬 개발 및 성능 모니터링 환경 구성

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+LOCAL_DB_NAME=basketball
+LOCAL_DB_USERNAME=basketball
+LOCAL_DB_PASSWORD=basketball-local-password
+LOCAL_DB_ROOT_PASSWORD=basketball-local-root-password

--- a/.env.performance.example
+++ b/.env.performance.example
@@ -1,0 +1,2 @@
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me-local

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
@@ -36,8 +37,16 @@ out/
 ### VS Code ###
 .vscode/
 
-# 민감한 설정 파일
-src/main/resources/application.yml
+### Secret configuration ###
+/src/main/resources/application-seed.yml
+/src/test/resources/application-test-only.yml
+
+.env
+.env.local
+.env.performance
+
+### Performance test result ###
+/performance/results/
 
 # macOS
 .DS_Store
@@ -48,8 +57,3 @@ src/main/resources/application.yml
 
 # Local Gradle environment
 /gradle.properties
-
-# Local configuration with secrets
-/src/main/resources/application-local.yml
-/src/main/resources/application-seed.yml
-/src/test/resources/application-test-only.yml

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ dependencies {
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
 
+    // monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // Testcontainers
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,0 +1,59 @@
+name: basketball-local
+
+services:
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+
+    environment:
+      MYSQL_DATABASE: ${LOCAL_DB_NAME}
+      MYSQL_USER: ${LOCAL_DB_USERNAME}
+      MYSQL_PASSWORD: ${LOCAL_DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${LOCAL_DB_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+
+    ports:
+      - "3307:3306"
+
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+    volumes:
+      - local_mysql_data:/var/lib/mysql
+
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h 127.0.0.1 -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} --silent"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+
+    ports:
+      - "6380:6379"
+
+    volumes:
+      - local_redis_data:/data
+
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  local_mysql_data:
+  local_redis_data:

--- a/compose.performance.yml
+++ b/compose.performance.yml
@@ -1,0 +1,42 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.12.0
+    restart: unless-stopped
+
+    ports:
+      - "9090:9090"
+
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - performance_prometheus_data:/prometheus
+
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:13.1.0
+    restart: unless-stopped
+
+    ports:
+      - "3001:3000"
+
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+
+    volumes:
+      - performance_grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning/datasources/prometheus.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+
+    depends_on:
+      - prometheus
+
+volumes:
+  performance_prometheus_data:
+  performance_grafana_data:

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus-local
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+    jsonData:
+      timeInterval: 5s

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 3s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: basketball-api
+    metrics_path: /actuator/prometheus
+
+    static_configs:
+      - targets:
+          - host.docker.internal:8080
+
+        labels:
+          environment: local

--- a/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SecurityConfig.java
@@ -55,7 +55,10 @@ public class SecurityConfig {
                                         "/swagger-ui.html",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
-                                        "/swagger"
+                                        "/swagger",
+                                        "/actuator/health",
+                                        "/actuator/health/**",
+                                        "/actuator/prometheus"
 
                                 ).permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,78 @@
+spring:
+  datasource:
+    url: ${LOCAL_DB_URL:jdbc:mysql://localhost:3307/basketball?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${LOCAL_DB_USERNAME:basketball}
+    password: ${LOCAL_DB_PASSWORD:basketball-local-password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+    open-in-view: false
+    show-sql: true
+
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+
+  data:
+    redis:
+      host: ${LOCAL_REDIS_HOST:localhost}
+      port: ${LOCAL_REDIS_PORT:6380}
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME:local@example.com}
+    password: ${MAIL_PASSWORD:local-password}
+
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
+    test-connection: false
+    default-encoding: UTF-8
+
+  jwt:
+    secret: ${JWT_SECRET}
+    access-token-expiration: 3600000
+    refresh-token-expiration: 1209600000
+
+app:
+  time-zone: Asia/Seoul
+
+  oauth2:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:local-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:local-client-secret}
+      authorization-uri: https://kauth.kakao.com/oauth/authorize
+      token-uri: https://kauth.kakao.com/oauth/token
+      user-info-uri: https://kapi.kakao.com/v2/user/me
+      redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/v1/auth/oauth2/kakao/callback}
+      connect-timeout: 3s
+      read-timeout: 5s
+
+springdoc:
+  swagger-ui:
+    path: /swagger
+
+  api-docs:
+    path: /v3/api-docs
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE

--- a/src/main/resources/application-performance.yml
+++ b/src/main/resources/application-performance.yml
@@ -1,0 +1,27 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+
+  endpoint:
+    health:
+      show-details: always
+
+  metrics:
+    tags:
+      application: basketball-matching
+
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+
+      slo:
+        "[http.server.requests]":
+          - 100ms
+          - 300ms
+          - 500ms
+          - 1s
+          - 3s


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 로컬 MySQL·Redis 실행 환경이 개발자 환경에 의존
- 애플리케이션 성능 지표 수집 및 시각화 환경 부재

### 🚀 TO-BE

- Docker Compose 기반 로컬 MySQL·Redis 환경 구성
- `local`, `performance` 프로필 분리
- Actuator·Micrometer를 통한 Prometheus 메트릭 제공
- Prometheus·Grafana 컨테이너 및 Data Source 자동 구성
- 실제 환경변수 파일과 예제 파일 분리

---

## ✅ 체크리스트

- [x] Spring Boot 로컬 실행 및 DB 테이블 생성 확인
- [x] MySQL·Redis 컨테이너 상태 확인
- [x] Prometheus 메트릭 수집 확인
- [x] CI 대상 단위·통합 테스트 통과
- [ ] 기존 레거시 테스트는 패키지별 리팩터링 시 수정 예정