### PR TITLE
[refactor] : 경기 참가 취소 책임 분리

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.game.controller;
 
 import com.example.basketballmatching.game.dto.response.GameApplyResponse;
 import com.example.basketballmatching.game.service.GameParticipantService;
+import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.dto.ErrorResponse;
 import com.example.basketballmatching.global.security.UserInfoDetails;
@@ -15,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -56,5 +54,26 @@ public class GameParticipantController {
                 ).toUri();
         return ResponseEntity.created(location)
                 .body(CommonResponse.of("경기 참가 신청이 완료되었습니다.", response));
+    }
+
+    @Operation(summary = "경기 참가 신청 취소")
+    @ApiResponse(responseCode = "200", description = "경기 참가 신청 취소 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 경기 참가 취소",
+    content = @Content(mediaType = "application/json",
+    schema = @Schema(implementation = ErrorResponse.class)))
+    @PatchMapping("/{gameId}/applications/me/cancel")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<CheckResponse> cancelApply(
+            @Parameter(description = "경기 ID", example = "1", required = true)
+            @PathVariable("gameId") Long gameId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        gameParticipantService.cancelApply(gameId, userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(
+                CheckResponse.of(true, "경기 참가 신청 취소가 완료되었습니다.")
+        );
+
     }
 }

--- a/src/main/java/com/example/basketballmatching/game/controller/MyGameController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/MyGameController.java
@@ -35,29 +35,6 @@ public class MyGameController {
     private final EvaluationService evaluationService;
 
 
-    /**
-     * 참가 경기 취소
-     */
-    @Operation(summary = "참가 경기 취소")
-    @ApiResponse(responseCode = "200", description = "참가 경기 취소 성공",
-    content = {@Content(mediaType = "application/json",
-    schema = @Schema(implementation = CheckResponse.class))})
-    @ApiResponse(responseCode = "400", description = "잘못된 요청",
-            content = {@Content(mediaType = "application/json",
-                    schema = @Schema(implementation = ErrorResponse.class))})
-    @PatchMapping("/cancel")
-    @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<CheckResponse> cancelGame(
-            @AuthenticationPrincipal UserInfoDetails userInfoDetails,
-            @Parameter(name = "gameId", example = "1")
-            @RequestParam Long gameId
-    ) {
-
-        CheckResponse checkResponse = gameUserService.cancelGame(userInfoDetails.getUserEntity().getUserId(), gameId);
-
-
-        return ResponseEntity.ok(checkResponse);
-    }
 
     /**
      * 현재 예정 경기 조회

--- a/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
@@ -208,6 +208,13 @@ public class GameEntity extends BaseEntity {
 
 
     }
+    public void validateParticipantCancel(LocalDateTime now) {
+        LocalDateTime cancelDeadline = startDateTime.minusMinutes(30);
+
+        if (!now.isBefore(cancelDeadline)) {
+            throw new CustomException(NOT_ALLOWED_CANCEL);
+        }
+    }
 
     private void validateScheduleChange(LocalDateTime startDateTime, LocalDateTime endDateTime, LocalDateTime now) {
 
@@ -280,6 +287,8 @@ public class GameEntity extends BaseEntity {
     private boolean existsOtherParticipants() {
         return participantCount > CREATOR_COUNT;
     }
+
+
 
 
     private void updateRecruitmentStatus(int headCount) {

--- a/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
@@ -83,6 +83,18 @@ public class ParticipantGameEntity extends BaseEntity {
         return participantGameEntity;
     }
 
+    public void cancelApply(LocalDateTime canceledAt) {
+
+        switch (participantGameStatus) {
+            case APPLY -> transitionTo(CANCEL, canceledAt);
+            case CANCEL -> throw new CustomException(ALREADY_CANCELED_USER);
+            case ACCEPT -> throw new CustomException(NOT_APPLY_USER);
+            case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
+            case REJECT, DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
+        }
+
+    }
+
     public void reapply(LocalDateTime appliedAt) {
         transitionTo(APPLY, appliedAt);
 

--- a/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
@@ -59,6 +59,35 @@ public class GameParticipantService {
         return GameApplyResponse.fromEntity(participation);
     }
 
+    @Transactional
+    public void cancelApply(Long gameId, Long userId) {
+
+        log.info("[경기 참가 취소 시작] gameId={}, userId={}", gameId, userId);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        getActiveUser(userId);
+
+        GameEntity game = getActiveGame(gameId);
+
+        ParticipantGameEntity participation = getParticipation(gameId, userId);
+
+
+        game.validateParticipantCancel(now);
+
+        participation.cancelApply(now);
+
+        log.info("[경기 참가 신청 취소 완료] gameId={}, userId={}", gameId, userId);
+
+
+    }
+
+    private ParticipantGameEntity getParticipation(Long gameId, Long userId) {
+        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(
+                gameId, userId
+        ).orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
+    }
+
     private ParticipantGameEntity applyOrReapply(GameEntity game, UserEntity applicant, ParticipantGameEntity existingParticipation, LocalDateTime now) {
 
         if (existingParticipation == null) {


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 참가 신청 취소가 기존 경기 참가 로직에 포함
- 신청 상태별 취소 정책이 명확하게 분리되지 않음

### 🚀 TO-BE
- 참가 신청 취소 API를 `/games/{gameId}/applications/me/cancel`로 변경
- `APPLY` -> `CANCEL` 상태 전이 책임을 도메인으로 이동
- 경기 시작 30분 전까지 취소할 수 있도록 정책 적용
- 서비스 로직에서 HTTP 응답 객체 생성 책임 제거

---


## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 참가 신청 취소 API 테스트
- [x] 기존 테스트 통과

---
