### PR TITLE
[refactor] : 경기 상세 조회 API 및 응답 구조 개선

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/controller/GameController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameController.java
@@ -5,6 +5,7 @@ import com.example.basketballmatching.game.dto.GameDto;
 import com.example.basketballmatching.game.dto.SearchGameDto;
 import com.example.basketballmatching.game.dto.request.CreateGameRequest;
 import com.example.basketballmatching.game.dto.response.CreateGameResponse;
+import com.example.basketballmatching.game.dto.response.GameDetailResponse;
 import com.example.basketballmatching.game.service.GameService;
 import com.example.basketballmatching.game.type.*;
 import com.example.basketballmatching.global.dto.CommonResponse;
@@ -74,18 +75,20 @@ public class GameController {
      */
     @Operation(summary = "경기 상세 조회")
     @ApiResponse(responseCode = "200", description = "경기 상세 조회 성공")
-    @ApiResponse(responseCode = "400", description = "잘못된 요청",
+    @ApiResponse(responseCode = "404", description = "경기를 찾을 수 없음",
     content = {@Content(mediaType = "application/json",
     schema = @Schema(implementation = ErrorResponse.class))})
-    @GetMapping("/details")
-    public ResponseEntity<CommonResponse<GameDto>> detailGame(
-            @Parameter(name = "gameId", example = "1")
-            @RequestParam Long gameId
+    @GetMapping("/{gameId}")
+    public ResponseEntity<CommonResponse<GameDetailResponse>> detailGame(
+            @Parameter(name = "gameId", example = "1", required = true)
+            @PathVariable("gameId") Long gameId
     ) {
 
-        CommonResponse<GameDto> gameDto = gameService.detailGame(gameId);
+        GameDetailResponse response = gameService.getGameDetail(gameId);
 
-        return ResponseEntity.ok(gameDto);
+        return ResponseEntity.ok(
+                CommonResponse.of("경기 상세 조회에 성공하였습니다.", response)
+        );
     }
 
     /**

--- a/src/main/java/com/example/basketballmatching/game/dto/response/GameDetailResponse.java
+++ b/src/main/java/com/example/basketballmatching/game/dto/response/GameDetailResponse.java
@@ -1,0 +1,99 @@
+package com.example.basketballmatching.game.dto.response;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.type.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record GameDetailResponse(
+        @Schema(description = "경기 ID", example = "1")
+        Long gameId,
+
+        @Schema(description = "경기 제목")
+        String title,
+
+        @Schema(description = "경기 상세 내용")
+        String content,
+
+        @Schema(description = "경기 정원", example = "6")
+        int headCount,
+
+        @Schema(description = "현재 참가 인원", example = "1")
+        int participantCount,
+
+        @Schema(description = "실내·실외 구분", example = "INDOOR")
+        FieldStatus fieldStatus,
+
+        @Schema(description = "경기 형식", example = "THREE_ON_THREE")
+        MatchFormat matchFormat,
+
+        @Schema(description = "경기 상태", example = "RECRUITING")
+        GameStatus gameStatus,
+
+        @Schema(
+                description = "경기 시작 시각",
+                example = "2026-11-22T15:00:00"
+        )
+        LocalDateTime startDateTime,
+
+        @Schema(
+                description = "경기 종료 시각",
+                example = "2026-11-22T17:00:00"
+        )
+        LocalDateTime endDateTime,
+
+        @Schema(description = "경기 장소명")
+        String placeName,
+
+        @Schema(description = "경기 주소")
+        String address,
+
+        @Schema(description = "위도")
+        Double latitude,
+
+        @Schema(description = "경도")
+        Double longitude,
+
+        @Schema(description = "지역", example = "SEOUL")
+        CityName cityName,
+
+        @Schema(description = "참가 성별 조건", example = "MIXED")
+        MatchGenderType matchGenderType,
+
+        @Schema(description = "경기 생성자 ID", example = "1")
+        Long creatorId,
+
+        @Schema(description = "경기 생성자 닉네임")
+        String creatorNickname,
+
+        @Schema(description = "참가자 수준")
+        GameUserLevel gameUserLevel
+
+) {
+
+    public static GameDetailResponse fromEntity(GameEntity game) {
+        return new GameDetailResponse(
+                game.getGameId(),
+                game.getTitle(),
+                game.getContent(),
+                game.getHeadCount(),
+                game.getParticipantCount(),
+                game.getFieldStatus(),
+                game.getMatchFormat(),
+                game.getGameStatus(),
+                game.getStartDateTime(),
+                game.getEndDateTime(),
+                game.getPlaceName(),
+                game.getAddress(),
+                game.getLatitude(),
+                game.getLongitude(),
+                game.getCityName(),
+                game.getMatchGenderType(),
+                game.getUserEntity().getUserId(),
+                game.getUserEntity().getNickname(),
+                game.getGameUserLevel()
+        );
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/game/service/GameService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameService.java
@@ -6,6 +6,7 @@ import com.example.basketballmatching.game.domain.ParticipantGameEntity;
 import com.example.basketballmatching.game.dto.*;
 import com.example.basketballmatching.game.dto.request.CreateGameRequest;
 import com.example.basketballmatching.game.dto.response.CreateGameResponse;
+import com.example.basketballmatching.game.dto.response.GameDetailResponse;
 import com.example.basketballmatching.game.event.GameCreateEvent;
 import com.example.basketballmatching.game.repository.GameRepository;
 import com.example.basketballmatching.game.repository.ParticipantGameRepository;
@@ -107,18 +108,18 @@ public class GameService {
      * 경기 상세조회
      */
     @Transactional(readOnly = true)
-    public CommonResponse<GameDto> detailGame(Long gameId) {
+    public GameDetailResponse getGameDetail(Long gameId) {
 
         log.info("[경기 상세 조회 시작] gameId : {}", gameId);
 
         GameEntity gameEntity = getGame(gameId);
 
 
-        GameDto gameDto = GameDto.fromEntity(gameEntity);
+        GameDetailResponse response = GameDetailResponse.fromEntity(gameEntity);
 
         log.info("[경기 상세조회 완료] gameId : {}", gameId);
 
-        return CommonResponse.of("경기 상세조회에 성공하였습니다.", gameDto);
+        return response;
     }
 
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,7 +15,7 @@ spring:
       ddl-auto: update
 
     open-in-view: false
-    show-sql: true
+    show-sql: false
 
     properties:
       hibernate:
@@ -75,6 +75,5 @@ springdoc:
 
 logging:
   level:
-    root: INFO
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 경기 상세 조회에 쿼리 파라미터 사용
- 서비스가 `CommonResponse`를 직접 생성
- 여러 기능에서 공용 `GameDto` 사용
- SQL 로그가 중복 출력됨

### 🚀 TO-BE

- 상세 조회 URI를 `GET /api/v1/games/{gameId}`로 변경
- `GameDetailResponse` record 추가
- 서비스는 상세 조회 데이터만 반환
- Controller에서 HTTP 응답 생성
- 로컬 SQL 중복 출력 설정 정리

---

## ✅ 체크리스트

- [x] 코드 빌드 확인
- [x] 경기 생성 API 확인
- [x] 경기 상세 조회 API 확인
