### PR TITLE
[refactor] : 경기 참가자 강퇴 책임 분리

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -119,5 +120,44 @@ public class GameParticipantController {
         return ResponseEntity.ok(
                 CommonResponse.of("경기 참가자 목록 조회가 완료되었습니다.", response)
         );
+    }
+
+    @Operation(summary = "경기 참가자 강퇴", description = "경기 생성자가 참가자를 경기에서 강퇴한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "참가자 강퇴 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "경기 생성자 본인 강퇴 또는 경기 시작 1시간 이내 요청"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "경기 생성자가 아닌 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "경기 또는 참가 정보 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 취소 또는 강퇴된 참가자"
+            )
+    })
+    @PatchMapping("/{gameId}/participants/{participantId}/kickout")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<CheckResponse> kickoutParticipant(
+            @PathVariable("gameId") Long gameId,
+            @PathVariable("participantId") Long participantId,
+            @AuthenticationPrincipal UserInfoDetails userInfoDetails
+    ) {
+
+        gameParticipantService.kickoutParticipant(gameId, participantId, userInfoDetails.getUserEntity().getUserId());
+
+        return ResponseEntity.ok(
+                CheckResponse.of(true, "참가자를 강퇴하였습니다.")
+        );
+
     }
 }

--- a/src/main/java/com/example/basketballmatching/game/controller/GameParticipationController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameParticipationController.java
@@ -29,35 +29,6 @@ public class GameParticipationController {
     private final ParticipantGameService participantGameService;
 
 
-
-
-
-    /**
-     * 경기 수락자 강퇴
-     */
-    @Operation(summary = "경기 수락자 강퇴")
-    @ApiResponse(responseCode = "200", description = "경기 수락자 강퇴 성공",
-            content = {@Content(mediaType = "application/json",
-                    schema = @Schema(implementation = CheckResponse.class))})
-    @ApiResponse(responseCode = "400", description = "잘못된 요청",
-            content = {@Content(mediaType = "application/json",
-                    schema = @Schema(implementation = ErrorResponse.class))})
-    @PatchMapping("/kickout")
-    @PreAuthorize("hasAnyRole('USER')")
-    public ResponseEntity<CheckResponse> kickoutGameUser (
-            @Parameter(name = "gameId", example = "1", required = true)
-            @RequestParam Long gameId,
-            @Parameter(name = "participantId", example = "1", required = true)
-            @RequestParam Long participantId,
-            @AuthenticationPrincipal UserInfoDetails userInfoDetails
-    ) {
-
-        CheckResponse checkResponse = participantGameService.kickOutGameUser(participantId, userInfoDetails.getUserEntity().getUserId(), gameId);
-
-        return ResponseEntity.ok(checkResponse);
-
-    }
-
     /**
      * 경기 삭제
      */

--- a/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/GameEntity.java
@@ -218,6 +218,21 @@ public class GameEntity extends BaseEntity {
         }
     }
 
