### PR TITLE
[test] : 신고 및 블랙리스트 통합 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
             --tests "com.example.basketballmatching.auth.oauth2.controller.OAuthStateFlowIntegrationTest" \
             --tests "com.example.basketballmatching.game.service.GameServiceIntegrationTest" \
             --tests "com.example.basketballmatching.game.service.GameParticipantServiceIntegrationTest" \
-            --tests "com.example.basketballmatching.game.repository.query.GameQueryRepositoryIntegrationTest"
+            --tests "com.example.basketballmatching.game.repository.query.GameQueryRepositoryIntegrationTest" \
+            --tests "com.example.basketballmatching.report.service.ReportServiceIntegrationTest" \
+            --tests "com.example.basketballmatching.blacklist.service.BlackListServiceIntegrationTest" \
+            --tests "com.example.basketballmatching.blacklist.event.UserBlacklistedEventListenerIntegrationTest" \
+            --tests "com.example.basketballmatching.game.service.BlackListGameServiceIntegrationTest"
 
       - name: Upload integration test report
         if: always()

--- a/src/test/java/com/example/basketballmatching/blacklist/event/UserBlacklistedEventListenerIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/blacklist/event/UserBlacklistedEventListenerIntegrationTest.java
@@ -1,0 +1,287 @@
+package com.example.basketballmatching.blacklist.event;
+
+import com.example.basketballmatching.auth.service.AuthTokenStore;
+import com.example.basketballmatching.blacklist.dto.response.CreateBlackListResponse;
+import com.example.basketballmatching.blacklist.repository.BlackListRepository;
+import com.example.basketballmatching.blacklist.service.BlackListService;
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.dto.BlackListGameResultDto;
+import com.example.basketballmatching.game.dto.GameCancelNotificationDto;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.service.BlackListGameService;
+import com.example.basketballmatching.notifications.repository.NotificationRepository;
+import com.example.basketballmatching.notifications.type.NotificationType;
+import com.example.basketballmatching.report.domain.ReportEntity;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.report.type.ReportType;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@IntegrationTest
+@DisplayName("블랙리스트 이벤트 리스너 통합 테스트")
+public class UserBlacklistedEventListenerIntegrationTest {
+
+    private static final String TARGET_EMAIL = "blacklist-target@test.com";
+
+    @Autowired
+    private BlackListService blackListService;
+
+    @Autowired
+    private BlackListRepository blackListRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private AuthTokenStore authTokenStore;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private Clock clock;
+
+    /*
+     * 경기 상태 정리 자체는 BlackListGameService 테스트의 책임이다.
+     * 여기서는 정리 결과가 이벤트 알림으로 연결되는지만 검증한다.
+     */
+    @MockBean
+    private BlackListGameService blackListGameService;
+
+    @AfterEach
+    void cleanUp() {
+        authTokenStore.deleteRefreshToken(TARGET_EMAIL);
+
+        notificationRepository.deleteAllInBatch();
+        blackListRepository.deleteAllInBatch();
+        reportRepository.deleteAllInBatch();
+        gameRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록 커밋 후 RefreshToken 폐기 후 제재 및경기 취소 알림 저장")
+    void createBlackList_success_afterCommit() {
+        // given
+
+        TestFixture fixture = createFixture();
+
+        GameCancelNotificationDto gameNotice = new GameCancelNotificationDto(fixture.receiverId, "주말 농구 경기");
+
+        when(blackListGameService.cleanup(eq(fixture.targetId), any(LocalDateTime.class)))
+                .thenReturn(new BlackListGameResultDto(List.of(gameNotice)));
+
+        String refreshToken = "test-refresh-token";
+
+        authTokenStore.saveRefreshToken(TARGET_EMAIL, refreshToken, 60_000L);
+
+        assertEquals(refreshToken, authTokenStore.getRefreshToken(TARGET_EMAIL));
+
+        // when
+
+        CreateBlackListResponse response = blackListService.createBlackList(fixture.adminId, fixture.reportId);
+
+        // then
+
+        /**
+         * createBlackList 트랜잭션이 커밋되면서
+         * AFTER_COMMIT 리스너도 동기적으로 실행된다.
+         */
+
+        assertTrue(blackListRepository.findById(response.blackListId()).isPresent());
+
+        /**
+         * 제재 대상의 Refresh Token 삭제 확인
+         */
+
+        assertNull(authTokenStore.getRefreshToken(TARGET_EMAIL));
+
+        List<NotificationResult> notificaitons = transactionTemplate.execute(
+                status -> notificationRepository.findAll()
+                        .stream()
+                        .map(notification -> new NotificationResult(
+                                notification.getReceiver().getUserId(), notification.getNotificationType(), notification.getContent()
+                        )).toList()
+        );
+
+        assertNotNull(notificaitons);
+
+        assertEquals(2, notificaitons.size());
+
+        NotificationResult restrictNotification = notificaitons.stream()
+                .filter(notification -> notification.notificationType == NotificationType.BLACKLISTED)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(fixture.targetId, restrictNotification.receiverId);
+
+        assertEquals("신고 검토 결과 " + response.expiresAt() + "까지 서비스 이용이 제한되었습니다.", restrictNotification.content);
+
+        NotificationResult gameCancelNotification = notificaitons.stream()
+                .filter(notification -> notification.notificationType == NotificationType.DELETE_GAME)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(fixture.receiverId, gameCancelNotification.receiverId);
+
+        assertEquals("주말 농구 경기의 게임이 취소되었습니다.", gameCancelNotification.content);
+
+    }
+
+
+
+    private TestFixture createFixture() {
+        return transactionTemplate.execute(status -> {
+            UserEntity creator = saveUser(
+                    "event-creator@test.com",
+                    "경기생성자",
+                    "010-1111-1111",
+                    UserType.USER
+            );
+
+            UserEntity reporter = saveUser(
+                    "event-reporter@test.com",
+                    "신고자",
+                    "010-2222-2222",
+                    UserType.USER
+            );
+
+            UserEntity target = saveUser(
+                    TARGET_EMAIL,
+                    "신고대상",
+                    "010-3333-3333",
+                    UserType.USER
+            );
+
+            UserEntity receiver = saveUser(
+                    "event-receiver@test.com",
+                    "알림수신자",
+                    "010-4444-4444",
+                    UserType.USER
+            );
+
+            UserEntity admin = saveUser(
+                    "event-admin@test.com",
+                    "관리자",
+                    "010-5555-5555",
+                    UserType.ADMIN
+            );
+
+            LocalDateTime now = LocalDateTime.now(clock)
+                    .withSecond(0)
+                    .withNano(0);
+
+            LocalDateTime startDateTime = now.minusDays(2);
+
+            LocalDateTime endDateTime = startDateTime.plusHours(2);
+
+            GameEntity game = GameEntity.create(
+                    "블랙리스트 이벤트 테스트 경기",
+                    "종료된 경기입니다.",
+                    6,
+                    INDOOR,
+                    THREE_ON_THREE,
+                    MIXED,
+                    startDateTime,
+                    endDateTime,
+                    "잠실 농구장",
+                    "서울특별시 송파구 올림픽로 25",
+                    SEOUL,
+                    37.515,
+                    127.073,
+                    creator,
+                    startDateTime.minusDays(1)
+            );
+
+            gameRepository.save(game);
+
+            ReportEntity report = ReportEntity.create(
+                    reporter, target, game, ReportType.POOR_SPORTSMANSHIP, "경기 중 비매너 행위를 반복했습니다.", now.minusHours(2)
+            );
+
+            report.approve(admin, "신고 내용을 확인하여 승인합니다.", now.minusHours(1));
+
+            reportRepository.save(report);
+
+            return new TestFixture(
+                    admin.getUserId(),
+                    target.getUserId(),
+                    receiver.getUserId(),
+                    report.getReportId()
+            );
+        });
+    }
+
+
+    private UserEntity saveUser(
+            String email,
+            String nickname,
+            String phone,
+            UserType userType
+    ) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone(phone)
+                .address("서울특별시 송파구")
+                .position(Position.GUARD)
+                .userType(userType)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .emailAuth(true)
+                .build();
+
+        return userRepository.save(user);
+    }
+    private record TestFixture(
+            Long adminId,
+            Long targetId,
+            Long receiverId,
+            Long reportId
+    ) {
+
+    }
+
+    private record NotificationResult(
+            Long receiverId,
+            NotificationType notificationType,
+            String content
+    ) {}
+}

