### PR TITLE
[feat] : 경기 키워드 검색 및 정렬 기능 추가

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/dto/request/GameListCondition.java
+++ b/src/main/java/com/example/basketballmatching/game/dto/request/GameListCondition.java
@@ -2,16 +2,19 @@ package com.example.basketballmatching.game.dto.request;
 
 import com.example.basketballmatching.game.type.*;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 public record GameListCondition(
         @Schema(name = "date", description = "조회 날짜", example = "2026-08-04")
-        @NotNull(message = "조회 날짜를 입력해주세요.")
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date,
+
+        @Schema(name = "keyword", description = "검색어", example = "잠실")
+        @Size(max = 50, message = "검색어는 50자 이하여야 합니다.")
+        String keyword,
 
         @Schema(name = "cityName", description = "지역", example = "SEOUL")
         CityName cityName,
@@ -22,11 +25,14 @@ public record GameListCondition(
         @Schema(name = "fieldStatus", description = "실내 실외 구분", example = "INDOOR")
         FieldStatus fieldStatus,
 
-        @Schema(name = "matchGenderType", description = "경기 성별 조건", example = "MALE")
+        @Schema(name = "matchGenderType", description = "경기 성별 조건", example = "MALE_ONLY")
         MatchGenderType matchGenderType,
 
         @Schema(name = "gameStatus", description = "경기 상태", example = "RECRUITING")
-        GameStatus gameStatus
+        GameStatus gameStatus,
+
+        @Schema(name = "sortType", description = "정렬 기준", example = "START_TIME_ASC")
+        GameSortType sortType
 
 ) {
 }

--- a/src/main/java/com/example/basketballmatching/game/repository/query/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/query/GameQueryRepository.java
@@ -7,20 +7,24 @@ import com.example.basketballmatching.game.domain.QParticipantGameEntity;
 import com.example.basketballmatching.game.dto.CurrentGameListDto;
 import com.example.basketballmatching.game.dto.LastGameListDto;
 import com.example.basketballmatching.game.dto.request.GameListCondition;
+import com.example.basketballmatching.game.type.GameSortType;
 import com.example.basketballmatching.user.domain.QUserEntity;
 import com.example.basketballmatching.user.domain.UserEntity;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.example.basketballmatching.game.type.GameSortType.*;
 import static com.example.basketballmatching.game.type.ParticipantGameStatus.ACCEPT;
 import static com.example.basketballmatching.game.type.ParticipantGameStatus.APPLY;
 
@@ -32,16 +36,18 @@ public class GameQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
 
-    public Page<GameEntity> findGames(GameListCondition condition, Pageable pageable) {
+    public Page<GameEntity> findGames(GameListCondition condition, Pageable pageable, LocalDateTime now) {
 
         QGameEntity game = QGameEntity.gameEntity;
 
-        BooleanBuilder builder = createGameListCondition(condition, game);
+        BooleanBuilder builder = createGameListCondition(condition, game, now);
 
         List<GameEntity> content = jpaQueryFactory
                 .selectFrom(game)
                 .where(builder)
-                .orderBy(game.startDateTime.asc())
+                .orderBy(resolveOrderSpecifiers(
+                        condition.sortType(), game
+                ))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -220,18 +226,36 @@ public class GameQueryRepository {
                 .fetch();
     }
 
-    private BooleanBuilder createGameListCondition(GameListCondition condition, QGameEntity game) {
-
-        LocalDateTime startOfDay = condition.date().atStartOfDay();
-
-        LocalDateTime nextDay = condition.date().plusDays(1)
-                .atStartOfDay();
+    private BooleanBuilder createGameListCondition(GameListCondition condition, QGameEntity game, LocalDateTime now) {
 
         BooleanBuilder builder = new BooleanBuilder();
 
         builder.and(game.deletedDateTime.isNull());
-        builder.and(game.startDateTime.goe(startOfDay));
-        builder.and(game.startDateTime.lt(nextDay));
+
+        if (condition.date() != null) {
+            LocalDateTime startOfDay = condition.date().atStartOfDay();
+
+            LocalDateTime nextDay = condition.date().plusDays(1).atStartOfDay();
+
+            builder.and(game.startDateTime.goe(startOfDay));
+
+            builder.and(game.startDateTime.lt(nextDay));
+        } else {
+            builder.and(game.startDateTime.goe(now));
+        }
+
+        if (StringUtils.hasText(condition.keyword())) {
+            String keyword = condition.keyword().trim();
+
+
+            builder.and(
+                    game.title.containsIgnoreCase(keyword)
+                            .or(game.placeName.containsIgnoreCase(keyword))
+            );
+
+        }
+
+
 
         if (condition.cityName() != null) {
             builder.and(game.cityName.eq(condition.cityName()));
@@ -263,6 +287,24 @@ public class GameQueryRepository {
 
 
         return builder;
+    }
+
+    private OrderSpecifier<?>[] resolveOrderSpecifiers(GameSortType sortType, QGameEntity game) {
+
+
+        GameSortType resolveSortType = sortType == null ? START_TIME_ASC : sortType;
+
+        return switch (resolveSortType) {
+            case START_TIME_ASC -> new OrderSpecifier[]{
+                    game.startDateTime.asc(),
+                    game.gameId.asc()
+            };
+            case LATEST -> new OrderSpecifier[]{
+                    game.createdAt.desc(),
+                    game.gameId.desc()
+            };
+        };
+
     }
 
 

--- a/src/main/java/com/example/basketballmatching/game/service/GameService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameService.java
@@ -127,13 +127,21 @@ public class GameService {
     @Transactional(readOnly = true)
     public Page<GameListResponse> getGames(GameListCondition condition, Pageable pageable) {
 
-        log.info("[경기 검색 정렬 시작] date={}, page={}, size={}", condition.date(), pageable.getPageNumber(), pageable.getPageSize());
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        log.info(
+                "[경기 목록 조회 시작] date={}, keyword={}, sortType={}, page={}, size={}",
+                condition.date(),
+                condition.keyword(),
+                condition.sortType(),
+                pageable.getPageNumber(),
+                pageable.getPageSize()
+        );
+
+        Page<GameListResponse> response = gameQueryRepository.findGames(condition, pageable, now)
+                .map(GameListResponse::fromEntity);
 
 
-        Page<GameEntity> games = gameQueryRepository.findGames(condition, pageable);
-
-
-        Page<GameListResponse> response = games.map(GameListResponse::fromEntity);
 
 
         log.info("[경기 검색 정렬 완료] totalElements={}", response.getTotalElements());

--- a/src/main/java/com/example/basketballmatching/game/type/GameSortType.java
+++ b/src/main/java/com/example/basketballmatching/game/type/GameSortType.java
@@ -1,0 +1,6 @@
+package com.example.basketballmatching.game.type;
+
+public enum GameSortType {
+
+    START_TIME_ASC, LATEST
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 목록 조회 시 날짜 입력 필수
- 경기 시작 시간 오름차순으로만 정렬
- 경기 키워드 검색 기능 없음

### 🚀 TO-BE
- 날짜 미입력 시 현재 이후 시간 기준으로 경기 조회
- 경기 제목·장소명 키워드 검색 기능 추가
- 경기 임박순·최신 등록순 정렬 기능 지원
- 검색·필터·정렬 조건을 기존 `getGames()`에서 통합 처리


---

## ✅ 체크리스트
- [x] 코드 빌드 및 테스트 통과


---
