### PR TITLE
[test] : 경기 기능 통합 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthAccountServiceUnitTest" \
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthServiceUnitTest" \
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthStateStoreUnitTest" \
-            --tests "com.example.basketballmatching.auth.oauth2.support.OAuthStateCookieManagerUnitTest"  
+            --tests "com.example.basketballmatching.auth.oauth2.service.OAuthStateCookieManagerUnitTest" \
+            --tests "com.example.basketballmatching.game.service.GameServiceUnitTest" \
+            --tests "com.example.basketballmatching.game.service.GameParticipantServiceUnitTest"
 
       - name: Upload unit test report
         if: always()
@@ -86,7 +88,10 @@ jobs:
             --tests "com.example.basketballmatching.user.service.UserWithdrawalServiceIntegrationTest" \
             --tests "com.example.basketballmatching.auth.service.AuthServiceIntegrationTest" \
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthServiceIntegrationTest" \
-            --tests "com.example.basketballmatching.auth.oauth2.controller.OAuthStateFlowIntegrationTest"
+            --tests "com.example.basketballmatching.auth.oauth2.controller.OAuthStateFlowIntegrationTest" \
+            --tests "com.example.basketballmatching.game.service.GameServiceIntegrationTest" \
+            --tests "com.example.basketballmatching.game.service.GameParticipantServiceIntegrationTest" \
+            --tests "com.example.basketballmatching.game.repository.query.GameQueryRepositoryIntegrationTest"
 
       - name: Upload integration test report
         if: always()

