### PR TITLE
[refactor] : 경기 참가 상태 모델 단순화

### DIFF
--- a/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/blackList/service/impl/BlackListServiceImpl.java
@@ -27,7 +27,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.example.basketballmatching.game.type.ParticipantGameStatus.ACCEPT;
-import static com.example.basketballmatching.game.type.ParticipantGameStatus.APPLY;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
@@ -133,7 +132,7 @@ public class BlackListServiceImpl implements BlackListService {
         LocalDateTime now = LocalDateTime.now();
 
 
-        List<ParticipantGameEntity> list = participantGameRepository.findByUserEntity_UserIdAndParticipantGameStatusIn(targetUser.getUserId(), List.of(ParticipantGameStatus.ACCEPT, APPLY))
+        List<ParticipantGameEntity> list = participantGameRepository.findByUserEntity_UserIdAndParticipantGameStatusIn(targetUser.getUserId(), List.of(ParticipantGameStatus.ACCEPT))
                 .stream()
                 .filter(participantGameEntity -> participantGameEntity.getGameEntity().getStartDateTime().isAfter(now))
                 .toList();
@@ -142,11 +141,6 @@ public class BlackListServiceImpl implements BlackListService {
         list.forEach(participantGameEntity -> {
             if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
                 participantGameEntity.kickout(now);
-                return;
-            }
-
-            if (participantGameEntity.getParticipantGameStatus().equals(APPLY)) {
-                participantGameEntity.cancel(now);
             }
 
         });

--- a/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
@@ -26,11 +26,8 @@ public class ParticipantGameEntity extends BaseEntity {
     @Column(nullable = false)
     private ParticipantGameStatus participantGameStatus;
 
-    private LocalDateTime applyDateTime;
 
     private LocalDateTime acceptDateTime;
-
-    private LocalDateTime rejectDateTime;
 
     private LocalDateTime canceledDateTime;
 
@@ -85,7 +82,7 @@ public class ParticipantGameEntity extends BaseEntity {
 
     public void join(LocalDateTime joinedAt) {
         switch (participantGameStatus) {
-            case APPLY, CANCEL-> {
+            case CANCEL-> {
                 transitionTo(ACCEPT, joinedAt);
 
                 this.canceledDateTime = null;
@@ -95,7 +92,7 @@ public class ParticipantGameEntity extends BaseEntity {
 
             case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
 
-            case REJECT, DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
+            case DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
 
         }
     }
@@ -103,34 +100,15 @@ public class ParticipantGameEntity extends BaseEntity {
     public void cancelParticipation(LocalDateTime canceledAt) {
 
         switch (participantGameStatus) {
-            case APPLY, ACCEPT -> transitionTo(CANCEL, canceledAt);
+            case ACCEPT -> transitionTo(CANCEL, canceledAt);
             case CANCEL -> throw new CustomException(ALREADY_CANCELED_USER);
             case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
-            case REJECT, DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
+            case DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
         }
 
     }
 
-    public void reapply(LocalDateTime appliedAt) {
-        transitionTo(APPLY, appliedAt);
 
-        this.canceledDateTime = null;
-
-    }
-
-    public void accept(LocalDateTime now) {
-
-        transitionTo(ACCEPT, now);
-    }
-
-    public void cancel(LocalDateTime now) {
-        transitionTo(CANCEL, now);
-    }
-
-    public void reject(LocalDateTime now) {
-
-        transitionTo(REJECT, now);
-    }
 
     public void kickout(LocalDateTime now) {
 
@@ -181,11 +159,6 @@ public class ParticipantGameEntity extends BaseEntity {
         }
 
         switch (oldStatue) {
-            case APPLY -> {
-                if (newStatus != ACCEPT && newStatus != REJECT && newStatus != CANCEL && newStatus != DELETE) {
-                    throw new CustomException(INVALID_STATUS_TRANSITION);
-                }
-            }
             case ACCEPT -> {
                 if (newStatus != CANCEL && newStatus != KICKOUT && newStatus != DELETE) {
                     throw new CustomException(INVALID_STATUS_TRANSITION);
@@ -196,18 +169,18 @@ public class ParticipantGameEntity extends BaseEntity {
                     throw new CustomException(INVALID_STATUS_TRANSITION);
                 }
             }
-            case REJECT, KICKOUT, DELETE -> {
-                throw new CustomException(ALREADY_FINAL_STATUS);
-            }
+            case KICKOUT, DELETE ->
+                    throw new CustomException(ALREADY_FINAL_STATUS);
+
+
+
         }
 
     }
 
     private void applyTimestamp(ParticipantGameStatus status, LocalDateTime now) {
         switch (status) {
-            case APPLY -> applyDateTime = now;
             case ACCEPT -> acceptDateTime = now;
-            case REJECT -> rejectDateTime = now;
             case CANCEL -> canceledDateTime = now;
             case KICKOUT -> kickoutDateTime = now;
             case DELETE -> deletedDateTime = now;

--- a/src/main/java/com/example/basketballmatching/game/repository/GameRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/GameRepository.java
@@ -1,9 +1,7 @@
 package com.example.basketballmatching.game.repository;
 
 import com.example.basketballmatching.game.domain.GameEntity;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -59,9 +57,6 @@ public interface GameRepository extends JpaRepository<GameEntity, Long> {
 
 
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select g from GameEntity g where g.gameId = :gameId and g.deletedDateTime is NULL ")
-    Optional<GameEntity> findByGameIdWithLock(@Param("gameId") Long gameId);
 
 
     Optional<GameEntity> findByGameIdAndDeletedDateTimeIsNull(Long gameId);

--- a/src/main/java/com/example/basketballmatching/game/repository/query/GameQueryRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/query/GameQueryRepository.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.example.basketballmatching.game.type.GameSortType.*;
 import static com.example.basketballmatching.game.type.ParticipantGameStatus.ACCEPT;
-import static com.example.basketballmatching.game.type.ParticipantGameStatus.APPLY;
 
 @Repository
 @RequiredArgsConstructor
@@ -193,7 +192,7 @@ public class GameQueryRepository {
                         game.gameId.in(gameIds),
                         participantGame
                                 .participantGameStatus
-                                .in(APPLY, ACCEPT)
+                                .eq(ACCEPT)
                 )
                 .fetch();
 
@@ -217,7 +216,7 @@ public class GameQueryRepository {
                 .where(
                         participantGame.userEntity.userId.eq(userId),
                         participantGame
-                                .participantGameStatus.in(APPLY, ACCEPT),
+                                .participantGameStatus.eq(ACCEPT),
                         game.startDateTime.gt(now),
                         game.deletedDateTime.isNull(),
                         game.userEntity.userId.ne(userId)

--- a/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
@@ -112,7 +112,7 @@ public class GameParticipantService {
         ParticipantGameStatus status = participation.getParticipantGameStatus();
 
         switch (status) {
-            case APPLY, CANCEL -> {
+            case CANCEL -> {
             }
             case ACCEPT -> {
                 throw new CustomException(ALREADY_ACCEPT_USER);
@@ -120,7 +120,7 @@ public class GameParticipantService {
             case KICKOUT -> {
                 throw new CustomException(NOT_APPLY_KICKOUT_USER);
             }
-            case REJECT, DELETE -> {
+            case DELETE -> {
                 throw new CustomException(ALREADY_FINAL_STATUS);
             }
         }

--- a/src/main/java/com/example/basketballmatching/game/service/UserWithdrawalGameService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/UserWithdrawalGameService.java
@@ -82,7 +82,6 @@ public class UserWithdrawalGameService {
             ParticipantGameStatus status = participation.getParticipantGameStatus();
 
             switch (status) {
-                case APPLY -> participation.cancel(withdrawnAt);
                 case ACCEPT -> participation.kickout(withdrawnAt);
                 default -> throw new CustomException(INVALID_STATUS_TRANSITION);
             }

--- a/src/main/java/com/example/basketballmatching/game/service/impl/GameUserServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/game/service/impl/GameUserServiceImpl.java
@@ -1,6 +1,5 @@
 package com.example.basketballmatching.game.service.impl;
 
-import com.example.basketballmatching.game.domain.GameEntity;
 import com.example.basketballmatching.game.domain.ParticipantGameEntity;
 import com.example.basketballmatching.game.dto.CurrentGameListDto;
 import com.example.basketballmatching.game.dto.GameUserLevelDto;
@@ -9,25 +8,21 @@ import com.example.basketballmatching.game.repository.GameRepository;
 import com.example.basketballmatching.game.repository.ParticipantGameRepository;
 import com.example.basketballmatching.game.repository.query.GameQueryRepository;
 import com.example.basketballmatching.game.service.GameUserService;
-import com.example.basketballmatching.game.type.MatchGenderType;
 import com.example.basketballmatching.global.dto.CommonResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.domain.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
-import com.example.basketballmatching.user.type.GenderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
-import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
-import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static com.example.basketballmatching.global.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -102,56 +97,8 @@ public class GameUserServiceImpl implements GameUserService {
     }
 
 
-    private GameEntity getGameWithLock(Long gameId) {
-        return gameRepository.findByGameIdWithLock(gameId)
-                .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
-    }
 
 
-    private void validateParticipantInfo(UserEntity userEntity, GameEntity gameEntity, ParticipantGameEntity participantGameEntity) {
-
-        LocalDateTime now = LocalDateTime.now();
-
-        if (Objects.equals(userEntity.getUserId(), gameEntity.getUserEntity().getUserId())) {
-            throw new CustomException(NOT_APPLY_GAME_CREATOR);
-        }
-
-        if (participantGameEntity != null) {
-
-            if (participantGameEntity.getParticipantGameStatus().equals(KICKOUT)) {
-                throw new CustomException(NOT_APPLY_KICKOUT_USER);
-            }
-
-            if (participantGameEntity.getParticipantGameStatus().equals(ACCEPT)) {
-                throw new CustomException(ALREADY_ACCEPT_USER);
-            }
-
-            if (participantGameEntity.getParticipantGameStatus().equals(APPLY)) {
-                throw new CustomException(ALREADY_APPLY_GAME_USER);
-            }
-
-        }
 
 
-        if (gameEntity.getParticipantCount() >= gameEntity.getHeadCount()) {
-            throw new CustomException(FULL_HEADCOUNT_GAME);
-        }
-
-        if (now.isAfter(gameEntity.getStartDateTime().minusMinutes(30))) {
-            throw new CustomException(NOT_ALLOWED_TO_JOIN);
-        }
-
-        if (gameEntity.getMatchGenderType().equals(MatchGenderType.FEMALE_ONLY) &&
-                userEntity.getGenderType().equals(GenderType.MALE)) {
-            throw new CustomException(ONLY_FEMALE_GAME);
-        }
-
-
-        if (gameEntity.getMatchGenderType().equals(MatchGenderType.MALE_ONLY) &&
-                userEntity.getGenderType().equals(GenderType.FEMALE)) {
-            throw new CustomException(ONLY_MALE_GAME);
-        }
-
-
-    }
 }

--- a/src/main/java/com/example/basketballmatching/game/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/game/service/impl/ParticipantGameServiceImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.example.basketballmatching.game.type.ParticipantGameStatus.ACCEPT;
-import static com.example.basketballmatching.game.type.ParticipantGameStatus.APPLY;
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
@@ -167,7 +166,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
         // ACCEPT/ APPLY 유저 리스트
-        List<ParticipantGameEntity> participantGameEntityList = participantGameRepository.findByParticipantGameStatusInAndGameEntity_GameId(List.of(ACCEPT, APPLY), gameId);
+        List<ParticipantGameEntity> participantGameEntityList = participantGameRepository.findByParticipantGameStatusInAndGameEntity_GameId(List.of(ACCEPT), gameId);
 
 
         // 조회 유저 상태 DELETE로 변경
@@ -198,21 +197,11 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
         return CheckResponse.of(true, "경기 삭제가 완료되었습니다.");
     }
 
-    public void validateGameStatusInAcceptAndReject(ParticipantGameStatus status) {
 
-        switch (status) {
-
-            case ACCEPT -> throw new CustomException(ALREADY_ACCEPT_USER);
-            case REJECT -> throw new CustomException(ALREADY_REJECT_USER);
-
-        }
-
-    }
 
     private void validateGameStatusInKickOut(ParticipantGameStatus status) {
 
         switch (status) {
-            case APPLY -> throw new CustomException(NOT_ACCEPT_USER);
             case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
         }
     }

--- a/src/main/java/com/example/basketballmatching/game/type/ParticipantGameStatus.java
+++ b/src/main/java/com/example/basketballmatching/game/type/ParticipantGameStatus.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ParticipantGameStatus {
 
-    APPLY, ACCEPT, REJECT, CANCEL, KICKOUT, DELETE
+    ACCEPT, CANCEL, KICKOUT, DELETE
 
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 선착순 참가 정책 변경 후에도 신청·거절 상태와 관련 로직이 남아 있음
- 사용하지 않는 참가 상태와 비관적 락 코드 존재

### 🚀 TO-BE

- 참가 상태를 `ACCEPT`, `CANCEL`, `KICKOUT`, `DELETE`로 단순화
- 신청·거절 관련 필드와 상태 전이 제거
- 조회·탈퇴·블랙리스트 로직을 참가 확정 상태 기준으로 변경
- 사용하지 않는 비관적 락과 레거시 코드 제거

---

## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 경기 도메인 단위 테스트 통과
- [x] 참가 상태 전이 검토