### PR TITLE
[test] : 신고 및 블랙리스트 단위 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthStateStoreUnitTest" \
             --tests "com.example.basketballmatching.auth.oauth2.service.OAuthStateCookieManagerUnitTest" \
             --tests "com.example.basketballmatching.game.service.GameServiceUnitTest" \
-            --tests "com.example.basketballmatching.game.service.GameParticipantServiceUnitTest"
+            --tests "com.example.basketballmatching.game.service.GameParticipantServiceUnitTest" \
+            --tests "com.example.basketballmatching.report.service.ReportServiceUnitTest" \
+            --tests "com.example.basketballmatching.blacklist.service.BlackListServiceUnitTest" \
+            --tests "com.example.basketballmatching.game.service.BlackListGameServiceUnitTest"
 
       - name: Upload unit test report
         if: always()

--- a/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceUnitTest.java
@@ -1,0 +1,533 @@
+package com.example.basketballmatching.blacklist.service;
+
+import com.example.basketballmatching.blacklist.domain.BlackListEntity;
+import com.example.basketballmatching.blacklist.dto.response.BlackListResponse;
+import com.example.basketballmatching.blacklist.dto.response.CreateBlackListResponse;
+import com.example.basketballmatching.blacklist.event.UserBlacklistedEvent;
+import com.example.basketballmatching.blacklist.repository.BlackListRepository;
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.dto.BlackListGameResultDto;
+import com.example.basketballmatching.game.dto.GameCancelNotificationDto;
+import com.example.basketballmatching.game.service.BlackListGameService;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.report.domain.ReportEntity;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.basketballmatching.blacklist.type.BlackListStatus.*;
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static com.example.basketballmatching.report.type.ReportType.*;
+import static com.example.basketballmatching.user.type.UserType.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BlackListService 단위 테스트")
+class BlackListServiceUnitTest {
+
+    private static final Long ADMIN_ID = 1L;
+    private static final Long REPORTER_ID = 2L;
+    private static final Long TARGET_ID = 3L;
+
+    private static final Long GAME_ID = 10L;
+    private static final Long REPORT_ID = 20L;
+    private static final Long BLACKLIST_ID = 30L;
+    private static final Long RECEIVER_ID = 4L;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 27, 12, 0);
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private BlackListRepository blackListRepository;
+
+    @Mock
+    private BlackListGameService blackListGameService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private BlackListService blackListService;
+
+    private UserEntity admin;
+    private UserEntity reporter;
+    private UserEntity target;
+    private GameEntity game;
+
+
+    @BeforeEach
+    void setUp() {
+
+        Clock clock = Clock.fixed(NOW.atZone(ZONE_ID).toInstant(), ZONE_ID);
+
+        blackListService = new BlackListService(
+                userRepository, reportRepository, blackListRepository, blackListGameService, eventPublisher, clock
+        );
+
+        admin = createUser(ADMIN_ID, "admin@test.com", "관리자", ADMIN);
+
+        reporter = createUser(REPORTER_ID, "reporter@test.com", "신고자", USER);
+
+        target = createUser(TARGET_ID, "target@test.com", "신고 대상", USER);
+
+        game = createGame();
+    }
+
+    @Nested
+    @DisplayName("블랙리스트 제재 등록")
+    class CreateBlackList {
+
+        @Test
+        @DisplayName("승인된 신고를 근거로 7일 제재를 등록하고 이벤트를 발행한다.")
+        void createBlackList_success() {
+            // given
+
+            ReportEntity approvedReport = createApprovedReport();
+
+            GameCancelNotificationDto notice = new GameCancelNotificationDto(RECEIVER_ID, game.getTitle());
+
+            BlackListGameResultDto gameResult = new BlackListGameResultDto(List.of(notice));
+
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(approvedReport));
+
+            when(blackListRepository.existsByReportEntity_ReportId(REPORT_ID))
+                    .thenReturn(false);
+
+            when(blackListRepository.existsByUserEntity_UserIdAndExpiresAtAfter(
+                    TARGET_ID, NOW
+            )).thenReturn(false);
+
+            when(blackListRepository.save(any(BlackListEntity.class)))
+                    .thenAnswer(invocation -> {
+                        BlackListEntity blackList = invocation.getArgument(0);
+
+                        ReflectionTestUtils.setField(blackList,"blackListId", BLACKLIST_ID);
+                        return blackList;
+                    });
+
+            when(blackListGameService.cleanup(TARGET_ID, NOW))
+                    .thenReturn(gameResult);
+
+            // when
+
+            CreateBlackListResponse response = blackListService.createBlackList(ADMIN_ID, REPORT_ID);
+
+            // then
+
+            assertEquals(BLACKLIST_ID, response.blackListId());
+
+            assertEquals(REPORT_ID, response.reportId());
+
+            assertEquals(TARGET_ID, response.targetUserId());
+
+            assertEquals(NOW.plusDays(7), response.expiresAt());
+
+            assertEquals(ACTIVE, response.status());
+
+            ArgumentCaptor<BlackListEntity> blackListCaptor = ArgumentCaptor.forClass(BlackListEntity.class);
+
+            verify(blackListRepository).save(blackListCaptor.capture());
+
+            BlackListEntity savedBlackList = blackListCaptor.getValue();
+
+            assertEquals(approvedReport, savedBlackList.getReportEntity());
+
+            assertEquals(target, savedBlackList.getUserEntity());
+
+            assertEquals(admin, savedBlackList.getBannedBy());
+
+            ArgumentCaptor<UserBlacklistedEvent> eventCaptor = ArgumentCaptor.forClass(UserBlacklistedEvent.class);
+
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+            UserBlacklistedEvent event = eventCaptor.getValue();
+
+            assertEquals(TARGET_ID, event.userId());
+
+            assertEquals(target.getEmail(), event.email());
+
+            assertEquals(NOW, event.bannedAt());
+
+            assertEquals(NOW.plusDays(7), event.expiresAt());
+
+            assertEquals(1, event.notices().size());
+
+            assertEquals(RECEIVER_ID, event.notices().get(0).receiverId());
+
+        }
+        @Test
+        @DisplayName("승인되지 않은 신고는 제재에 사용할 수 없다.")
+        void createBlackList_fail_reportNotApproved() {
+            // given
+
+            ReportEntity pendingReport = createPendingReport();
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(pendingReport));
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> blackListService.createBlackList(ADMIN_ID, REPORT_ID));
+
+            // then
+
+            assertEquals(REPORT_NOT_APPROVED, exception.getErrorCode());
+
+            verifyNoInteractions(blackListGameService, eventPublisher);
+
+        }
+
+        @Test
+        @DisplayName("이미 제재에 사용한 신고를 재사용할 수 없다.")
+        void createBlackList_fail_reportAlreadyUsed() {
+            // given
+
+            ReportEntity approvedReport = createApprovedReport();
+
+            when(userRepository
+                    .findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(approvedReport));
+
+            when(blackListRepository
+                    .existsByReportEntity_ReportId(REPORT_ID))
+                    .thenReturn(true);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> blackListService.createBlackList(ADMIN_ID, REPORT_ID));
+
+            // then
+
+            assertEquals(BLACKLIST_REPORT_ALREADY_USED, exception.getErrorCode());
+
+            verify(blackListRepository, never()).save(any());
+
+            verifyNoInteractions(blackListGameService, eventPublisher);
+
+        }
+
+        @Test
+        @DisplayName("이미 활성 제재 중인 사용자를 다시 제재할 수 없다.")
+        void createBlackList_fail_alreadyBlacklisted() {
+            // given
+
+            ReportEntity approvedReport = createApprovedReport();
+
+            when(userRepository
+                    .findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(approvedReport));
+
+            when(blackListRepository
+                    .existsByReportEntity_ReportId(REPORT_ID))
+                    .thenReturn(false);
+
+            when(blackListRepository
+                    .existsByUserEntity_UserIdAndExpiresAtAfter(
+                            TARGET_ID,
+                            NOW
+                    ))
+                    .thenReturn(true);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> blackListService.createBlackList(ADMIN_ID, REPORT_ID));
+
+            // then
+
+            assertEquals(ALREADY_BLACK_USER, exception.getErrorCode());
+
+            verify(blackListRepository, never()).save(any());
+
+            verifyNoInteractions(blackListGameService, eventPublisher);
+
+        }
+
+    }
+
+    @Nested
+    @DisplayName(("블랙리스트 목록 조회"))
+    class GetBlackLists{
+
+        @Test
+        @DisplayName("활성 제재 목록을 조회한다")
+        void getBlackLists_success_active() {
+            // given
+            PageRequest pageable =
+                    PageRequest.of(0, 20);
+
+            BlackListEntity activeBlackList =
+                    createBlackListEntity(
+                            NOW.minusDays(1),
+                            NOW.plusDays(6)
+                    );
+
+            Page<BlackListEntity> page =
+                    new PageImpl<>(
+                            List.of(activeBlackList),
+                            pageable,
+                            1
+                    );
+
+            when(userRepository
+                    .findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(blackListRepository
+                    .findAllByExpiresAtAfterOrderByBannedDateTimeDesc(
+                            NOW,
+                            pageable
+                    ))
+                    .thenReturn(page);
+
+            // when
+            Page<BlackListResponse> response =
+                    blackListService.getBlackLists(
+                            ADMIN_ID,
+                            ACTIVE,
+                            pageable
+                    );
+
+            // then
+            assertEquals(
+                    1,
+                    response.getTotalElements()
+            );
+
+            BlackListResponse content =
+                    response.getContent().get(0);
+
+            assertEquals(
+                    BLACKLIST_ID,
+                    content.blackListId()
+            );
+
+            assertEquals(
+                    TARGET_ID,
+                    content.targetUserId()
+            );
+
+            assertEquals(
+                    ACTIVE,
+                    content.status()
+            );
+
+            verify(blackListRepository, never())
+                    .findAllByExpiresAtLessThanEqualOrderByBannedDateTimeDesc(
+                            any(),
+                            any()
+                    );
+        }
+
+        @Test
+        @DisplayName("만료된 제재 목록을 조회한다")
+        void getBlackLists_success_expired() {
+            // given
+            PageRequest pageable =
+                    PageRequest.of(0, 20);
+
+            BlackListEntity expiredBlackList =
+                    createBlackListEntity(
+                            NOW.minusDays(10),
+                            NOW.minusDays(3)
+                    );
+
+            Page<BlackListEntity> page =
+                    new PageImpl<>(
+                            List.of(expiredBlackList),
+                            pageable,
+                            1
+                    );
+
+            when(userRepository
+                    .findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(blackListRepository
+                    .findAllByExpiresAtLessThanEqualOrderByBannedDateTimeDesc(
+                            NOW,
+                            pageable
+                    ))
+                    .thenReturn(page);
+
+            // when
+            Page<BlackListResponse> response =
+                    blackListService.getBlackLists(
+                            ADMIN_ID,
+                            EXPIRED,
+                            pageable
+                    );
+
+            // then
+            assertEquals(
+                    1,
+                    response.getTotalElements()
+            );
+
+            BlackListResponse content =
+                    response.getContent().get(0);
+
+            assertEquals(
+                    BLACKLIST_ID,
+                    content.blackListId()
+            );
+
+            assertEquals(
+                    EXPIRED,
+                    content.status()
+            );
+
+            verify(blackListRepository, never())
+                    .findAllByExpiresAtAfterOrderByBannedDateTimeDesc(
+                            any(),
+                            any()
+                    );
+        }
+
+    }
+
+
+
+    private BlackListEntity createBlackListEntity(
+            LocalDateTime bannedAt,
+            LocalDateTime expiresAt
+    ) {
+        ReportEntity approvedReport =
+                createApprovedReport();
+
+        BlackListEntity blackList =
+                BlackListEntity.create(
+                        approvedReport,
+                        admin,
+                        bannedAt,
+                        expiresAt
+                );
+
+        ReflectionTestUtils.setField(
+                blackList,
+                "blackListId",
+                BLACKLIST_ID
+        );
+
+        return blackList;
+    }
+
+    private ReportEntity createApprovedReport() {
+
+        ReportEntity report = createPendingReport();
+
+
+        report.approve(admin, "신고 내용을 확인하여 승인합니다.", NOW.minusHours(1));
+
+        return report;
+
+    }
+
+    private ReportEntity createPendingReport() {
+        ReportEntity report = ReportEntity.create(
+                reporter, target, game, POOR_SPORTSMANSHIP, "경기 중 반복적인 비매너 행위", NOW.minusDays(1)
+        );
+
+        ReflectionTestUtils.setField(report, "reportId", REPORT_ID);
+
+        return report;
+    }
+
+    private GameEntity createGame() {
+        LocalDateTime startDateTime =
+                NOW.plusDays(2);
+
+        GameEntity createdGame =
+                GameEntity.create(
+                        "블랙리스트 테스트 경기",
+                        "블랙리스트 정책 검증용 경기입니다.",
+                        6,
+                        INDOOR,
+                        THREE_ON_THREE,
+                        MIXED,
+                        startDateTime,
+                        startDateTime.plusHours(2),
+                        "테스트 농구장",
+                        "서울특별시 송파구",
+                        SEOUL,
+                        37.5,
+                        127.0,
+                        reporter,
+                        NOW
+                );
+
+        ReflectionTestUtils.setField(createdGame, "gameId", GAME_ID);
+
+
+        return createdGame;
+    }
+
+    private UserEntity createUser(Long userId, String email, String nickname, UserType userType) {
+
+
+        return UserEntity.builder()
+                .userId(userId)
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone("010-1234-5678")
+                .address("서울특별시")
+                .position(Position.GUARD)
+                .userType(userType)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/basketballmatching/game/service/BlackListGameServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/game/service/BlackListGameServiceUnitTest.java
@@ -1,0 +1,257 @@
+package com.example.basketballmatching.game.service;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.dto.BlackListGameResultDto;
+import com.example.basketballmatching.game.dto.GameCancelNotificationDto;
+import com.example.basketballmatching.game.repository.query.GameQueryRepository;
+import com.example.basketballmatching.game.type.GameStatus;
+import com.example.basketballmatching.game.type.ParticipantGameStatus;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BlackListGameService 단위 테스트")
+class BlackListGameServiceUnitTest {
+
+    private static final Long BANNED_USER_ID = 1L;
+    private static final Long RECEIVER_ID = 2L;
+    private static final Long OTHER_CREATOR_ID = 3L;
+
+    private static final Long CREATED_GAME_ID = 10L;
+    private static final Long OTHER_GAME_ID = 20L;
+
+    private static final LocalDateTime BANNED_AT = LocalDateTime.of(2026, 8, 27, 12, 0);
+
+    @Mock
+    private GameQueryRepository gameQueryRepository;
+
+    private BlackListGameService blackListGameService;
+
+    private UserEntity bannedUser;
+
+    private UserEntity receiver;
+
+    private UserEntity otherCreator;
+
+    @BeforeEach
+    void setUp() {
+
+        blackListGameService = new BlackListGameService(gameQueryRepository);
+
+        bannedUser = createUser(BANNED_USER_ID, "banned@test.com", "제재대상");
+
+        receiver = createUser(RECEIVER_ID, "receiver@test.com", "알림대상");
+
+        otherCreator = createUser(OTHER_CREATOR_ID, "otherCreator@test.com", "다른 경기 생성자");
+    }
+
+    @Test
+    @DisplayName("제재 대상자가 생성한 예정 경기와 다른 경기 참가 상태를 정리한다.")
+    void cleanUp_success() {
+        // given
+
+        GameEntity createdGame = createGame(CREATED_GAME_ID, bannedUser, "제재 대상자가 생성한 경기");
+
+        ParticipantGameEntity creatorParticipation = ParticipantGameEntity.createCreator(createdGame, bannedUser, BANNED_AT.minusDays(1));
+
+        ParticipantGameEntity receiverParticipation = ParticipantGameEntity.createParticipation(createdGame, receiver, BANNED_AT.minusHours(1));
+
+        GameEntity otherGame = createGame(OTHER_GAME_ID, otherCreator, "다른 사용자가 생성한 경기");
+
+        ParticipantGameEntity otherCreatorParticipation = ParticipantGameEntity.createCreator(otherGame, otherCreator, BANNED_AT.minusDays(1));
+
+        ParticipantGameEntity bannedParticipation = ParticipantGameEntity.createParticipation(otherGame, bannedUser, BANNED_AT.minusHours(1));
+
+        when(gameQueryRepository.findFutureGamesCreatedBy(BANNED_USER_ID, BANNED_AT))
+                .thenReturn(List.of(createdGame));
+
+        when(gameQueryRepository.findActiveParticipantsByGameIds(List.of(CREATED_GAME_ID)))
+                .thenReturn(List.of(creatorParticipation, receiverParticipation));
+
+        when(gameQueryRepository.findFutureParticipationExcludingCreatedGames(BANNED_USER_ID, BANNED_AT))
+                .thenReturn(List.of(bannedParticipation));
+
+        // when
+
+        BlackListGameResultDto result = blackListGameService.cleanup(BANNED_USER_ID, BANNED_AT);
+
+        // then
+
+        assertEquals(BANNED_AT, createdGame.getDeletedDateTime());
+
+        assertEquals(DELETE, creatorParticipation.getParticipantGameStatus());
+
+        assertEquals(DELETE, receiverParticipation.getParticipantGameStatus());
+
+        assertEquals(KICKOUT, bannedParticipation.getParticipantGameStatus());
+
+        assertEquals(BANNED_AT, bannedParticipation.getKickoutDateTime());
+
+        assertEquals(0, createdGame.getParticipantCount());
+
+        assertEquals(1, otherGame.getParticipantCount());
+
+        assertEquals(ACCEPT, otherCreatorParticipation.getParticipantGameStatus());
+
+        GameCancelNotificationDto notice = result.notices().get(0);
+
+        assertEquals(RECEIVER_ID, notice.receiverId());
+        assertEquals(createdGame.getTitle(), notice.gameTitle());
+
+    }
+
+    @Test
+    @DisplayName("생성된 예정 경기가 없어도 다른 경기의 참가 상태는 강퇴로 변경")
+    void cleanUp_success_onlyOtherParticipation() {
+        // given
+
+        GameEntity otherGame = createGame(OTHER_GAME_ID, otherCreator, "다른 사용자가 생성한 경기");
+
+        ParticipantGameEntity otherCreatorParticipation = ParticipantGameEntity.createCreator(otherGame, otherCreator, BANNED_AT.minusDays(1));
+
+        ParticipantGameEntity bannedParticipation = ParticipantGameEntity.createParticipation(otherGame, bannedUser, BANNED_AT.minusHours(1));
+
+        when(gameQueryRepository.findFutureGamesCreatedBy(BANNED_USER_ID, BANNED_AT))
+                .thenReturn(List.of());
+
+        when(gameQueryRepository.findFutureParticipationExcludingCreatedGames(BANNED_USER_ID, BANNED_AT))
+                .thenReturn(List.of(bannedParticipation));
+        // when
+
+        BlackListGameResultDto result = blackListGameService.cleanup(BANNED_USER_ID, BANNED_AT);
+
+        // then
+        assertTrue(result.notices().isEmpty());
+
+        assertEquals(KICKOUT, bannedParticipation.getParticipantGameStatus());
+        assertEquals(BANNED_AT, bannedParticipation.getKickoutDateTime());
+
+        assertEquals(1, otherGame.getParticipantCount());
+
+        assertEquals(ACCEPT, otherCreatorParticipation.getParticipantGameStatus());
+
+        verify(gameQueryRepository, never()).findActiveParticipantsByGameIds(anyList());
+
+
+    }
+
+    @Test
+    @DisplayName("생성한 예정 경기의 활성 참가자가 없어도 경기는 취소한다")
+    void cleanup_success_createdGameWithoutParticipants() {
+        // given
+        GameEntity createdGame =
+                createGame(
+                        CREATED_GAME_ID,
+                        bannedUser,
+                        "참가자가 없는 예정 경기"
+                );
+
+        when(gameQueryRepository
+                .findFutureGamesCreatedBy(
+                        BANNED_USER_ID,
+                        BANNED_AT
+                ))
+                .thenReturn(List.of(createdGame));
+
+        when(gameQueryRepository
+                .findActiveParticipantsByGameIds(
+                        List.of(CREATED_GAME_ID)
+                ))
+                .thenReturn(List.of());
+
+        when(gameQueryRepository
+                .findFutureParticipationExcludingCreatedGames(
+                        BANNED_USER_ID,
+                        BANNED_AT
+                ))
+                .thenReturn(List.of());
+
+        // when
+        BlackListGameResultDto result =
+                blackListGameService.cleanup(
+                        BANNED_USER_ID,
+                        BANNED_AT
+                );
+
+        // then
+        assertEquals(
+                BANNED_AT,
+                createdGame.getDeletedDateTime()
+        );
+
+        assertTrue(result.notices().isEmpty());
+    }
+
+    private GameEntity createGame(Long gameId, UserEntity creator, String title) {
+        LocalDateTime startDateTime =
+                BANNED_AT.plusDays(2);
+
+        GameEntity game = GameEntity.create(
+                title,
+                "블랙리스트 경기 정리 테스트입니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                startDateTime.plusHours(2),
+                "테스트 농구장",
+                "서울특별시 송파구",
+                SEOUL,
+                37.5,
+                127.0,
+                creator,
+                BANNED_AT.minusDays(1)
+        );
+
+        ReflectionTestUtils.setField(
+                game,
+                "gameId",
+                gameId
+        );
+
+        return game;
+    }
+
+    private UserEntity createUser(Long userId, String email, String nickname) {
+        return UserEntity.builder()
+                .userId(userId)
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone("010-1234-5678")
+                .address("서울특별시")
+                .position(Position.GUARD)
+                .userType(UserType.USER)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/basketballmatching/report/service/ReportServiceUnitTest.java
+++ b/src/test/java/com/example/basketballmatching/report/service/ReportServiceUnitTest.java
@@ -1,0 +1,455 @@
+package com.example.basketballmatching.report.service;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.game.type.ParticipantGameStatus;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.report.domain.ReportEntity;
+import com.example.basketballmatching.report.dto.request.CreateReportRequest;
+import com.example.basketballmatching.report.dto.request.ReviewReportRequest;
+import com.example.basketballmatching.report.dto.response.CreateReportResponse;
+import com.example.basketballmatching.report.dto.response.ReviewReportResponse;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.report.type.ReportDecision;
+import com.example.basketballmatching.report.type.ReportStatus;
+import com.example.basketballmatching.report.type.ReportType;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
+import static com.example.basketballmatching.global.exception.ErrorCode.*;
+import static com.example.basketballmatching.report.type.ReportStatus.REJECTED;
+import static com.example.basketballmatching.report.type.ReportType.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReportService 단위 테스트")
+class ReportServiceUnitTest {
+
+    private static final Long GAME_ID = 1L;
+    private static final Long REPORT_ID = 10L;
+
+    private static final Long REPORTER_ID = 1L;
+    private static final Long TARGET_ID = 2L;
+    private static final Long ADMIN_ID = 3L;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 27, 12, 0);
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @Mock
+    private ParticipantGameRepository participantGameRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    private ReportService reportService;
+
+    private UserEntity reporter;
+    private UserEntity target;
+    private UserEntity admin;
+    private GameEntity endedGame;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(NOW.atZone(ZONE_ID).toInstant(), ZONE_ID);
+
+        reportService = new ReportService(
+                gameRepository, participantGameRepository, userRepository, reportRepository, clock
+        );
+
+        reporter = createUser(REPORTER_ID, "reporter@test.com", "신고자", UserType.USER);
+
+        target = createUser(TARGET_ID, "target@test.com", "신고 대상", UserType.USER);
+
+        admin = createUser(ADMIN_ID, "admin@test.com", "관리자", UserType.ADMIN);
+
+        endedGame = createEndedGame(NOW.minusDays(1));
+    }
+
+
+    @Nested
+    @DisplayName("신고 접수")
+    class CreateReport {
+
+        @Test
+        @DisplayName("종료된 경기의 확정 참가자는 다른 확정 참가자 신고할 수 있다.")
+        void createReport_success() {
+            // given
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+
+            stubValidReportCondition();
+
+            when(reportRepository.save(any(ReportEntity.class)))
+                    .thenAnswer(invocation -> {
+                        ReportEntity report = invocation.getArgument(0);
+
+                        ReflectionTestUtils.setField(report, "reportId", REPORT_ID);
+                        return report;
+                    });
+            // when
+
+            CreateReportResponse response = reportService.createReport(REPORTER_ID, GAME_ID, request);
+
+
+            // then
+
+            assertEquals(REPORT_ID, response.reportId());
+            assertEquals(NOW, response.reportedAt());
+            verify(reportRepository).save(any(ReportEntity.class));
+        }
+
+        @Test
+        @DisplayName("자기 자신은 신고 불가")
+        void createReport_fail_selfReport() {
+            // given
+
+            CreateReportRequest request = createReportRequest(REPORTER_ID);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+            // then
+
+            assertEquals(SELF_REPORT_NOT_ALLOWED, exception.getErrorCode());
+
+
+            verifyNoInteractions(
+                    gameRepository, participantGameRepository, userRepository, reportRepository
+            );
+
+        }
+
+        @Test
+        @DisplayName("종료되지 않은 경기는 신고할 수 없다.")
+        void createReport_fail_gameNotEnded() {
+            // given
+
+            GameEntity futureGame = createFutureGame();
+
+            when(gameRepository.findByGameIdAndDeletedDateTimeIsNull(GAME_ID))
+                    .thenReturn(Optional.of(futureGame));
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+            // then
+
+            assertEquals(NOT_GAME_ENDED, exception.getErrorCode());
+            verifyNoInteractions(participantGameRepository, userRepository, reportRepository);
+
+        }
+
+        @Test
+        @DisplayName("경기 종료 후 7일이 지나면 신고할 수 없다.")
+        void createReport_fail_reportPeriodExpired() {
+            // given
+
+            GameEntity expiredGame = createEndedGame(NOW.minusDays(8));
+
+            when(gameRepository.findByGameIdAndDeletedDateTimeIsNull(GAME_ID))
+                    .thenReturn(Optional.of(expiredGame));
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+            // then
+
+            assertEquals(REPORT_PERIOD_EXPIRED, exception.getErrorCode());
+
+            verifyNoInteractions(participantGameRepository, userRepository, reportRepository);
+
+        }
+
+        @Test
+        @DisplayName("확정 참가자가 아닌 사용자는 신고할 수 없다.")
+        void createReport_fail_reporterNotAccepted() {
+            // given
+
+            when(gameRepository.findByGameIdAndDeletedDateTimeIsNull(GAME_ID))
+                    .thenReturn(Optional.of(endedGame));
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(REPORTER_ID))
+                    .thenReturn(Optional.of(reporter));
+
+            when(participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                    GAME_ID, REPORTER_ID, ACCEPT
+            )).thenReturn(false);
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+
+            // then
+
+            assertEquals(REPORTER_NOT_ACCEPTED_PARTICIPANT, exception.getErrorCode());
+
+            verify(reportRepository, never()).save(any(ReportEntity.class));
+        }
+
+
+        @Test
+        @DisplayName("신고 대상이 확정 참가자가 아니면 신고할 수 없다.")
+        void createReport_fail_targetNotAccepted() {
+            // given
+
+            when(gameRepository.findByGameIdAndDeletedDateTimeIsNull(GAME_ID))
+                    .thenReturn(Optional.of(endedGame));
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(REPORTER_ID))
+                    .thenReturn(Optional.of(reporter));
+
+            when(participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                    GAME_ID, REPORTER_ID, ACCEPT
+            )).thenReturn(true);
+
+            when(participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                    GAME_ID, TARGET_ID, ACCEPT
+            )).thenReturn(false);
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+            // then
+
+            assertEquals(REPORT_TARGET_NOT_ACCEPTED_PARTICIPANT, exception.getErrorCode());
+
+            verify(reportRepository, never()).save(any(ReportEntity.class));
+
+        }
+
+        @Test
+        @DisplayName("같은 경기에서 같은 사용자 중복 신고 불가")
+        void createReport_fail_duplicateReport() {
+            // given
+
+            stubValidReportCondition();
+
+            when(reportRepository.existsByReportUser_UserIdAndTargetUser_UserIdAndGameEntity_GameId(
+                    REPORTER_ID, TARGET_ID, GAME_ID
+            )).thenReturn(true);
+
+            CreateReportRequest request = createReportRequest(TARGET_ID);
+            // when
+
+            CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(REPORTER_ID, GAME_ID, request));
+
+            // then
+
+            assertEquals(ALREADY_REPORTED_USER, exception.getErrorCode());
+
+            verify(reportRepository, never()).save(any(ReportEntity.class));
+
+        }
+    }
+
+    @Nested
+    @DisplayName("신고 검토")
+    class ReviewReport {
+
+        @Test
+        @DisplayName("관리자는 신고를 승인할 수 있다.")
+        void reviewReport_success() {
+            // given
+
+            ReportEntity report = createPendingReport();
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(report));
+
+            ReviewReportRequest request = new ReviewReportRequest(ReportDecision.APPROVE, "신고 내용을 확인하여 승인합니다.");
+
+            // when
+
+            ReviewReportResponse response = reportService.reviewReport(ADMIN_ID, REPORT_ID, request);
+
+            // then
+
+            assertEquals(REPORT_ID, response.reportId());
+            assertEquals(ReportStatus.APPROVED, response.reportStatus());
+            assertEquals(NOW, response.reviewedAt());
+
+            assertEquals(ReportStatus.APPROVED, report.getReportStatus());
+            assertEquals(admin, report.getReviewedBy());
+
+            assertEquals("신고 내용을 확인하여 승인합니다.", report.getReviewReason());
+
+
+
+        }
+
+        @Test
+        @DisplayName("관리자는 신고를 거절할 수 있다")
+        void reviewReport_success_reject() {
+            // given
+
+            ReportEntity report = createPendingReport();
+
+            when(userRepository.findByUserIdAndDeletedDateTimeIsNull(ADMIN_ID))
+                    .thenReturn(Optional.of(admin));
+
+            when(reportRepository.findById(REPORT_ID))
+                    .thenReturn(Optional.of(report));
+
+            ReviewReportRequest request = new ReviewReportRequest(ReportDecision.REJECT, "신고 사유가 충분하지 않습니다.");
+
+            // when
+
+            ReviewReportResponse response = reportService.reviewReport(ADMIN_ID, REPORT_ID, request);
+
+            // then
+            assertEquals(REPORT_ID, response.reportId());
+            assertEquals(REJECTED, response.reportStatus());
+            assertEquals(NOW, response.reviewedAt());
+
+            assertEquals(REJECTED, report.getReportStatus());
+            assertEquals(admin, report.getReviewedBy());
+            assertEquals("신고 사유가 충분하지 않습니다.", report.getReviewReason());
+        }
+    }
+
+    private void stubValidReportCondition() {
+        when(gameRepository.findByGameIdAndDeletedDateTimeIsNull(GAME_ID))
+                .thenReturn(Optional.of(endedGame));
+
+        when(userRepository.findByUserIdAndDeletedDateTimeIsNull(REPORTER_ID))
+                .thenReturn(Optional.of(reporter));
+
+        when(participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                GAME_ID, REPORTER_ID, ACCEPT
+        )).thenReturn(true);
+
+        when(participantGameRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
+                GAME_ID, TARGET_ID, ACCEPT
+        )).thenReturn(true);
+
+        when(userRepository.findById(TARGET_ID))
+                .thenReturn(Optional.of(target));
+
+        when(reportRepository.existsByReportUser_UserIdAndTargetUser_UserIdAndGameEntity_GameId(
+                REPORTER_ID, TARGET_ID, GAME_ID
+        )).thenReturn(false);
+    }
+
+    private CreateReportRequest createReportRequest(Long targetUserId) {
+        return new CreateReportRequest(
+                targetUserId, POOR_SPORTSMANSHIP, "경기 중 반복적으로 비매너 행위"
+        );
+    }
+
+    private ReportEntity createPendingReport() {
+
+        ReportEntity report = ReportEntity.create(
+                reporter, target, endedGame, POOR_SPORTSMANSHIP, "경기 중 반복적으로 비매너 행위", NOW.minusHours(1)
+        );
+
+        ReflectionTestUtils.setField(report, "reportId", REPORT_ID);
+
+        return report;
+    }
+
+    private GameEntity createEndedGame(LocalDateTime endDateTime) {
+        LocalDateTime startDateTime = endDateTime.minusHours(2);
+
+        LocalDateTime creationTime = startDateTime.minusDays(2);
+
+        return createGame(startDateTime, endDateTime, creationTime);
+    }
+
+    private GameEntity createFutureGame() {
+        LocalDateTime startDateTime = NOW.plusDays(2);
+
+        return createGame(startDateTime, startDateTime.plusHours(2), NOW);
+    }
+
+    private GameEntity createGame(LocalDateTime startDateTime, LocalDateTime endDateTime, LocalDateTime creationTime) {
+
+        GameEntity game = GameEntity.create(
+                "신고 테스트 경기",
+                "신고 정책 검증을 위한 경기입니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                endDateTime,
+                "테스트 농구장",
+                "서울특별시 송파구",
+                SEOUL,
+                37.5,
+                127.0,
+                reporter,
+                creationTime
+        );
+
+        ReflectionTestUtils.setField(game, "gameId", GAME_ID);
+
+        return game;
+    }
+
+    private UserEntity createUser(Long userId, String email, String nickname, UserType userType) {
+
+        return UserEntity.builder()
+                .userId(userId)
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone("010-1234-5678")
+                .address("서울특별시")
+                .position(Position.GUARD)
+                .userType(userType)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 신고 및 블랙리스트 정책을 검증하는 단위 테스트가 부족했습니다.
- 제재 사용자의 예정 경기 및 참가 상태 정리 로직에 대한 테스트가 없었습니다.
- 관련 단위 테스트가 CI 실행 대상에 포함되지 않았습니다.

### 🚀 TO-BE

- 신고 접수 및 관리자 승인·거절 단위 테스트를 추가했습니다.
- 블랙리스트 등록, 중복 제재 방지 및 상태별 목록 조회 테스트를 추가했습니다.
- 제재 사용자의 예정 경기 취소 및 참가 상태 정리 테스트를 추가했습니다.
- 신고 및 블랙리스트 단위 테스트 3개 클래스를 CI 실행 대상에 추가했습니다.

---

## ✅ 체크리스트

- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (단위 테스트)
- [ ] 관련 문서(README, API 명세) 업데이트
- [x] 성능/보안/예외 처리 검토 완료

---