### PR TITLE
[refactor] : 경기 참가 신청 책임 분리

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
@@ -1,0 +1,60 @@
+package com.example.basketballmatching.game.controller;
+
+import com.example.basketballmatching.game.dto.response.GameApplyResponse;
+import com.example.basketballmatching.game.service.GameParticipantService;
+import com.example.basketballmatching.global.dto.CommonResponse;
+import com.example.basketballmatching.global.exception.dto.ErrorResponse;
+import com.example.basketballmatching.global.security.UserInfoDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/games")
+@Tag(name = "GAME_PARTICIPANT")
+public class GameParticipantController {
+
+    private final GameParticipantService gameParticipantService;
+
+    @Operation(summary = "경기 참가 신청")
+    @ApiResponse(responseCode = "201", description = "경기 참가 신청 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 참가 신청",
+            content = {@Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))})
+    @PostMapping("/{gameId}/applications")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<CommonResponse<GameApplyResponse>> apply(
+            @Parameter(description = "경기 ID", example = "1", required = true)
+            @PathVariable("gameId")
+            Long gameId,
+            @AuthenticationPrincipal
+            UserInfoDetails userInfoDetails
+    ) {
+
+        GameApplyResponse response = gameParticipantService.apply(gameId, userInfoDetails.getUserEntity().getUserId());
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{participationId}")
+                .buildAndExpand(
+                        response.participationId()
+                ).toUri();
+        return ResponseEntity.created(location)
+                .body(CommonResponse.of("경기 참가 신청이 완료되었습니다.", response));
+    }
+}