+    public void validateParticipantKickout(UserEntity participant, LocalDateTime now) {
+
+        LocalDateTime kickoutDeadLine = startDateTime.minusHours(1);
+
+        if (Objects.equals(userEntity.getUserId(), participant.getUserId())) {
+            throw new CustomException(NOT_KICKOUT_CREATOR);
+        }
+
+        if (!now.isBefore(kickoutDeadLine)) {
+            throw new CustomException(NOT_ALLOWED_KICKOUT);
+        }
+
+    }
+
+
     private void validateNotCreatorCancel(UserEntity participant) {
         if (Objects.equals(userEntity.getUserId(), participant.getUserId())) {
             throw new CustomException(NOT_CANCEL_GAME_CREATOR);

--- a/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
+++ b/src/main/java/com/example/basketballmatching/game/domain/ParticipantGameEntity.java
@@ -110,9 +110,16 @@ public class ParticipantGameEntity extends BaseEntity {
 
 
 
-    public void kickout(LocalDateTime now) {
+    public void kickout(LocalDateTime kickoutAt) {
 
-        transitionTo(KICKOUT, now);
+        switch (participantGameStatus) {
+            case ACCEPT -> transitionTo(KICKOUT, kickoutAt);
+            case CANCEL -> throw new CustomException(NOT_ACTIVE_PARTICIPANT);
+            case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
+            case DELETE -> throw new CustomException(ALREADY_FINAL_STATUS);
+        }
+
+
     }
 
     public void delete(LocalDateTime now) {

--- a/src/main/java/com/example/basketballmatching/game/event/GameParticipantKickedOutEvent.java
+++ b/src/main/java/com/example/basketballmatching/game/event/GameParticipantKickedOutEvent.java
@@ -1,0 +1,8 @@
+package com.example.basketballmatching.game.event;
+
+public record GameParticipantKickedOutEvent(
+        Long gameId,
+        String gameTitle,
+        Long participantUserId
+) {
+}

--- a/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
@@ -37,4 +37,7 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 """
     )
     List<ParticipantGameEntity> findByGameEntity_GameIdAndParticipantGameStatus(@Param("gameId") Long gameId, @Param("participantGameStatus") ParticipantGameStatus participantGameStatus);
+
+
+    Optional<ParticipantGameEntity> findByParticipantGameIdAndGameEntity_GameId(Long participantGameId, Long gameId);
 }

--- a/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
@@ -5,6 +5,7 @@ import com.example.basketballmatching.game.domain.GameEntity;
 import com.example.basketballmatching.game.domain.ParticipantGameEntity;
 import com.example.basketballmatching.game.dto.response.GameParticipantListResponse;
 import com.example.basketballmatching.game.dto.response.GameParticipantResponse;
+import com.example.basketballmatching.game.event.GameParticipantKickedOutEvent;
 import com.example.basketballmatching.game.repository.GameRepository;
 import com.example.basketballmatching.game.repository.ParticipantGameRepository;
 import com.example.basketballmatching.game.type.ParticipantGameStatus;
@@ -13,6 +14,7 @@ import com.example.basketballmatching.user.domain.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -34,6 +36,7 @@ public class GameParticipantService {
     private final GameRepository gameRepository;
     private final ParticipantGameRepository participantGameRepository;
     private final BlackListRepository blackListRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
 
     @Transactional
@@ -110,6 +113,37 @@ public class GameParticipantService {
         return participants;
     }
 
+    @Transactional
+    public void kickoutParticipant(Long gameId, Long participantId, Long requesterId) {
+
+        log.info("[경기 참가자 강퇴 시작] gameId={}, participantId={}, requesterId={}", gameId, participantId, requesterId);
+
+        LocalDateTime kickoutAt = LocalDateTime.now(clock);
+
+
+        UserEntity requester = getActiveUser(requesterId);
+
+        GameEntity game = getActiveGame(gameId);
+
+        validateGameCreator(game, requester);
+
+        ParticipantGameEntity participation = getParticipant(gameId, participantId);
+
+        UserEntity participant = participation.getUserEntity();
+
+        game.validateParticipantKickout(participant, kickoutAt);
+
+        participation.kickout(kickoutAt);
+
+        log.info("[경기 참가자 강퇴 완료] gameId={}, participantId={}, requesterId={}", gameId, participantId, requesterId);
+
+        eventPublisher.publishEvent(new GameParticipantKickedOutEvent(
+                game.getGameId(),game.getTitle(), participant.getUserId()
+        ));
+
+
+    }
+
     private void validateGameCreator(GameEntity game, UserEntity requester) {
         if (!Objects.equals(requester.getUserId(), game.getUserEntity().getUserId())) {
             throw new CustomException(NOT_GAME_CREATOR);
@@ -160,6 +194,13 @@ public class GameParticipantService {
                 throw new CustomException(ALREADY_FINAL_STATUS);
             }
         }
+
+    }
+
+    private ParticipantGameEntity getParticipant(Long gameId, Long participantId) {
+
+        return participantGameRepository.findByParticipantGameIdAndGameEntity_GameId(participantId, gameId)
+                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
 
     }
 

--- a/src/main/java/com/example/basketballmatching/game/service/ParticipantGameService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/ParticipantGameService.java
@@ -9,7 +9,6 @@ public interface ParticipantGameService {
 
 
 
-    CheckResponse kickOutGameUser(Long participantId, Long userId, Long gameId);
 
     CheckResponse deleteGame(Long userId, Long gameId);
 

--- a/src/main/java/com/example/basketballmatching/game/service/impl/ParticipantGameServiceImpl.java
+++ b/src/main/java/com/example/basketballmatching/game/service/impl/ParticipantGameServiceImpl.java
@@ -6,7 +6,6 @@ import com.example.basketballmatching.game.repository.GameRepository;
 import com.example.basketballmatching.game.repository.ParticipantGameRepository;
 import com.example.basketballmatching.game.service.ParticipantGameService;
 import com.example.basketballmatching.game.type.GameUserLevel;
-import com.example.basketballmatching.game.type.ParticipantGameStatus;
 import com.example.basketballmatching.global.dto.CheckResponse;
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.notifications.service.NotificationService;
@@ -39,69 +38,6 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
     private final NotificationService notificationService;
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    /**
-     * 경기 강퇴
-     */
-    @Override
-    @Transactional
-    public CheckResponse kickOutGameUser(Long participantUserId, Long userId, Long gameId) {
-
-        log.info("[경기 강퇴 시작] : participantId : {}, gameId : {}", participantUserId, gameId);
-
-        GameEntity gameEntity = getGame(gameId);
-
-        UserEntity userEntity = getUser(userId);
-
-        validateGameCreator(gameEntity, userEntity);
-
-
-        ParticipantGameEntity participantGameEntity = getParticipantGame(gameEntity, participantUserId);
-
-        if (Objects.equals(participantGameEntity.getUserEntity().getUserId(), gameEntity.getUserEntity().getUserId())) {
-            throw new CustomException(NOT_KICKOUT_CREATOR);
-        }
-
-        // 경기 참가자 상태 유효성 검사
-        validateGameStatusInKickOut(participantGameEntity.getParticipantGameStatus());
-
-
-        LocalDateTime now = validateStartDateTime(gameEntity);
-
-
-        participantGameEntity.kickout(now);
-
-
-        gameRepository.save(participantGameEntity.getGameEntity());
-
-        updateGameUserLevel(gameEntity);
-
-        notificationService.send(NotificationType.KICKED_OUT, participantGameEntity.getUserEntity(), participantGameEntity.getGameEntity().getTitle() + "에서 강퇴당하였습니다.");
-
-
-
-
-        log.info("[경기 강퇴 완료] participantId : {}, gameId : {}", participantUserId, gameId);
-
-        return CheckResponse.of(true, "참가자 강퇴를 완료하였습니다.");
-
-
-    }
 
 
 
@@ -161,12 +97,7 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
 
 
 
-    private void validateGameStatusInKickOut(ParticipantGameStatus status) {
 
-        switch (status) {
-            case KICKOUT -> throw new CustomException(ALREADY_KICKOUT_USER);
-        }
-    }
 
 
 
@@ -187,37 +118,5 @@ public class ParticipantGameServiceImpl implements ParticipantGameService {
                 .orElseThrow(() -> new CustomException(GAME_NOT_FOUND));
     }
 
-
-
-    private ParticipantGameEntity getParticipantGame(GameEntity gameEntity, Long participantUserId) {
-        return participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameEntity.getGameId(), participantUserId)
-                .orElseThrow(() -> new CustomException(PARTICIPANT_NOT_FOUND));
-    }
-
-    private static LocalDateTime validateStartDateTime(GameEntity gameEntity) {
-        LocalDateTime now = LocalDateTime.now();
-        if (gameEntity.getStartDateTime().isBefore(now)) {
-            throw new CustomException(ALREADY_START_GAME);
-        }
-        return now;
-    }
-
-    public void updateGameUserLevel(GameEntity gameEntity) {
-
-        List<ParticipantGameEntity> acceptedParticipants = participantGameRepository.findByGameEntity_GameIdAndParticipantGameStatus(gameEntity.getGameId(), ACCEPT);
-
-
-        double average = acceptedParticipants.stream()
-                .map(participantGameEntity -> participantGameEntity.getUserEntity().getGameUserLevel())
-                .mapToDouble(GameUserLevel::getValue)
-                .average()
-                .orElse(0.0);
-
-        GameUserLevel gameUserLevel = GameUserLevel.fromUserLevelAverage(average);
-
-
-        gameEntity.setGameUserLevel(gameUserLevel);
-
-    }
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -89,7 +89,8 @@ public enum ErrorCode {
     GAME_CREATION_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "경기 생성은 24시간 전에만 생성 가능합니다."),
     GAME_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "경기 수정이 불가능합니다."),
     GAME_SCHEDULE_TOO_SOON(HttpStatus.BAD_REQUEST, "경기 시작 시각은 현재보다 최소 24시간 이후여야 합니다."),
-
+    NOT_ALLOWED_KICKOUT(HttpStatus.BAD_REQUEST, "경기 시작 1시간 전부터는 참가자를 강퇴할 수 없습니다."),
+    NOT_ACTIVE_PARTICIPANT(HttpStatus.CONFLICT, "현재 경기에 참가 중인 사용자가 아닙니다."),
     GAME_SCHEDULE_REQUIRED_TOGETHER(HttpStatus.BAD_REQUEST, "경기 시작 시각과 종료 시각을 함께 입력해주세요."),
     NOT_CANCEL_GAME_CREATOR(HttpStatus.FORBIDDEN, "경기 생성자는 참가를 취소할 수 없습니다."),
 

--- a/src/main/java/com/example/basketballmatching/notifications/event/GameParticipantKickoutEventListener.java
+++ b/src/main/java/com/example/basketballmatching/notifications/event/GameParticipantKickoutEventListener.java
@@ -1,0 +1,43 @@
+package com.example.basketballmatching.notifications.event;
+
+import com.example.basketballmatching.game.event.GameParticipantKickedOutEvent;
+import com.example.basketballmatching.notifications.service.NotificationService;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameParticipantKickoutEventListener {
+
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(GameParticipantKickedOutEvent event) {
+
+        UserEntity participant = userRepository.findByUserIdAndDeletedDateTimeIsNull(event.participantUserId())
+                .orElse(null);
+
+        if (participant == null) {
+            log.warn("강퇴 알림 대상 사용자를 찾을 수 없습니다. userId={}", event.participantUserId());
+            return;
+        }
+
+        notificationService.send(
+                NotificationType.KICKED_OUT, participant, "'" + event.gameTitle() + "' 경기에서 강퇴되었습니다."
+        );
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 참가자 강퇴 로직이 기존 참가 서비스에 혼재
- 강퇴 알림을 트랜잭션 내부에서 직접 처리
- 강퇴 API URI가 쿼리 파라미터 방식

### 🚀 TO-BE

- 참가자 강퇴 책임을 `GameParticipantService`로 이동
- 경기 시작 1시간 전부터 강퇴를 제한하는 도메인 정책 적용
- 강퇴 알림을 `AFTER_COMMIT` 이벤트로 분리
- API를 `/api/v1/games/{gameId}/participants/{participantId}/kickout`으로 변경
- 기존 강퇴 로직 및 랭크 갱신 코드 제거

---

## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 전체 테스트 통과
- [x] 강퇴 상태 및 참가 인원 변경 확인
- [x] Swagger 설명 업데이트