--- a/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceIntegrationTest.java
@@ -1,0 +1,317 @@
+package com.example.basketballmatching.blacklist.service;
+
+import com.example.basketballmatching.blacklist.domain.BlackListEntity;
+import com.example.basketballmatching.blacklist.dto.response.BlackListResponse;
+import com.example.basketballmatching.blacklist.dto.response.CreateBlackListResponse;
+import com.example.basketballmatching.blacklist.repository.BlackListRepository;
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.dto.BlackListGameResultDto;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.service.BlackListGameService;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.report.domain.ReportEntity;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.report.type.ReportType;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.basketballmatching.blacklist.type.BlackListStatus.ACTIVE;
+import static com.example.basketballmatching.blacklist.type.BlackListStatus.EXPIRED;
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.global.exception.ErrorCode.BLACKLIST_REPORT_ALREADY_USED;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@IntegrationTest
+@Transactional
+@DisplayName("BlackListService 통합 테스트")
+class BlackListServiceIntegrationTest {
+
+    @Autowired
+    private BlackListService blackListService;
+
+    @Autowired
+    private BlackListStore blackListStore;
+
+    @Autowired
+    private BlackListRepository blackListRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    /**
+     * 경기 정리 로직은 BlackListGameService의 책임이다.
+     * 이 테스트에서는 블랙리스트 등록과 경기 정리 호출의 연결만 검증한다.
+     */
+
+    @MockBean
+    private BlackListGameService blackListGameService;
+
+    private Long adminId;
+    private Long targetId;
+    private Long reportId;
+
+    private String targetEmail;
+
+    @BeforeEach
+    void setUp() {
+
+        UserEntity creator = saveUser(
+                "creator@test.com",
+                "경기생성자",
+                "010-1111-1111",
+                UserType.USER
+        );
+
+        UserEntity reporter = saveUser(
+                "reporter@test.com",
+                "신고자",
+                "010-2222-2222",
+                UserType.USER
+        );
+
+        UserEntity target = saveUser(
+                "target@test.com",
+                "신고대상",
+                "010-3333-3333",
+                UserType.USER
+        );
+
+        UserEntity admin = saveUser(
+                "admin@test.com",
+                "관리자",
+                "010-4444-4444",
+                UserType.ADMIN
+        );
+
+        LocalDateTime now = LocalDateTime.now()
+                .withSecond(0)
+                .withNano(0);
+
+        LocalDateTime startDateTime = now.minusDays(2);
+        LocalDateTime endDateTime = startDateTime.plusHours(2);
+        LocalDateTime createdAt = startDateTime.minusDays(1);
+
+        GameEntity game = GameEntity.create(
+                "블랙리스트 통합 테스트 경기",
+                "종료된 경기입니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                endDateTime,
+                "잠실 농구장",
+                "서울특별시 송파구 올림픽로 25",
+                SEOUL,
+                37.515,
+                127.073,
+                creator,
+                createdAt
+        );
+
+        gameRepository.save(game);
+
+        ReportEntity report = ReportEntity.create(
+                reporter, target, game, ReportType.POOR_SPORTSMANSHIP, "경기 중 비매너 행위를 반복했습니다.", now.minusHours(2));
+
+        report.approve(admin, "신고 내용을 확인하여 승인합니다.", now.minusHours(1));
+
+        reportRepository.save(report);
+
+        adminId = admin.getUserId();
+        targetId = target.getUserId();
+        targetEmail = target.getEmail();
+        reportId = report.getReportId();
+
+        flushAndClear();
+
+
+    }
+
+    @Test
+    @DisplayName("승인된 신고를 근거로 7일간 블랙리스트 제재 저장")
+    void createBlackList_success() {
+        // given
+
+        when(blackListGameService.cleanup(eq(targetId), any(LocalDateTime.class)))
+                .thenReturn(new BlackListGameResultDto(List.of()));
+
+        // when
+
+        CreateBlackListResponse response = blackListService.createBlackList(adminId, reportId);
+
+        flushAndClear();
+        // then
+
+        BlackListEntity blackList = blackListRepository.findById(response.blackListId()).orElseThrow();
+
+
+        assertEquals(reportId, blackList.getReportEntity().getReportId());
+        assertEquals(targetId, blackList.getUserEntity().getUserId());
+        assertEquals(adminId, blackList.getBannedBy().getUserId());
+
+        assertEquals(response.bannedAt().plusDays(7), blackList.getExpiresAt());
+
+        assertEquals(response.expiresAt(), blackList.getExpiresAt());
+
+        assertEquals(ACTIVE, response.status());
+
+        assertTrue(blackListStore.isBlacklisted(targetEmail));
+
+        verify(blackListGameService).cleanup(eq(targetId), any(LocalDateTime.class));
+    }
+
+
+    @Test
+    @DisplayName("이미 제재에 성공한 신고를 다시 사용할 수 없다")
+    void createBlackList_fail_reportAlreadyUsed() {
+        // given
+
+        when(blackListGameService.cleanup(eq(targetId), any(LocalDateTime.class)))
+                .thenReturn(new BlackListGameResultDto(List.of()));
+
+        blackListService.createBlackList(adminId, reportId);
+
+        flushAndClear();
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> blackListService.createBlackList(adminId, reportId));
+
+        // then
+
+        assertEquals(BLACKLIST_REPORT_ALREADY_USED, exception.getErrorCode());
+
+        assertEquals(1, blackListRepository.count());
+
+    }
+
+    @Test
+    @DisplayName("관리자는 활성 블")
+    void getBlackLists_success() {
+        // given
+
+        when(blackListGameService.cleanup(eq(targetId), any(LocalDateTime.class)))
+                .thenReturn(new BlackListGameResultDto(List.of()));
+
+        CreateBlackListResponse created = blackListService.createBlackList(adminId, reportId);
+
+        flushAndClear();
+        // when
+
+        Page<BlackListResponse> response = blackListService.getBlackLists(adminId, ACTIVE, PageRequest.of(0, 20));
+
+        // then
+
+        assertEquals(1, response.getTotalElements());
+
+
+        BlackListResponse blackList = response.getContent().get(0);
+
+        assertEquals(created.blackListId(), blackList.blackListId());
+        assertEquals(reportId, blackList.reportId());
+        assertEquals(targetId, blackList.targetUserId());
+        assertEquals(targetEmail, blackList.email());
+        assertEquals(ACTIVE, blackList.status());
+    }
+
+    @Test
+    @DisplayName("제재 기간이 지나면 만료 목록으로 조회되고 제재가 자동 해제된다.")
+    void getBlackLists_success_expired() {
+        // given
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        UserEntity admin = userRepository.findById(adminId)
+                .orElseThrow();
+
+        ReportEntity report = reportRepository.findById(reportId)
+                .orElseThrow();
+
+        BlackListEntity expiredBlackList = BlackListEntity.create(report, admin, now.minusDays(8), now.minusDays(1));
+
+        blackListRepository.save(expiredBlackList);
+        flushAndClear();
+
+        // when
+
+        Page<BlackListResponse> response = blackListService.getBlackLists(adminId, EXPIRED, PageRequest.of(0, 20));
+
+
+        // then
+
+        assertEquals(1, response.getTotalElements());
+
+        BlackListResponse blackList = response.getContent().get(0);
+
+        assertEquals(expiredBlackList.getBlackListId(), blackList.blackListId());
+        assertEquals(EXPIRED, blackList.status());
+
+        assertFalse(blackListStore.isBlacklisted(targetEmail));
+    }
+
+
+
+
+    private UserEntity saveUser(
+            String email,
+            String nickname,
+            String phone,
+            UserType userType
+    ) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone(phone)
+                .address("서울특별시 송파구")
+                .position(Position.GUARD)
+                .userType(userType)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .emailAuth(true)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/blacklist/service/BlackListServiceIntegrationTest.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.example.basketballmatching.blacklist.type.BlackListStatus.ACTIVE;
@@ -185,9 +186,12 @@ class BlackListServiceIntegrationTest {
         assertEquals(targetId, blackList.getUserEntity().getUserId());
         assertEquals(adminId, blackList.getBannedBy().getUserId());
 
-        assertEquals(response.bannedAt().plusDays(7), blackList.getExpiresAt());
+        assertEquals(response.bannedAt().plusDays(7), response.expiresAt());
 
-        assertEquals(response.expiresAt(), blackList.getExpiresAt());
+        assertEquals(
+                response.expiresAt().truncatedTo(ChronoUnit.SECONDS),
+                blackList.getExpiresAt().truncatedTo(ChronoUnit.SECONDS)
+        );
 
         assertEquals(ACTIVE, response.status());
 

--- a/src/test/java/com/example/basketballmatching/game/service/BlackListGameServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/game/service/BlackListGameServiceIntegrationTest.java
@@ -1,0 +1,400 @@
+package com.example.basketballmatching.game.service;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.dto.BlackListGameResultDto;
+import com.example.basketballmatching.game.dto.GameCancelNotificationDto;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.Position;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.game.type.ParticipantGameStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@IntegrationTest
+@DisplayName("BlackListGameService 통합 테스트")
+class BlackListGameServiceIntegrationTest {
+
+    @Autowired
+    private BlackListGameService blackListGameService;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private UserEntity bannedUser;
+    private UserEntity receiver;
+    private UserEntity otherCreator;
+
+    private LocalDateTime bannedAt;
+
+    @BeforeEach
+    void setUp() {
+        bannedUser = saveUser(
+                "banned-user@test.com",
+                "제재대상",
+                "010-1111-1111"
+        );
+
+        receiver = saveUser(
+                "receiver@test.com",
+                "알림대상",
+                "010-2222-2222"
+        );
+
+        otherCreator = saveUser(
+                "other-creator@test.com",
+                "다른경기생성자",
+                "010-3333-3333"
+        );
+
+        bannedAt = LocalDateTime.now(clock)
+                .withSecond(0)
+                .withNano(0);
+
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("제재 대상자가 생성한 예정 경기와 다른 예정 경기 참가 상태를 정리한다.")
+    void cleanUp_success() {
+        // given
+
+        GameEntity createdGame = saveFutureGame(
+                "제재 대상자가 생성한 경기",
+                "제재 대상자 경기장",
+                bannedUser,
+                bannedAt.plusDays(2)
+        );
+
+        ParticipantGameEntity creatorParticipation = participantGameRepository.save(
+                ParticipantGameEntity.createCreator(
+                        createdGame, bannedUser, bannedAt.minusDays(1)
+                )
+        );
+
+        ParticipantGameEntity receiverParticipation = participantGameRepository.save(
+                ParticipantGameEntity.createParticipation(
+                        createdGame, receiver, bannedAt.minusHours(1)
+                )
+        );
+
+        GameEntity otherGame = saveFutureGame(
+                "다른 사용자가 생성한 경기",
+                "다른 사용자 경기장",
+                otherCreator,
+                bannedAt.plusDays(3)
+        );
+
+        ParticipantGameEntity otherCreatorParticipation = participantGameRepository.save(
+                ParticipantGameEntity.createCreator(
+                        otherGame, otherCreator, bannedAt.minusDays(1)
+                )
+        );
+
+        ParticipantGameEntity bannedParticipation = participantGameRepository.save(
+                ParticipantGameEntity.createParticipation(
+                        otherGame, bannedUser, bannedAt.minusHours(1)
+                )
+        );
+
+        Long createdGameId = createdGame.getGameId();
+        Long otherGameId = otherGame.getGameId();
+
+        Long creatorParticipationId =
+                creatorParticipation.getParticipantGameId();
+
+        Long receiverParticipationId =
+                receiverParticipation.getParticipantGameId();
+
+        Long bannedParticipationId =
+                bannedParticipation.getParticipantGameId();
+
+        Long otherCreatorParticipationId =
+                otherCreatorParticipation.getParticipantGameId();
+
+        flushAndClear();
+        // when
+
+        BlackListGameResultDto result = blackListGameService.cleanup(bannedUser.getUserId(), bannedAt);
+
+        flushAndClear();
+
+        // then
+
+        GameEntity canceledCreatedGame = gameRepository.findById(createdGameId)
+                .orElseThrow();
+
+        GameEntity remainedOtherGame =
+                gameRepository.findById(otherGameId)
+                        .orElseThrow();
+
+        ParticipantGameEntity deletedCreatorParticipation =
+                participantGameRepository.findById(
+                        creatorParticipationId
+                ).orElseThrow();
+
+        ParticipantGameEntity deletedReceiverParticipation =
+                participantGameRepository.findById(
+                        receiverParticipationId
+                ).orElseThrow();
+
+        ParticipantGameEntity kickedOutParticipation =
+                participantGameRepository.findById(
+                        bannedParticipationId
+                ).orElseThrow();
+
+        ParticipantGameEntity remainedCreatorParticipation =
+                participantGameRepository.findById(
+                        otherCreatorParticipationId
+                ).orElseThrow();
+
+        assertEquals(bannedAt, canceledCreatedGame.getDeletedDateTime());
+
+        assertEquals(DELETE, deletedCreatorParticipation.getParticipantGameStatus());
+        assertEquals(DELETE, deletedReceiverParticipation.getParticipantGameStatus());
+
+        assertEquals(KICKOUT, kickedOutParticipation.getParticipantGameStatus());
+        assertEquals(bannedAt, kickedOutParticipation.getKickoutDateTime());
+
+        assertEquals(ACCEPT, remainedCreatorParticipation.getParticipantGameStatus());
+
+        assertEquals(0, canceledCreatedGame.getParticipantCount());
+        assertEquals(1, remainedOtherGame.getParticipantCount());
+
+        GameCancelNotificationDto notice = result.notices().get(0);
+
+        assertEquals(receiver.getUserId(), notice.receiverId());
+        assertEquals(createdGame.getTitle(), notice.gameTitle());
+
+    }
+
+    @Test
+    @DisplayName("이미 종료된 경기와 종료된 경기의 참가 상태는 변경하지 않는다.")
+    void cleanUp_success_excludeCompletedGames() {
+        // given
+
+        LocalDateTime completedStart =
+                bannedAt.minusDays(2);
+
+        GameEntity completedCreatedGame = saveCompletedGame(
+                "제재 대상자가 생성했던 종료 경기",
+                "종료된 생성 경기장",
+                bannedUser,
+                completedStart
+        );
+
+        ParticipantGameEntity completedCreatorParticipation =
+                participantGameRepository.save(
+                        ParticipantGameEntity.createCreator(
+                                completedCreatedGame,
+                                bannedUser,
+                                completedStart.minusDays(1)
+                        )
+                );
+
+        ParticipantGameEntity completedReceiverParticipation =
+                participantGameRepository.save(
+                        ParticipantGameEntity.createParticipation(
+                                completedCreatedGame,
+                                receiver,
+                                completedStart.minusHours(1)
+                        )
+                );
+
+        GameEntity otherCompletedGame = saveCompletedGame(
+                "다른 사용자의 종료 경기",
+                "다른 종료 경기장",
+                otherCreator,
+                completedStart.minusDays(1)
+        );
+
+        participantGameRepository.save(
+                ParticipantGameEntity.createCreator(
+                        otherCompletedGame,
+                        otherCreator,
+                        completedStart.minusDays(2)
+                )
+        );
+
+        ParticipantGameEntity completedBannedParticipation =
+                participantGameRepository.save(
+                        ParticipantGameEntity.createParticipation(
+                                otherCompletedGame,
+                                bannedUser,
+                                completedStart.minusHours(2)
+                        )
+                );
+
+        Long completedCreatedGameId =
+                completedCreatedGame.getGameId();
+
+        Long completedCreatorParticipationId =
+                completedCreatorParticipation
+                        .getParticipantGameId();
+
+        Long completedReceiverParticipationId =
+                completedReceiverParticipation
+                        .getParticipantGameId();
+
+        Long completedBannedParticipationId =
+                completedBannedParticipation
+                        .getParticipantGameId();
+
+        flushAndClear();
+
+        // when
+
+        BlackListGameResultDto result = blackListGameService.cleanup(bannedUser.getUserId(), bannedAt);
+
+        // then
+        GameEntity remainedCompletedGame =
+                gameRepository.findById(
+                        completedCreatedGameId
+                ).orElseThrow();
+
+        ParticipantGameEntity remainedCreator =
+                participantGameRepository.findById(
+                        completedCreatorParticipationId
+                ).orElseThrow();
+
+        ParticipantGameEntity remainedReceiver =
+                participantGameRepository.findById(
+                        completedReceiverParticipationId
+                ).orElseThrow();
+
+        ParticipantGameEntity remainedBannedParticipant =
+                participantGameRepository.findById(
+                        completedBannedParticipationId
+                ).orElseThrow();
+
+        assertNull(remainedCompletedGame.getDeletedDateTime());
+
+        assertEquals(ACCEPT, remainedCreator.getParticipantGameStatus());
+
+        assertEquals(ACCEPT, remainedReceiver.getParticipantGameStatus());
+
+        assertEquals(ACCEPT, remainedBannedParticipant.getParticipantGameStatus());
+
+        assertTrue(result.notices().isEmpty());
+    }
+
+
+    private GameEntity saveFutureGame(
+            String title,
+            String placeName,
+            UserEntity creator,
+            LocalDateTime startDateTime
+    ) {
+        return saveGame(
+                title,
+                placeName,
+                creator,
+                startDateTime,
+                bannedAt
+        );
+    }
+
+    private GameEntity saveCompletedGame(
+            String title,
+            String placeName,
+            UserEntity creator,
+            LocalDateTime startDateTime
+    ) {
+        return saveGame(
+                title,
+                placeName,
+                creator,
+                startDateTime,
+                startDateTime.minusDays(1)
+        );
+    }
+
+    private GameEntity saveGame(
+            String title,
+            String placeName,
+            UserEntity creator,
+            LocalDateTime startDateTime,
+            LocalDateTime createdAt
+    ) {
+        GameEntity game = GameEntity.create(
+                title,
+                "블랙리스트 경기 정리 통합 테스트입니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                startDateTime.plusHours(2),
+                placeName,
+                "서울특별시 송파구 " + placeName,
+                SEOUL,
+                37.515,
+                127.073,
+                creator,
+                createdAt
+        );
+
+        return gameRepository.save(game);
+    }
+
+    private UserEntity saveUser(
+            String email,
+            String nickname,
+            String phone
+    ) {
+        UserEntity user = UserEntity.create(
+                email,
+                "encoded-password",
+                nickname,
+                nickname,
+                LocalDate.of(1997, 1, 1),
+                phone,
+                "서울특별시 송파구",
+                Position.GUARD,
+                GenderType.MALE
+        );
+
+        user.setEmailAuth();
+
+        return userRepository.save(user);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+
+
+}

--- a/src/test/java/com/example/basketballmatching/report/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/report/service/ReportServiceIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.PageRequest;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static com.example.basketballmatching.game.type.CityName.SEOUL;
 import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
@@ -205,7 +206,10 @@ class ReportServiceIntegrationTest {
 
         assertEquals(PENDING, report.getReportStatus());
 
-        assertEquals(response.reportedAt(), report.getReportedDateTime());
+        assertEquals(
+                response.reportedAt().truncatedTo(ChronoUnit.SECONDS),
+                report.getReportedDateTime().truncatedTo(ChronoUnit.SECONDS)
+        );
     }
 
     @Test

--- a/src/test/java/com/example/basketballmatching/report/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/com/example/basketballmatching/report/service/ReportServiceIntegrationTest.java
@@ -1,0 +1,349 @@
+package com.example.basketballmatching.report.service;
+
+import com.example.basketballmatching.game.domain.GameEntity;
+import com.example.basketballmatching.game.domain.ParticipantGameEntity;
+import com.example.basketballmatching.game.repository.GameRepository;
+import com.example.basketballmatching.game.repository.ParticipantGameRepository;
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.report.domain.ReportEntity;
+import com.example.basketballmatching.report.dto.request.CreateReportRequest;
+import com.example.basketballmatching.report.dto.request.ReviewReportRequest;
+import com.example.basketballmatching.report.dto.response.CreateReportResponse;
+import com.example.basketballmatching.report.dto.response.ReportListResponse;
+import com.example.basketballmatching.report.dto.response.ReviewReportResponse;
+import com.example.basketballmatching.report.repository.ReportRepository;
+import com.example.basketballmatching.report.type.ReportDecision;
+import com.example.basketballmatching.report.type.ReportType;
+import com.example.basketballmatching.support.IntegrationTest;
+import com.example.basketballmatching.user.domain.UserEntity;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.LoginProvider;
+import com.example.basketballmatching.user.type.Position;
+import com.example.basketballmatching.user.type.UserType;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.example.basketballmatching.game.type.CityName.SEOUL;
+import static com.example.basketballmatching.game.type.FieldStatus.INDOOR;
+import static com.example.basketballmatching.game.type.MatchFormat.THREE_ON_THREE;
+import static com.example.basketballmatching.game.type.MatchGenderType.MIXED;
+import static com.example.basketballmatching.global.exception.ErrorCode.ALREADY_REPORTED_USER;
+import static com.example.basketballmatching.report.type.ReportStatus.APPROVED;
+import static com.example.basketballmatching.report.type.ReportStatus.PENDING;
+import static org.junit.jupiter.api.Assertions.*;
+@Transactional
+@IntegrationTest
+@DisplayName("ReportService 통합 테스트")
+class ReportServiceIntegrationTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private ParticipantGameRepository participantGameRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private Long gameId;
+    private Long reporterId;
+    private Long secondReporterId;
+    private Long targetId;
+    private Long adminId;
+
+    @BeforeEach
+    void setUp() {
+
+        UserEntity creator = saveUser(
+                "creator@test.com",
+                "경기생성자",
+                "010-1111-1111",
+                UserType.USER
+        );
+
+        UserEntity reporter = saveUser(
+                "reporter@test.com",
+                "신고자",
+                "010-2222-2222",
+                UserType.USER
+        );
+
+        UserEntity secondReporter = saveUser(
+                "second-reporter@test.com",
+                "두번째신고자",
+                "010-3333-3333",
+                UserType.USER
+        );
+
+        UserEntity target = saveUser(
+                "target@test.com",
+                "신고대상",
+                "010-4444-4444",
+                UserType.USER
+        );
+
+        UserEntity admin = saveUser(
+                "admin@test.com",
+                "관리자",
+                "010-5555-5555",
+                UserType.ADMIN
+        );
+
+        LocalDateTime now = LocalDateTime.now(clock)
+                .withSecond(0)
+                .withNano(0);
+
+        LocalDateTime startDateTime = now.minusDays(2);
+        LocalDateTime endDateTime = startDateTime.plusHours(2);
+        LocalDateTime createdAt = startDateTime.minusDays(1);
+
+        GameEntity game = GameEntity.create(
+                "신고 통합 테스트 경기",
+                "종료된 경기입니다.",
+                6,
+                INDOOR,
+                THREE_ON_THREE,
+                MIXED,
+                startDateTime,
+                endDateTime,
+                "잠실 농구장",
+                "서울특별시 송파구 올림픽로 25",
+                SEOUL,
+                37.515,
+                127.073,
+                creator,
+                createdAt
+        );
+
+        gameRepository.save(game);
+
+        participantGameRepository.save(
+                ParticipantGameEntity.createCreator(
+                        game,
+                        creator,
+                        createdAt
+                )
+        );
+
+        participantGameRepository.save(
+                ParticipantGameEntity.createParticipation(
+                        game,
+                        reporter,
+                        createdAt
+                )
+        );
+
+        participantGameRepository.save(
+                ParticipantGameEntity.createParticipation(
+                        game,
+                        secondReporter,
+                        createdAt
+                )
+        );
+
+        participantGameRepository.save(
+                ParticipantGameEntity.createParticipation(
+                        game,
+                        target,
+                        createdAt
+                )
+        );
+
+        gameId = game.getGameId();
+        reporterId = reporter.getUserId();
+        secondReporterId = secondReporter.getUserId();
+        targetId = target.getUserId();
+        adminId = admin.getUserId();
+
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("종료된 경기의 확정 참가자가 신고 시 신고 정보가 저장된다.")
+    void createReport_success() {
+        // given
+
+        CreateReportRequest request = createReportRequest();
+
+        // when
+
+        CreateReportResponse response = reportService.createReport(reporterId, gameId, request);
+
+        flushAndClear();
+        // then
+
+        ReportEntity report = reportRepository.findById(response.reportId()).orElseThrow();
+
+
+        assertEquals(reporterId, report.getReportUser().getUserId());
+        assertEquals(targetId, report.getTargetUser().getUserId());
+        assertEquals(gameId, report.getGameEntity().getGameId());
+        assertEquals("경기 중 비매너 행위를 반복했습니다.", report.getContent());
+
+        assertEquals(PENDING, report.getReportStatus());
+
+        assertEquals(response.reportedAt(), report.getReportedDateTime());
+    }
+
+    @Test
+    @DisplayName("동일한 경기에서 같은 사용자를 중복 신고할 수 없다.")
+    void createReport_fail_duplicateReport() {
+        // given
+
+        CreateReportRequest request = createReportRequest();
+
+        reportService.createReport(reporterId, gameId, request);
+
+        flushAndClear();
+
+        // when
+
+        CustomException exception = assertThrows(CustomException.class, () -> reportService.createReport(reporterId, gameId, request));
+
+        // then
+
+        assertEquals(ALREADY_REPORTED_USER, exception.getErrorCode());
+        assertEquals(1, reportRepository.count());
+
+    }
+
+    @Test
+    @DisplayName("서로 다른 참가자는 같은 대상을 신고할 수 있다.")
+    void createReport_success_differentReporters() {
+        // given
+
+        CreateReportRequest request = createReportRequest();
+
+        // when
+        reportService.createReport(reporterId, gameId, request);
+
+        reportService.createReport(secondReporterId, gameId, request);
+
+        flushAndClear();
+        // then
+
+        assertEquals(2, reportRepository.count());
+
+
+    }
+
+    @Test
+    @DisplayName("관리자는 처리 상태에 따라 신고 목록을 조회할 수 있다.")
+    void getReports_success_filterByStatus() {
+        // given
+
+        CreateReportResponse pendingReport = reportService.createReport(
+                secondReporterId, gameId, createReportRequest()
+        );
+
+        CreateReportResponse approvedReport = reportService.createReport(reporterId, gameId, createReportRequest());
+
+        reportService.reviewReport(adminId, approvedReport.reportId(), new ReviewReportRequest(
+                ReportDecision.APPROVE, "신고 내용을 확인하여 승인합니다."
+        ));
+
+        flushAndClear();
+
+        // when
+
+        Page<ReportListResponse> response = reportService.getReports(adminId, PENDING, PageRequest.of(0, 20));
+
+        // then
+
+        assertEquals(1, response.getTotalElements());
+        assertEquals(1, response.getContent().size());
+
+        ReportListResponse report = response.getContent().get(0);
+
+        assertEquals(pendingReport.reportId(), report.reportId());
+        assertEquals(gameId, report.gameId());
+        assertEquals(secondReporterId, report.reporterId());
+        assertEquals(targetId, report.targetUserId());
+        assertEquals(ReportType.POOR_SPORTSMANSHIP, report.reportType());
+
+    }
+
+    @Test
+    @DisplayName("신고 승인 시 검토 정보가 저장")
+    void reviewReport_success_approve() {
+        // given
+
+        CreateReportResponse created = reportService.createReport(reporterId, gameId, createReportRequest());
+
+        flushAndClear();
+
+        ReviewReportRequest request = new ReviewReportRequest(ReportDecision.APPROVE, "신고 내용을 확인하여 승인합니다.");
+        // when
+
+        ReviewReportResponse response = reportService.reviewReport(adminId, created.reportId(), request);
+
+        // then
+        ReportEntity report = reportRepository.findById(created.reportId()).orElseThrow();
+
+        assertEquals(APPROVED, report.getReportStatus());
+        assertEquals(APPROVED, response.reportStatus());
+
+        assertNotNull(response.reviewedAt());
+
+        assertEquals("신고 내용을 확인하여 승인합니다.", report.getReviewReason());
+
+
+    }
+
+
+
+
+    private CreateReportRequest createReportRequest() {
+        return new CreateReportRequest(
+                targetId, ReportType.POOR_SPORTSMANSHIP, "경기 중 비매너 행위를 반복했습니다."
+        );
+    }
+
+    private UserEntity saveUser(String email, String nickname, String phone, UserType userType) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("encoded-password")
+                .nickname(nickname)
+                .name(nickname)
+                .birth(LocalDate.of(1997, 1, 1))
+                .phone(phone)
+                .address("서울특별시 송파구")
+                .position(Position.GUARD)
+                .userType(userType)
+                .genderType(GenderType.MALE)
+                .loginProvider(LoginProvider.LOCAL)
+                .emailAuth(true)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 신고 및 블랙리스트 정책을 실제 DB 환경에서 검증하는 통합 테스트가 부족했다
- 블랙리스트 등록 커밋 이후 토큰 폐기와 알림 처리를 검증하지 않았다
- 제재 사용자의 예정 경기 및 참가 상태 정리 QueryDSL 로직을 실제 데이터로 검증하지 않았다
- 관련 통합 테스트가 CI 실행 대상에 포함되지 않았다

### 🚀 TO-BE

- 신고 저장, 중복 방지, 관리자 검토 및 상태별 목록 조회 통합 테스트를 추가했다.
- 블랙리스트 등록, 중복 제재 방지, 활성·만료 상태 조회 및 자동 해제를 검증했다.
- 커밋 이후 Refresh Token 폐기와 제재·경기 취소 알림 저장을 검증했다.
- 제재 사용자의 예정 경기 취소 및 다른 경기 참가 상태 정리 로직을 실제 DB에서 검증했다.
- 신고 및 블랙리스트 관련 통합 테스트 4개 클래스를 CI 실행 대상에 추가했다.

---

## ✅ 체크리스트

- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (통합 테스트)
- [ ] 관련 문서(README, API 명세) 업데이트
- [x] 성능/보안/예외 처리 검토 완료

---