--- a/src/test/java/com/example/basketballmatching/game/repository/query/GameQueryRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/game/repository/query/GameQueryRepositoryIntegrationTest.java
@@ -1,0 +1,429 @@
+package com.example.basketballmatching.game.repository.query;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.dto.request.GameListCondition;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.type.*;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.basketballmatching.game.type.CityName.GYEONGGI;
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.FieldStatus.OUTDOOR;
+import static com.example.basketballmatching.game.type.GameSortType.LATEST;
+import static com.example.basketballmatching.game.type.GameSortType.START_TIME_ASC;
+import static com.example.basketballmatching.game.type.GameStatus.RECRUITING;
+import static com.example.basketballmatching.game.type.MatchFormat.FIVE_ON_FIVE;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static org.junit.jupiter.api.Assertions.*;
+
+@IntegrationTest
+@Transactional
+@DisplayName("GameQueryRepository 통합 테스트")
+class GameQueryRepositoryIntegrationTest {
+
+    @Autowired
+    private GameQueryRepository gameQueryRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private UserEntity creator;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.save(
+                UserEntity.create(
+                        "query-creator@test.com",
+                        "encoded-password",
+                        "조회테스트생성자",
+                        "조회테스트생성자",
+                        LocalDate.of(1997, 1, 1),
+                        "010-3333-3333",
+                        "서울특별시 송파구",
+                        Position.GUARD,
+                        GenderType.MALE
+                )
+        );
+
+        now = LocalDateTime.now(clock)
+                .withSecond(0)
+                .withNano(0);
+    }
+
+
+    @Test
+    @DisplayName("기본 조회 시 삭제되지 않은 미래 경기를 시작 시간순으로 조회")
+    void findGames_success_defaultCondition() {
+        // given
+
+        GameEntity earlyGame = saveGame(
+                "빠른 미래 경기",
+                "잠실 1경기장",
+                "서울특별시 송파구 테스트로 1",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(2)
+        );
+
+        GameEntity lateGame = saveGame(
+                "늦은 미래 경기",
+                "잠실 2경기장",
+                "서울특별시 송파구 테스트로 2",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(4)
+        );
+
+        saveGame(
+                "지난 경기",
+                "잠실 3경기장",
+                "서울특별시 송파구 테스트로 3",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.minusDays(1)
+        );
+
+        GameEntity deletedGame = saveGame(
+                "삭제된 미래 경기",
+                "잠실 4경기장",
+                "서울특별시 송파구 테스트로 4",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(3)
+        );
+
+        deletedGame.cancelByCreatorWithdrawal(now);
+
+        flushAndClear();
+
+        GameListCondition condition = condition(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                START_TIME_ASC
+        );
+
+        // when
+
+        Page<GameEntity> result = gameQueryRepository.findGames(condition, PageRequest.of(0, 10), now);
+
+        // then
+
+        List<Long> gameIds = result.getContent()
+                .stream()
+                .map(GameEntity::getGameId)
+                .toList();
+
+        assertAll(
+                () -> assertEquals(
+                        List.of(
+                                earlyGame.getGameId(),
+                                lateGame.getGameId()
+                        ),
+                        gameIds
+                ),
+                () -> assertEquals(
+                        2,
+                        result.getTotalElements()
+                ),
+                () -> assertEquals(
+                        1,
+                        result.getTotalPages()
+                )
+        );
+
+    }
+
+    @Test
+    @DisplayName("키워드, 지역 및 경기 조건을 조합하여 조회")
+    void findGames_success_combinedCondition() {
+        // given
+        GameEntity expectedGame = saveGame(
+                "잠실 초보 농구",
+                "잠실체육관",
+                "서울특별시 송파구 테스트로 10",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(2)
+        );
+
+        saveGame(
+                "강남 직장인 농구",
+                "강남체육관",
+                "서울특별시 강남구 테스트로 11",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(3)
+        );
+
+        saveGame(
+                "잠실과 이름이 비슷한 경기",
+                "경기체육관",
+                "경기도 성남시 테스트로 12",
+                GYEONGGI,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(4)
+        );
+
+        saveGame(
+                "잠실 5대5 농구",
+                "잠실 5대5 체육관",
+                "서울특별시 송파구 테스트로 13",
+                SEOUL,
+                FIVE_ON_FIVE,
+                OUTDOOR,
+                MIXED,
+                now.plusDays(5)
+        );
+
+        flushAndClear();
+
+        GameListCondition condition = condition(
+                "잠실",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                RECRUITING,
+                START_TIME_ASC
+        );
+
+        // when
+
+        Page<GameEntity> result =
+                gameQueryRepository.findGames(
+                        condition,
+                        PageRequest.of(0, 10),
+                        now
+                );
+
+        // then
+
+        assertEquals(1, result.getTotalElements());
+
+        assertEquals(expectedGame.getGameId(), result.getContent().get(0).getGameId());
+
+
+    }
+
+    @Test
+    @DisplayName("최신순 정렬 및 페이지 사이즈에 맞게 조회")
+    void findGames_success_latestPagination() {
+        // given
+
+        GameEntity firstCreatedGame = saveGame(
+                "첫 번째 생성 경기",
+                "경기장 20",
+                "서울특별시 송파구 테스트로 20",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(2)
+        );
+
+        GameEntity secondCreatedGame = saveGame(
+                "두 번째 생성 경기",
+                "경기장 21",
+                "서울특별시 송파구 테스트로 21",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(3)
+        );
+
+        GameEntity lastCreatedGame = saveGame(
+                "마지막 생성 경기",
+                "경기장 22",
+                "서울특별시 송파구 테스트로 22",
+                SEOUL,
+                THREE_ON_THREE,
+                INDOOR,
+                MIXED,
+                now.plusDays(4)
+        );
+
+        flushAndClear();
+
+        GameListCondition condition = condition(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                LATEST
+        );
+
+        // when
+
+        Page<GameEntity> firstPage =
+                gameQueryRepository.findGames(
+                        condition,
+                        PageRequest.of(0, 2),
+                        now
+                );
+
+        Page<GameEntity> secondPage =
+                gameQueryRepository.findGames(
+                        condition,
+                        PageRequest.of(1, 2),
+                        now
+                );
+
+        // then
+
+        List<Long> firstPageIds =
+                firstPage.getContent()
+                        .stream()
+                        .map(GameEntity::getGameId)
+                        .toList();
+
+        List<Long> secondPageIds =
+                secondPage.getContent()
+                        .stream()
+                        .map(GameEntity::getGameId)
+                        .toList();
+
+        assertAll(
+                () -> assertEquals(
+                        List.of(
+                                lastCreatedGame.getGameId(),
+                                secondCreatedGame.getGameId()
+                        ),
+                        firstPageIds
+                ),
+                () -> assertEquals(
+                        List.of(firstCreatedGame.getGameId()),
+                        secondPageIds
+                ),
+                () -> assertEquals(
+                        3,
+                        firstPage.getTotalElements()
+                ),
+                () -> assertEquals(
+                        2,
+                        firstPage.getTotalPages()
+                ),
+                () -> assertEquals(
+                        2,
+                        firstPage.getNumberOfElements()
+                ),
+                () -> assertEquals(
+                        1,
+                        secondPage.getNumberOfElements()
+                )
+        );
+
+    }
+
+    private GameEntity saveGame(
+            String title,
+            String placeName,
+            String address,
+            CityName cityName,
+            MatchFormat matchFormat,
+            FieldStatus fieldStatus,
+            MatchGenderType matchGenderType,
+            LocalDateTime startDateTime
+    ) {
+        int headCount =
+                matchFormat == THREE_ON_THREE
+                        ? 6
+                        : 10;
+
+        GameEntity game = GameEntity.create(
+                title,
+                "경기 조회 통합 테스트입니다.",
+                headCount,
+                fieldStatus,
+                matchFormat,
+                matchGenderType,
+                startDateTime,
+                startDateTime.plusHours(2),
+                placeName,
+                address,
+                cityName,
+                37.515,
+                127.073,
+                creator,
+                startDateTime.minusDays(2)
+        );
+
+        return gameRepository.save(game);
+    }
+
+    private GameListCondition condition(
+            String keyword,
+            CityName cityName,
+            MatchFormat matchFormat,
+            FieldStatus fieldStatus,
+            MatchGenderType matchGenderType,
+            com.example.basketballmatching.game.type.GameStatus gameStatus,
+            GameSortType sortType
+    ) {
+        return new GameListCondition(
+                null,
+                keyword,
+                cityName,
+                matchFormat,
+                fieldStatus,
+                matchGenderType,
+                gameStatus,
+                sortType
+        );
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/example/basketballmatching/game/service/GameParticipantServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/game/service/GameParticipantServiceIntegrationTest.java
@@ -1,0 +1,253 @@
+package com.example.basketballmatching.game.service;
+
+import com.example.basketballmatching.blackList.repository.BlackListRepository;
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.dto.request.CreateGameRequest;
+import com.example.basketballmatching.game.dto.response.CreateGameResponse;
+import com.example.basketballmatching.game.dto.response.GameParticipantResponse;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.game.type.ParticipantGameStatus;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@IntegrationTest
+@DisplayName("GameParticipantService 통합 테스트")
+class GameParticipantServiceIntegrationTest {
+
+    @Autowired
+    private GameService gameService;
+
+    @Autowired
+    private GameParticipantService gameParticipantService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
+
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private Long creatorId;
+    private Long participantId;
+    private Long gameId;
+
+
+    @BeforeEach
+    void setUp() {
+
+        UserEntity creator = saveUser("creator@test.com", "경기생성자", "010-1111-1111");
+
+        UserEntity participant = saveUser("participant@test.com", "경기 참가자", "010-2222-2222");
+
+        creatorId = creator.getUserId();
+        participantId = participant.getUserId();
+
+        LocalDateTime startDateTime = LocalDateTime.now(clock).plusDays(2).withSecond(0).withNano(0);
+
+        CreateGameRequest request =
+                new CreateGameRequest(
+                        "잠실 참가 테스트 경기",
+                        "경기 참가 통합 테스트입니다.",
+                        6,
+                        INDOOR,
+                        THREE_ON_THREE,
+                        MIXED,
+                        startDateTime,
+                        startDateTime.plusHours(2),
+                        "잠실종합운동장 농구장",
+                        "서울특별시 송파구 올림픽로 25",
+                        37.515,
+                        127.073
+                );
+
+        CreateGameResponse response = gameService.createGame(creatorId, request);
+
+        gameId = response.gameId();
+
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("경기 참가 시 참가 정보 저장 후 경기 인원 증가")
+    void join_success() {
+        // given
+
+
+        // when
+
+        GameParticipantResponse response = gameParticipantService.join(gameId, participantId);
+
+        flushAndClear();
+
+        // then
+
+        ParticipantGameEntity participation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+                .orElseThrow();
+
+        GameEntity game = gameRepository.findById(gameId)
+                .orElseThrow();
+
+        assertNotNull(response.participationId());
+        assertEquals(ACCEPT, participation.getParticipantGameStatus());
+        assertEquals(ACCEPT, response.status());
+        assertNotNull(participation.getAcceptDateTime());
+        assertEquals(2, game.getParticipantCount());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 시 상태 변경 후 인원 감소")
+    void cancelParticipation_success() {
+        // given
+
+        GameParticipantResponse joined = gameParticipantService.join(gameId, participantId);
+
+        flushAndClear();
+
+        // when
+
+        gameParticipantService.cancelParticipation(gameId, participantId);
+
+        flushAndClear();
+        // then
+
+        ParticipantGameEntity participation = participantGameRepository.findById(joined.participationId())
+                .orElseThrow();
+
+        GameEntity game = gameRepository.findById(gameId)
+                .orElseThrow();
+
+        assertEquals(CANCEL, participation.getParticipantGameStatus());
+
+        assertNotNull(participation.getCanceledDateTime());
+
+        assertEquals(1, game.getParticipantCount());
+
+    }
+
+    @Test
+    @DisplayName("경기 참가 취소 후 재참가하면 참가 정보를 재사용")
+    void rejoin_success() {
+        // given
+
+        GameParticipantResponse firstJoin = gameParticipantService.join(gameId, participantId);
+
+        gameParticipantService.cancelParticipation(gameId, participantId);
+
+        flushAndClear();
+
+        // when
+
+        GameParticipantResponse rejoined = gameParticipantService.join(gameId, participantId);
+
+        flushAndClear();
+
+        // then
+
+        ParticipantGameEntity participation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(gameId, participantId)
+                .orElseThrow();
+
+        GameEntity game = gameRepository.findById(gameId)
+                .orElseThrow();
+
+
+        assertEquals(firstJoin.participationId(), rejoined.participationId());
+
+        assertEquals(ACCEPT, participation.getParticipantGameStatus());
+
+        assertNull(participation.getCanceledDateTime());
+
+        assertEquals(2, game.getParticipantCount());
+
+        assertEquals(2, participantGameRepository.count());
+
+    }
+
+    @Test
+    @DisplayName("경기 생성자가 참가자 강퇴 시 상태 변경 및 인원 감소")
+    void kickoutParticipant_success() {
+        // given
+
+        GameParticipantResponse joined = gameParticipantService.join(gameId, participantId);
+
+        flushAndClear();
+
+
+
+        // when
+
+        gameParticipantService.kickoutParticipant(gameId, joined.participationId(), creatorId);
+
+        flushAndClear();
+        // then
+
+        ParticipantGameEntity participation = participantGameRepository.findById(joined.participationId())
+                .orElseThrow();
+
+        GameEntity game = gameRepository.findById(gameId)
+                .orElseThrow();
+
+        assertEquals(KICKOUT, participation.getParticipantGameStatus());
+
+        assertNotNull(participation.getKickoutDateTime());
+        assertEquals(1, game.getParticipantCount());
+
+    }
+
+
+    private UserEntity saveUser(String email, String nickname, String phone) {
+
+        UserEntity user = UserEntity.create(
+                email,
+                "encoded-password",
+                nickname,
+                nickname,
+                LocalDate.of(1997, 1, 1),
+                phone,
+                "서울특별시 송파구",
+                Position.GUARD,
+                GenderType.MALE
+        );
+
+        return userRepository.save(user);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+
+}

--- a/src/test/java/com/example/basketballmatching/game/service/GameServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/game/service/GameServiceIntegrationTest.java
@@ -1,0 +1,274 @@
+package com.example.basketballmatching.game.service;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.dto.request.CreateGameRequest;
+import com.example.basketballmatching.game.dto.request.UpdateGameRequest;
+import com.example.basketballmatching.game.dto.response.CreateGameResponse;
+import com.example.basketballmatching.game.dto.response.GameDetailResponse;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.ACCEPT;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.DELETE;
+import static com.example.basketballmatching.global.exception.ErrorCode.PLACE_SCHEDULE_OVERLAP;
+import static org.junit.jupiter.api.Assertions.*;
+@IntegrationTest
+@Transactional
+@DisplayName("GameService 통합 테스트")
+class GameServiceIntegrationTest {
+
+    @Autowired
+    private GameService gameService;
+
+    @Autowired
+    private GameParticipantService gameParticipantService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private UserEntity creator;
+    private LocalDateTime startDateTime;
+
+    @BeforeEach
+    void setUp() {
+
+        creator = saveUser(
+                "creator@test.com", "경기 생성자", "010-1111-1111"
+        );
+
+        startDateTime = LocalDateTime.now(clock).plusDays(2).withSecond(0).withNano(0);
+    }
+
+    @Test
+    @DisplayName("경기 생성 시 경기와 생성자 참가 정보가 함께 저장")
+    void createGame_success() {
+        // given
+
+        CreateGameRequest request = createGameRequest();
+
+
+
+        // when
+        CreateGameResponse response = gameService.createGame(creator.getUserId(), request);
+
+        flushAndClear();
+
+
+        // then
+
+        GameEntity savedGame = gameRepository.findByGameIdAndDeletedDateTimeIsNull(response.gameId())
+                .orElseThrow();
+
+        ParticipantGameEntity creatorParticipation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(response.gameId(), creator.getUserId())
+                .orElseThrow();
+
+        assertAll(
+                () -> assertNotNull(response.gameId()),
+                () -> assertEquals(request.title(), savedGame.getTitle()),
+                () -> assertEquals(SEOUL, savedGame.getCityName()),
+                () -> assertEquals(1, savedGame.getParticipantCount()),
+                () -> assertEquals(ACCEPT, creatorParticipation.getParticipantGameStatus()),
+                () -> assertEquals(creator.getUserId(), creatorParticipation.getUserEntity().getUserId())
+        );
+
+    }
+
+    @Test
+    @DisplayName("동일 장소에 경기 시간이 겹치면 예외 발생")
+    void createGame_fail_scheduleOverlap() {
+        // given
+
+        CreateGameRequest request = createGameRequest();
+
+        CreateGameResponse response = gameService.createGame(creator.getUserId(), request);
+
+
+        flushAndClear();
+
+        long gameCountBefore = gameRepository.count();
+        long participationCountBefore = participantGameRepository.count();
+
+        CreateGameRequest overlapRequest =
+                new CreateGameRequest(
+                        "시간이 겹치는 경기",
+                        "동일 장소의 시간이 겹치는 경기입니다.",
+                        6,
+                        INDOOR,
+                        THREE_ON_THREE,
+                        MIXED,
+                        request.startDateTime().plusMinutes(30),
+                        request.endDateTime().plusMinutes(30),
+                        request.placeName(),
+                        request.address(),
+                        request.latitude(),
+                        request.longitude()
+                );
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> gameService.createGame(creator.getUserId(), overlapRequest));
+
+        // then
+
+        assertAll(
+                () -> assertEquals(PLACE_SCHEDULE_OVERLAP, exception.getErrorCode()),
+                () -> assertEquals(gameCountBefore, gameRepository.count()),
+                () -> assertEquals(participationCountBefore, participantGameRepository.count())
+        );
+
+    }
+
+    @Test
+    @DisplayName("경기 수정 성공")
+    void updateGame_success() {
+        // given
+
+        CreateGameResponse createGame = gameService.createGame(creator.getUserId(), createGameRequest());
+
+        flushAndClear();
+
+        UpdateGameRequest request =
+                new UpdateGameRequest(
+                        "수정된 경기 제목",
+                        "수정된 경기 내용",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                );
+        // when
+
+        GameDetailResponse response = gameService.updateGame(request, createGame.gameId(), creator.getUserId());
+
+        flushAndClear();
+        // then
+
+        GameEntity updateGame = gameRepository.findByGameIdAndDeletedDateTimeIsNull(createGame.gameId())
+                .orElseThrow();
+
+        assertEquals("수정된 경기 제목", updateGame.getTitle());
+        assertEquals("수정된 경기 제목", response.title());
+        assertEquals("수정된 경기 내용", updateGame.getContent());
+
+
+
+    }
+
+    @Test
+    @DisplayName("경기 삭제 시 경기와 모든 참가 정보가 삭제 상태로 변경")
+    void deleteGame_success() {
+        // given
+
+        UserEntity participant = saveUser("participant@test.com", "경기 참가자", "010-2222-2222");
+
+        CreateGameResponse createdGame = gameService.createGame(creator.getUserId(), createGameRequest());
+
+        gameParticipantService.join(createdGame.gameId(), participant.getUserId());
+
+        flushAndClear();
+
+        // when
+
+        gameService.deleteGame(createdGame.gameId(), creator.getUserId());
+
+        flushAndClear();
+
+        // then
+
+        GameEntity deletedGame = gameRepository.findById(createdGame.gameId())
+                .orElseThrow();
+
+        ParticipantGameEntity creatorParticipation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(createdGame.gameId(), creator.getUserId())
+                .orElseThrow();
+
+        ParticipantGameEntity participantParticipation = participantGameRepository.findByGameEntity_GameIdAndUserEntity_UserId(createdGame.gameId(), participant.getUserId())
+                .orElseThrow();
+
+        assertAll(
+                () -> assertNotNull(deletedGame.getDeletedDateTime()),
+                () -> assertEquals(0, deletedGame.getParticipantCount()),
+                () -> assertTrue(gameRepository.findByGameIdAndDeletedDateTimeIsNull(createdGame.gameId()).isEmpty()),
+                () -> assertEquals(DELETE, creatorParticipation.getParticipantGameStatus()),
+                () -> assertEquals(DELETE, participantParticipation.getParticipantGameStatus()),
+                () -> assertNotNull(participantParticipation.getDeletedDateTime())
+        );
+    }
+
+    private CreateGameRequest createGameRequest() {
+        return new CreateGameRequest(
+                "잠실 주말 농구",
+                "즐겁게 농구하실 분을 모집합니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                startDateTime.plusHours(2),
+                "잠실종합운동장 농구장",
+                "서울특별시 송파구 올림픽로 25",
+                37.515,
+                127.073
+        );
+    }
+
+    private UserEntity saveUser(
+            String email,
+            String nickname,
+            String phone
+    ) {
+        UserEntity user = UserEntity.create(
+                email,
+                "encoded-password",
+                nickname,
+                nickname,
+                LocalDate.of(1997, 1, 1),
+                phone,
+                "서울특별시 송파구",
+                Position.GUARD,
+                GenderType.MALE
+        );
+
+        return userRepository.save(user);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+}

--- a/src/test/java/com/example/basketballmatching/game/service/GameServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/game/service/GameServiceIntegrationTest.java
@@ -9,7 +9,6 @@ import com.example.basketballmatching.game.dto.response.GameDetailResponse;
 import com.example.basketballmatching.game.repository.GameRepository;
 import com.example.basketballmatching.game.repository.ParticipantGameRepository;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.support.IntegrationTest;
 import com.example.basketballmatching.user.domain.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;

--- a/src/test/java/com/example/basketballmatching/user/service/UserWithdrawalServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/user/service/UserWithdrawalServiceIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @IntegrationTest
-@DisplayName("UserWithdrawalService xhdgkq xptmxm")
+@DisplayName("UserWithdrawalService 통합 테스트")
 class UserWithdrawalServiceIntegrationTest {
 
     private static final String WITHDRAWAL_EMAIL =


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 경기 리팩터링 이후 실제 DB 기반 검증 부족
- 경기 단위·통합 테스트가 CI 실행 대상에서 누락
- 복잡한 QueryDSL 조회 결과를 검증하는 테스트 부재

### 🚀 TO-BE

- 경기 생성·수정·삭제 통합 테스트 추가
- 참가·취소·재참가·강퇴 통합 테스트 추가
- 검색·필터·정렬·페이징 QueryDSL 통합 테스트 추가
- 경기 단위 및 통합 테스트를 CI 실행 대상으로 등록
- OAuth 단위 테스트 패키지 경로 오류 수정

---

## ✅ 체크리스트

- [x] 경기 단위 테스트 통과
- [x] 경기 통합 테스트 통과
- [x] 실제 MySQL Testcontainers 환경 검증
- [x] CI 테스트 실행 대상 추가