### PR TITLE
[feat] : 경기 확정 참가자 명단 조회 권한 확장

### DIFF
--- a/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
+++ b/src/main/java/com/example/basketballmatching/game/controller/GameParticipantController.java
@@ -86,9 +86,9 @@ public class GameParticipantController {
 
     }
 
-    @Operation(summary = "경기 참가자 목록 조회", description = "경기 생성자가 참가 확정된 사용자 목록을 조회한다.")
+    @Operation(summary = "경기 참가자 목록 조회", description = "해당 경기에 참가 확정된 사용자가 같은 경기 확정 참가자 목록 조회")
     @ApiResponse(responseCode = "200", description = "경기 참가자 목록 조회 성공")
-    @ApiResponse(responseCode = "403", description = "경기 생성자가 아님",
+    @ApiResponse(responseCode = "403", description = "해당 경기의 참가 확정 사용자가 아님",
     content = @Content(mediaType = "application/json",
     schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "404", description = "사용자 또는 경기를 찾을 수 없다.",
@@ -107,7 +107,7 @@ public class GameParticipantController {
             @Parameter(description = "페이지 크기", example = "10")
             @RequestParam(defaultValue = "10")
             @Min(1)
-            @Max(100)
+            @Max(20)
             int size,
             @AuthenticationPrincipal UserInfoDetails userInfoDetails
     ) {

--- a/src/main/java/com/example/basketballmatching/game/dto/response/GameParticipantListResponse.java
+++ b/src/main/java/com/example/basketballmatching/game/dto/response/GameParticipantListResponse.java
@@ -2,11 +2,9 @@ package com.example.basketballmatching.game.dto.response;
 
 import com.example.basketballmatching.game.domain.ParticipantGameEntity;
 import com.example.basketballmatching.user.domain.UserEntity;
-import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 public record GameParticipantListResponse(
@@ -20,14 +18,9 @@ public record GameParticipantListResponse(
         @Schema(description = "사용자 닉네임", example = "농구왕")
         String nickname,
 
-        @Schema(description = "성별", example = "MALE")
-        GenderType genderType,
 
         @Schema(description = "선호 포지션", example = "GUARD")
         Position position,
-
-        @Schema(description = "참가 확정 시각", example = "2026-08-13T15:00:00")
-        LocalDateTime joinedAt,
 
         @Schema(description = "경기 생성자 여부", example = "false")
         boolean creator
@@ -42,9 +35,7 @@ public record GameParticipantListResponse(
                 participation.getParticipantGameId(),
                 participant.getUserId(),
                 participant.getNickname(),
-                participant.getGenderType(),
                 participant.getPosition(),
-                participation.getAcceptDateTime(),
                 Objects.equals(participant.getUserId(), creatorId)
         );
 

--- a/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
@@ -13,7 +13,9 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
 
     boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long userId, Long gameId);
 
-
+    boolean existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+            Long gameId, Long userId, ParticipantGameStatus status
+    );
 
     List<ParticipantGameEntity> findByParticipantGameStatusInAndGameEntity_GameId(List<ParticipantGameStatus> statuses, Long gameId);
 

--- a/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
+++ b/src/main/java/com/example/basketballmatching/game/service/GameParticipantService.java
@@ -94,11 +94,12 @@ public class GameParticipantService {
 
         log.info("[경기 참가자 목록 조회 시작] gameId={}, userId={}", gameId, userId);
 
-        UserEntity requester = getActiveUser(userId);
+       getActiveUser(userId);
 
         GameEntity game = getActiveGame(gameId);
 
-        validateGameCreator(game, requester);
+        validateParticipantListAccess(gameId, userId);
+
 
         Long creatorId = game.getUserEntity().getUserId();
 
@@ -141,6 +142,18 @@ public class GameParticipantService {
                 game.getGameId(),game.getTitle(), participant.getUserId()
         ));
 
+
+    }
+
+    private void validateParticipantListAccess(Long gameId, Long userId) {
+
+        boolean acceptedParticipant = participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                gameId, userId, ACCEPT
+        );
+
+        if (!acceptedParticipant) {
+            throw new CustomException(PARTICIPANT_LIST_ACCESS_DENIED);
+        }
 
     }
 

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -93,7 +93,7 @@ public enum ErrorCode {
     NOT_ACTIVE_PARTICIPANT(HttpStatus.CONFLICT, "현재 경기에 참가 중인 사용자가 아닙니다."),
     GAME_SCHEDULE_REQUIRED_TOGETHER(HttpStatus.BAD_REQUEST, "경기 시작 시각과 종료 시각을 함께 입력해주세요."),
     NOT_CANCEL_GAME_CREATOR(HttpStatus.FORBIDDEN, "경기 생성자는 참가를 취소할 수 없습니다."),
-
+    PARTICIPANT_LIST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "참가가 확정된 사용자만 참가자 목록을 조회할 수 있습니다."),
     NO_GAME_UPDATE_FIELDS(HttpStatus.BAD_REQUEST, "수정할 경기 정보를 입력해주세요."),
 
     // level


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 경기 생성자만 확정 참가자 목록 조회 가능
- 참가자 응답에 불필요한 성별과 참가 시각 포함

### 🚀 TO-BE

- 해당 경기의 `ACCEPT` 참가자도 확정 참가자 목록 조회 가능
- 닉네임·포지션 중심으로 참가자 응답 간소화
- 신고 및 강퇴 처리를 위한 사용자·참가 관계 ID 유지
- 참가자 목록 페이지 크기를 경기 최대 인원인 20명으로 제한

---

## ✅ 체크리스트

- [x] 코드 컴파일 확인
- [x] 기존 경기 참가 단위 테스트 통과
- [ ] 참가자 목록 API 동작 확인