--- a/src/main/java/com/example/basketballmatching/game/controller/MyGameController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/MyGameController.java
@@ -34,27 +34,7 @@ public class MyGameController {
     private final GameUserService gameUserService;
     private final EvaluationService evaluationService;
 
-    /**
-     * 경기 참가
-     */
-    @Operation(summary = "경기 참가")
-    @ApiResponse(responseCode = "200", description = "경기 참가 성공")
-    @ApiResponse(responseCode = "400", description = "잘못된 요청",
-    content = {@Content(mediaType = "application/json",
-    schema = @Schema(implementation = ErrorResponse.class))})
-    @PostMapping("/apply")
-    @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<CommonResponse<ApplyGameUserDto>> applyGame(
-            @Parameter(name = "gameId", example = "1")
-            @RequestParam Long gameId,
-            @AuthenticationPrincipal UserInfoDetails userInfoDetails
-            ) {
 
-        CommonResponse<ApplyGameUserDto> applyGame = gameUserService.applyGame(gameId, userInfoDetails.getUserEntity().getUserId());
-
-        return ResponseEntity.ok(applyGame);
-
-    }
     /**
      * 참가 경기 취소
      */

--- a/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
@@ -6,6 +6,7 @@ import com.example.basketballmatching.global.entity.BaseEntity;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
@@ -299,6 +301,47 @@ public class GameEntity extends BaseEntity {
 
         this.deletedDateTime = now;
     }
+
+    public void validateApply(UserEntity applicant, LocalDateTime now) {
+        validateNotCreator(applicant);
+        validateRecruiting();
+        validateApplyDeadline(now);
+        validateApplicantGender(applicant.getGenderType());
+
+
+    }
+
+    private void validateNotCreator(UserEntity applicant) {
+
+        if (Objects.equals(userEntity.getUserId(), applicant.getUserId())) {
+            throw new CustomException(NOT_APPLY_GAME_CREATOR);
+        }
+    }
+
+    private void validateRecruiting() {
+        if (gameStatus == GameStatus.CLOSED || participantCount >= headCount) {
+            throw new CustomException(FULL_HEADCOUNT_GAME);
+        }
+    }
+
+    private void validateApplyDeadline(LocalDateTime now) {
+        LocalDateTime deadline = startDateTime.minusMinutes(30);
+
+        if (!now.isBefore(deadline)) {
+            throw new CustomException(NOT_ALLOWED_TO_JOIN);
+        }
+    }
+
+    private void validateApplicantGender(GenderType genderType) {
+        if (matchGenderType == MatchGenderType.FEMALE_ONLY && genderType == GenderType.MALE) {
+            throw new CustomException(ONLY_FEMALE_GAME);
+        }
+
+        if (matchGenderType == MatchGenderType.MALE_ONLY && genderType == GenderType.FEMALE) {
+            throw new CustomException(ONLY_MALE_GAME);
+        }
+    }
+
 
     public void setGameUserLevel(GameUserLevel gameUserLevel) {
         this.gameUserLevel = gameUserLevel;

--- a/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
@@ -6,10 +6,7 @@ import com.example.basketballmatching.game.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.user.domain.UserEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -17,9 +14,7 @@ import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Entity
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ParticipantGameEntity extends BaseEntity {
 
@@ -53,15 +48,24 @@ public class ParticipantGameEntity extends BaseEntity {
     @JoinColumn(nullable = false)
     private UserEntity userEntity;
 
-    public static ParticipantGameEntity createApply(GameEntity gameEntity, UserEntity userEntity) {
-        ParticipantGameEntity participantGameEntity = ParticipantGameEntity.builder()
-                .gameEntity(gameEntity)
-                .userEntity(userEntity)
+    @Builder(access = AccessLevel.PRIVATE)
+    private ParticipantGameEntity(GameEntity game, UserEntity applicant) {
+        this.gameEntity = game;
+        this.userEntity = applicant;
+    }
+
+
+    public static ParticipantGameEntity createApply(GameEntity gameEntity, UserEntity userEntity, LocalDateTime appliedAt) {
+
+        ParticipantGameEntity participation = ParticipantGameEntity.builder()
+                .game(gameEntity)
+                .applicant(userEntity)
                 .build();
 
-        participantGameEntity.transitionTo(APPLY, LocalDateTime.now());
 
-        return participantGameEntity;
+        participation.transitionTo(APPLY, appliedAt);
+
+        return participation;
 
 
     }
@@ -71,17 +75,18 @@ public class ParticipantGameEntity extends BaseEntity {
     ) {
 
         ParticipantGameEntity participantGameEntity = ParticipantGameEntity.builder()
-                .gameEntity(gameEntity)
-                .userEntity(userEntity)
+                .game(gameEntity)
+                .applicant(userEntity)
                 .build();
 
         participantGameEntity.transitionTo(ACCEPT, createdAt);
         return participantGameEntity;
     }
 
-    public void reApply() {
+    public void reapply(LocalDateTime appliedAt) {
+        transitionTo(APPLY, appliedAt);
+
         this.canceledDateTime = null;
-        transitionTo(APPLY, LocalDateTime.now());
 
     }
 
@@ -138,7 +143,7 @@ public class ParticipantGameEntity extends BaseEntity {
 
 
     private boolean isOccupied(ParticipantGameStatus status) {
-        return status == APPLY || status == ACCEPT;
+        return status == ACCEPT;
     }
 
     private void validateTransition(ParticipantGameStatus oldStatue, ParticipantGameStatus newStatus) {
@@ -183,8 +188,5 @@ public class ParticipantGameEntity extends BaseEntity {
 
 
 
-
-
-
-
 }
+

--- a/src/main/java/com/example/basketballmatching/game/dto/response/GameApplyResponse.java
+++ b/src/main/java/com/example/basketballmatching/game/dto/response/GameApplyResponse.java
@@ -1,0 +1,33 @@
+package com.example.basketballmatching.game.dto.response;
+
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.type.ParticipantGameStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record GameApplyResponse(
+        @Schema(description = "경기 참가 관계 ID", example = "1")
+        Long participationId,
+
+        @Schema(description = "경기 ID", example = "1")
+        Long gameId,
+
+        @Schema(description = "참가 상태", example = "APPLY")
+        ParticipantGameStatus status,
+
+        @Schema(description = "신청 시각", example = "2026-08-09T15:00:00")
+        LocalDateTime appliedAt
+) {
+
+    public static GameApplyResponse fromEntity(ParticipantGameEntity participation) {
+
+        return new GameApplyResponse(
+                participation.getParticipantGameId(),
+                participation.getGameEntity().getGameId(),
+                participation.getParticipantGameStatus(),
+                participation.getApplyDateTime()
+        );
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
@@ -1,0 +1,118 @@
+package com.example.basketballmatching.game.service;
+
+import com.example.basketballmatching.blackList.repository.BlackListRepository;
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.dto.response.GameApplyResponse;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.game.type.ParticipantGameStatus;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameParticipantService {
+
+    private final UserRepository userRepository;
+    private final GameRepository gameRepository;
+    private final ParticipantGameRepository participantGameRepository;
+    private final BlackListRepository blackListRepository;
+    private final Clock clock;
+
+    @Transactional
+    public GameApplyResponse apply(Long gameId, Long userId) {
+
+        log.info("[경기 참가 신청 시작] gameId={}, userId={}", gameId, userId);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        UserEntity applicant = getActiveUser(userId);
+
+        validateNotBlackList(userId);
+
+        GameEntity game = getActiveGame(gameId);
+
+        ParticipantGameEntity existingParticipation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
+                .orElse(null);
+
+        validateExistingParticipation(existingParticipation);
+
+        game.validateApply(applicant, now);
+
+        ParticipantGameEntity participation = applyOrReapply(game, applicant, existingParticipation, now);
+
+        log.info("[경기 신청 완료] gameId={}, userId={}", gameId, userId);
+
+        return GameApplyResponse.fromEntity(participation);
+    }
+
+    private ParticipantGameEntity applyOrReapply(GameEntity game, UserEntity applicant, ParticipantGameEntity existingParticipation, LocalDateTime now) {
+
+        if (existingParticipation == null) {
+            ParticipantGameEntity participation = ParticipantGameEntity.createApply(
+                    game, applicant, now
+            );
+
+            return participantGameRepository.save(participation);
+        }
+
+        existingParticipation.reapply(now);
+
+        return existingParticipation;
+
+    }
+
+    private void validateExistingParticipation(ParticipantGameEntity participation) {
+
+        if (participation == null || participation.getParticipantGameStatus() == CANCEL) {
+            return;
+        }
+
+        ParticipantGameStatus status = participation.getParticipantGameStatus();
+
+        switch (status) {
+            case APPLY -> {
+                throw new CustomException(ALREADY_APPLY_GAME_USER);
+            }
+            case ACCEPT -> {
+                throw new CustomException(ALREADY_ACCEPT_USER);
+            }
+            case KICKOUT -> {
+                throw new CustomException(NOT_APPLY_KICKOUT_USER);
+            }
+            case REJECT, DELETE -> {
+                throw new CustomException(ALREADY_FINAL_STATUS);
+            }
+        }
+
+    }
+
+    private UserEntity getActiveUser(Long userId) {
+        return userRepository.findByUserIdAndDeletedDateTimeIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private GameEntity getActiveGame(Long gameId) {
+        return gameRepository.findByGameIdAndDeletedDateTimeIsNull(gameId)
+                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
+    }
+
+    private void validateNotBlackList(Long userId) {
+        if (blackListRepository.existsByUserEntity_UserId(userId)) {
+            throw new CustomException(BLACKLIST_USER);
+        }
+    }
+}

--- a/src/main/java/com/example/basketballmatching/game/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameUserService.java
@@ -13,7 +13,6 @@ import java.util.List;
 public interface GameUserService {
 
 
-    CommonResponse<ApplyGameUserDto> applyGame(Long gameId, Long UserId);
 
     CheckResponse cancelGame(Long userId, Long gameId);
 

--- a/src/main/java/com/example/basketballmatching/game/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/game/service/impl/GameUserServiceImpl.java
@@ -45,59 +45,7 @@ public class GameUserServiceImpl implements GameUserService {
     private final GameQueryRepository gameQueryRepository;
     private final RedisService redisService;
 
-    /**
-     * 경기 참가 신청
-     */
-    @Override
-    @Transactional
-    public CommonResponse<ApplyGameUserDto> applyGame(Long gameId, Long userId) {
-        log.info("[경기 참가 신청 시작] gameId : {} userId : {}", gameId, userId);
 
-
-        UserEntity userEntity = getUser(userId);
-
-        GameEntity gameEntity = getGameWithLock(gameId);
-
-        String data = redisService.getData("blackList:" + userEntity.getEmail());
-
-        if (data != null) {
-            throw new CustomException(BLACKLIST_USER);
-        }
-
-        if (gameEntity.getGameStatus().equals(GameStatus.CLOSED)) {
-            throw new CustomException(CLOSED_GAME);
-        }
-
-        ParticipantGameEntity participantGameEntity = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, userId)
-                .orElse(null);
-
-        validateParticipantInfo(userEntity, gameEntity, participantGameEntity);
-
-        if (participantGameEntity == null) {
-
-            participantGameEntity = ParticipantGameEntity.createApply(gameEntity, userEntity);
-
-
-            participantGameRepository.save(participantGameEntity);
-
-
-            if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
-                gameEntity.setStatue(GameStatus.CLOSED);
-            }
-
-
-        } else if (participantGameEntity.getParticipantGameStatus().equals(CANCEL)) {
-
-            participantGameEntity.reApply();
-        }
-
-        ApplyGameUserDto participantDto = ApplyGameUserDto.fromEntity(participantGameEntity);
-
-
-        log.info("[경기 참가 신청 완료] gameId : {}, participantId : {}", gameId, participantGameEntity.getParticipantGameId());
-
-        return CommonResponse.of("경기 신청이 완료되었습니다.", participantDto);
-    }
 
 
     /**

--- a/src/main/java/com/example/basketballmatching/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/SwaggerConfig.java
@@ -37,7 +37,8 @@ import java.util.Arrays;
                 @Tag(name = "GAME_USER", description = "경기 참가자 기능"),
                 @Tag(name = "NOTIFICATION", description = "알림 기능"),
                 @Tag(name = "BLACK_LIST", description = "블랙리스트 기능"),
-                @Tag(name = "OAUTH2", description = "소셜 로그인 (Kakao)")
+                @Tag(name = "OAUTH2", description = "소셜 로그인 (Kakao)"),
+                @Tag(name = "GAME_PARTICIPANT", description = "경기 참가 관리 API")
         }
 )
 @Configuration

--- a/src/test/java/com/example/basketballmatching/game/domain/GameEntityUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/game/domain/GameEntityUnitTest.java
@@ -31,7 +31,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class GameEntityUnitTest {
 
 
-    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 8, 12, 0);
+    private static final LocalDateTime NOW =
+            LocalDateTime.of(
+                    2026,
+                    8,
+                    8,
+                    12,
+                    0
+            );
 
     private UserEntity creator;
 
@@ -60,7 +67,9 @@ class GameEntityUnitTest {
 
             UserEntity participant = createUser(2L, "participant@test.com", "참가자");
 
-            ParticipantGameEntity.createApply(game, participant);
+            ParticipantGameEntity participation = ParticipantGameEntity.createApply(game, participant, NOW);
+
+            participation.accept(NOW);
 
             // when
 
@@ -93,10 +102,14 @@ class GameEntityUnitTest {
                             "참가자"
                     );
 
-            ParticipantGameEntity.createApply(
+            ParticipantGameEntity participation = ParticipantGameEntity.createApply(
                     game,
-                    participant
+                    participant,
+                    NOW
             );
+
+            participation.accept(NOW);
+
 
             // when
             CustomException exception =


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 경기 신청 로직이 `GameUserServiceImpl`에 혼재
- 서비스가 HTTP 공통 응답 객체 직접 반환
- 신청 상태도 경기 참가 인원에 포함

### 🚀 TO-BE
- `GameParticipantController`, `GameParticipantSertvice`로 참가 신청 책임 분리
- 참가 신청 응답을 `GameApplyResponse` record로 변경
- 승인된 참가자만 경기 참가 인원에 포함하도록 정책 변경
- API를 `/api/v1/games/{gameId}/applications`로 변경

---

## ✅ 체크리스트
- [x] 코드 컴파일 확인
- [x] 전체 테스트 통과
- [x] 경기 참가 신청 정책 검증

---
