### PR TITLE
[perf]: 목록 조회 N+1 문제 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,11 @@ OAuth 로그인은 콜백 URI에서 장기 인증 토큰을 직접 노출하지 
 
 ## 🚀 성능 개선
 
-50만 건의 경기 데이터를 생성하고 목록 Content Query와 COUNT Query를 분리해 측정했습니다. 인덱스 적용 전후에 같은 데이터와 요청 조건을 사용하고, `EXPLAIN ANALYZE` 5회 중앙값과 k6 20 RPS·3분·3회 결과를 비교했습니다.
+조회 성능, 동시성 정합성, ORM 쿼리 증폭을 서로 다른 문제로 분리해 측정했습니다. MySQL `EXPLAIN ANALYZE`, 요청당 Hibernate 쿼리 수 메트릭, k6, Prometheus, Grafana를 사용했고 개선 전·후에 같은 데이터와 요청 조건을 적용했습니다.
+
+### 50만 건 경기 목록 인덱스
+
+50만 건의 경기 데이터를 생성하고 목록 Content Query와 COUNT Query를 분리해 측정했습니다. `EXPLAIN ANALYZE` 5회 중앙값과 k6 20 RPS·3분·3회 결과를 비교했습니다.
 
 ### 기본 시작 시간순 조회
 
@@ -269,10 +273,42 @@ CREATE INDEX idx_game_list_active_start
 
 처음 추가한 인덱스가 다른 정렬 조건에 회귀를 만드는 것도 확인했습니다. 후보 인덱스를 바로 채택하지 않고 실행계획과 부하 테스트로 기각 근거를 남긴 뒤, 기본·필터·최신순 접근 패턴을 각각 담당하는 인덱스로 분리했습니다.
 
+### 경기 참가 동시성 제어
+
+정원 6명인 경기의 남은 5자리에 100명이 동시에 참가하는 상황을 재현했습니다. 락이 없을 때는 초과 승인과 집계 불일치가 발생했고, 낙관적 락 무재시도는 DB 정합성은 복구했지만 충돌 요청 39건이 시스템 오류로 종료됐습니다. 비관적 쓰기 락을 적용해 남은 자리에 정확히 5명만 참가하고 나머지 요청을 정상적인 정원 초과 응답으로 처리했습니다.
+
+| 항목 | 락 없음 | 낙관적 락 무재시도 | 비관적 락 |
+|---|---:|---:|---:|
+| 참가 성공 | 12건 | 5건 | 5건 |
+| 정상 정원 초과 | 52건 | 56건 | 95건 |
+| 시스템 오류 | 36건 | 39건 | 0건 |
+| 최종 `ACCEPT` | 13명 | 6명 | 6명 |
+| DB 정합성 | FAIL | PASS | PASS |
+
+비관적 락 채택 후 200·500·1,000 VU로 동시 요청 규모를 높였으며, 1,000 VU에서 참가 성공 5건, 정상 거절 995건, 시스템 오류 0건과 p95 2,024.20ms를 기록했습니다. 정합성과 API 계약은 유지했지만 요청 규모에 따라 락·커넥션 대기가 지연으로 나타나는 트레이드오프도 확인했습니다.
+
+### 목록 조회 N+1 제거
+
+Repository 조회와 DTO 변환 경로를 연결해 `LAZY` 연관관계의 일반 필드에 접근하는 목록을 선별했습니다. QueryDSL 커스텀 조회에는 Fetch Join을, Spring Data JPA 파생 쿼리에는 `EntityGraph`를 적용해 전역 `LAZY` 정책과 DB 페이지네이션을 유지했습니다.
+
+| 대상 목록 | 검증 건수 | 개선 전 SELECT | 개선 후 SELECT | 결과 |
+|---|---:|---:|---:|---|
+| 내 예정·지난 경기 | 100건 | 103회 | 3회 | 97.09% 감소 |
+| 경기 참가자 | 20건 | 24회 | 4회 | 83.33% 감소 |
+| 관리자 블랙리스트 | 20건 | 23회 | 3회 | 86.96% 감소 |
+| 관리자 신고 | 20건 | 유효한 기준선 미확보 | 3회 | 쿼리 수 상수 유지 |
+
+내 경기 목록은 요청당 SELECT를 103회에서 3회로 줄였고, 최대 200 RPS 스트레스 구간의 p95를 4,744.71ms에서 14.70ms로 단축했습니다. 같은 구간에서 dropped iteration 4,445건과 HikariCP Pending Connection 최대 189건이 모두 0건으로 감소했습니다.
+
 - [성능 테스트 재현 문서](performance/README.md)
 - [경기 목록 필터 실험](performance/results/game-list-filter/README.md)
+- [내 경기 N+1 개선 전 기준선](performance/results/my-game-list-n-plus-one/before/summary.md)
+- [내 경기 N+1 개선 후 검증](performance/results/my-game-list-n-plus-one/after/summary.md)
 - [필터 인덱스 설계 결정](docs/adr/game/game-list-filter-index.md)
 - [최신순 인덱스 설계 결정](docs/adr/game/game-list-latest-index.md)
+- [경기 참가 동시성 제어 결정](docs/adr/game/game-participation-concurrency-lock.md)
+- [N+1 로딩 전략 결정](docs/adr/performance/n-plus-one-loading-strategy.md)
+- [목록 조회 N+1 리팩터링](docs/refactoring/performance/list-query-n-plus-one-refactoring.md)
 
 ---
 
@@ -302,10 +338,14 @@ Pull Request / main push
 - [OAuth 일회용 티켓](docs/adr/auth/oauth-one-time-ticket.md)
 - [OAuth state와 CSRF 방어](docs/adr/auth/oauth-state-csrf-protection.md)
 - [선착순 즉시 참가 정책](docs/adr/game/direct-participation-policy.md)
+- [경기 참가 동시성 제어](docs/adr/game/game-participation-concurrency-lock.md)
+- [경기 목록 필터 인덱스](docs/adr/game/game-list-filter-index.md)
+- [경기 목록 최신순 인덱스](docs/adr/game/game-list-latest-index.md)
 - [경기 랭크 기능 제거](docs/adr/game/game-rank-removal.md)
 - [신고 승인과 블랙리스트 제재 분리](docs/adr/report/report-review-and-sanction-separation.md)
 - [블랙리스트 커밋 이후 처리](docs/adr/blacklist/blacklist-after-commit-processing.md)
 - [영속 알림과 실시간 알림 분리](docs/adr/notification/persistent-and-realtime-notification.md)
+- [N+1 로딩 전략](docs/adr/performance/n-plus-one-loading-strategy.md)
 
 </details>
 
@@ -320,6 +360,7 @@ Pull Request / main push
 - [신고 기능 리팩터링](docs/refactoring/report/report-refactoring.md)
 - [블랙리스트 기능 리팩터링](docs/refactoring/blacklist/blacklist-refactoring.md)
 - [알림 기능 리팩터링](docs/refactoring/notification/notification-refactoring.md)
+- [목록 조회 N+1 리팩터링](docs/refactoring/performance/list-query-n-plus-one-refactoring.md)
 
 </details>
 
@@ -338,8 +379,8 @@ Pull Request / main push
 
 ## 🔭 향후 개선 계획
 
-- [ ] 동시 참가 요청 재현 후 정원 정합성을 위한 락 전략 비교
-- [ ] 실제 쿼리 수 측정을 통한 N+1 후보 분석과 개선
+- [ ] 인기 경기 집중 요청에서 락 대기시간과 운영 임계치 관측
+- [ ] 페이지 크기 증가에도 쿼리 수가 상수인지 확인하는 N+1 회귀 테스트 추가
 - [ ] 조회 빈도와 변경 빈도를 측정한 뒤 캐싱 대상 선정
 - [ ] 이벤트 유실이 허용되지 않는 후속 작업에 Transactional Outbox 검토
 - [ ] 배포 환경에서 선별한 개선 항목의 부하 테스트 및 비용 관측

--- a/docs/adr/performance/n-plus-one-loading-strategy.md
+++ b/docs/adr/performance/n-plus-one-loading-strategy.md
@@ -1,0 +1,50 @@
+# 목록 조회 형태에 따라 Fetch Join과 EntityGraph 사용
+
+## 문제 상황
+
+목록 조회 쿼리는 대상 엔티티만 가져오지만, 응답 DTO 변환 과정에서 `LAZY` 연관관계의 일반 필드를 읽고 있었다. 이로 인해 내 경기, 경기 참가자, 관리자 신고, 관리자 블랙리스트 목록에서 페이지 항목 수에 비례하는 추가 SELECT 위험이 있었다.
+
+목록 API는 페이지네이션을 유지해야 하며, 다른 사용 상황에서는 지연 로딩을 계속 사용해야 한다. 따라서 엔티티 연관관계를 전역 `EAGER`로 변경하지 않고 조회 메서드별 로딩 전략이 필요했다.
+
+## 선택지
+
+### 연관관계를 EAGER로 변경
+
+구현은 간단하지만 해당 엔티티를 사용하는 모든 조회에 로딩 정책이 전파된다. 연관 데이터가 필요하지 않은 API에서도 불필요한 조회를 유발하므로 제외했다.
+
+### Batch Fetch 설정
+
+추가 SELECT를 배치 단위로 묶어 횟수를 줄일 수 있다. 그러나 N+1 접근 구조 자체는 남고 전역 설정의 영향 범위와 적정 배치 크기를 별도로 관리해야 한다.
+
+### DTO Projection
+
+응답에 필요한 컬럼만 직접 조회할 수 있어 읽기 비용을 더 줄일 수 있다. 다만 현재 DTO 변환 구조와 Repository 반환 타입의 변경 범위가 크고, 우선 해결할 문제는 불필요한 반복 SELECT였다.
+
+### Fetch Join과 EntityGraph
+
+모두 특정 조회에서만 필요한 연관관계를 함께 가져올 수 있다. Fetch Join은 QueryDSL 조회의 조인 의도를 명시적으로 표현하기 좋고, `EntityGraph`는 Spring Data JPA 파생 쿼리를 유지하면서 로딩 범위만 선언하기 좋다.
+
+## 결정
+
+조회 구조에 따라 두 방식을 구분해 사용한다.
+
+- QueryDSL로 content·count 쿼리를 직접 구성하는 내 경기 목록은 `gameEntity` Fetch Join을 사용한다.
+- Spring Data JPA 파생 쿼리를 사용하는 경기 참가자, 신고, 블랙리스트 목록은 `EntityGraph`를 사용한다.
+- DTO가 일반 필드를 읽는 연관관계만 Fetch 대상에 포함한다.
+- 프록시의 식별자만 읽는 연관관계는 실제 추가 SELECT가 확인되지 않는 한 Fetch 대상에서 제외한다.
+- COUNT 쿼리에는 Fetch Join을 적용하지 않는다.
+
+이번 대상은 모두 `ManyToOne` 또는 식별자 기반의 단건 연관관계이다. 컬렉션 Fetch Join을 사용하지 않으므로 본문 결과 행이 증가하지 않고 DB 페이지네이션을 유지할 수 있다.
+
+## 결과
+
+| 대상 목록 | 개선 방식 | 검증 결과 |
+|---|---|---|
+| 내 예정·지난 경기 | QueryDSL Fetch Join | 100건 조회 `103 → 3` |
+| 경기 참가자 | `EntityGraph(userEntity)` | 20건 조회 `24 → 4` |
+| 관리자 신고 | `EntityGraph(gameEntity, reportUser, targetUser)` | 연관 데이터 20건 조회 SELECT 3회 |
+| 관리자 블랙리스트 | `EntityGraph(userEntity)` | 20건 조회 `23 → 3` |
+
+목록 크기가 커져도 요청당 쿼리 수가 상수로 유지되는 구조로 변경했다. 다만 `EntityGraph`에 연관관계를 추가할수록 JOIN 크기와 전송 데이터가 커지므로, DTO가 실제로 사용하는 필드와 쿼리 수를 함께 확인해야 한다.
+
+세부 구현과 검증 내용은 [목록 조회 N+1 리팩터링](../../refactoring/performance/list-query-n-plus-one-refactoring.md)에 기록한다.

--- a/docs/refactoring/performance/list-query-n-plus-one-refactoring.md
+++ b/docs/refactoring/performance/list-query-n-plus-one-refactoring.md
@@ -1,0 +1,175 @@
+# 목록 조회 N+1 리팩터링
+
+## 1. 개요
+
+내 경기, 경기 참가자, 관리자 신고, 관리자 블랙리스트 목록의 Repository 조회와 DTO 변환 경로를 연결해 N+1 발생 위치를 확인했다.
+
+조회 쿼리만으로는 문제가 보이지 않았지만, 트랜잭션 안에서 `Page.map()`이나 `stream()`으로 DTO를 만들 때 `LAZY` 연관관계의 일반 필드에 접근하면 항목별 추가 SELECT가 실행됐다. 각 조회에 필요한 단건 연관관계만 Fetch해 쿼리 수를 상수로 고정했다.
+
+---
+
+## 2. 문제 탐지 방법
+
+요청 시작에서 종료까지 Hibernate `StatementInspector`가 SQL 유형별 실행 횟수를 누적하고, Micrometer `DistributionSummary`로 요청 경로·HTTP 메서드·쿼리 유형 태그를 기록했다.
+
+```text
+HTTP 요청 시작
+ → ThreadLocal 컨텍스트 생성
+ → StatementInspector가 SELECT 횟수 누적
+ → HTTP 요청 종료
+ → app.query.per_request 메트릭 기록
+ → ThreadLocal 정리
+```
+
+페이지 크기를 1, 10, 20, 100으로 변경해 SELECT 횟수가 선형으로 증가하는지 확인했다. Grafana percentile은 히스토그램 보간값이므로, 정확한 쿼리 수 판정에는 요청 단위 측정값과 페이지 크기별 결과를 사용했다.
+
+---
+
+## 3. 내 경기 목록
+
+`ParticipantGameEntity` 목록을 조회한 뒤 `MyUpcomingGameResponse`와 `MyCompletedGameResponse`를 만들며 `gameEntity`에 접근했다.
+
+```text
+개선 전: 사용자 검증 1 + 목록 1 + COUNT 1 + GameEntity N
+개선 후: 사용자 검증 1 + Fetch Join 목록 1 + COUNT 1
+```
+
+QueryDSL content 쿼리에 `ManyToOne` 연관관계를 Fetch Join했다.
+
+```java
+.selectFrom(participation)
+.join(participation.gameEntity, game).fetchJoin()
+```
+
+| 페이지 크기 | 개선 전 | 개선 후 |
+|---:|---:|---:|
+| 1 | 4 | 3 |
+| 10 | 13 | 3 |
+| 20 | 23 | 3 |
+| 100 | 103 | 3 |
+
+세부 부하 결과는 [개선 전 기준선](../../../performance/results/my-game-list-n-plus-one/before/summary.md)과 [개선 후 검증](../../../performance/results/my-game-list-n-plus-one/after/summary.md)에 보관한다.
+
+---
+
+## 4. 경기 참가자 목록
+
+`GameParticipantListResponse` 변환은 `ParticipantGameEntity.userEntity`의 닉네임과 포지션을 읽는다. 서로 다른 참가자로 구성한 페이지에서 항목별 사용자 SELECT가 발생했다.
+
+```java
+@EntityGraph(attributePaths = "userEntity")
+Page<ParticipantGameEntity>
+findByGameEntity_GameIdAndParticipantGameStatus(
+        Long gameId,
+        ParticipantGameStatus status,
+        Pageable pageable
+);
+```
+
+| 페이지 크기 | 개선 전 | 개선 후 |
+|---:|---:|---:|
+| 1 | 5 | 4 |
+| 10 | 14 | 4 |
+| 20 | 24 | 4 |
+
+개선 후에는 페이지 크기와 관계없이 SELECT 4회를 유지했다.
+
+---
+
+## 5. 관리자 신고 목록
+
+`ReportListResponse` 변환은 경기 제목, 신고자 닉네임, 신고 대상 닉네임을 읽는다. 따라서 `gameEntity`, `reportUser`, `targetUser` 세 개의 `LAZY` 연관관계가 목록 크기에 따라 추가 쿼리를 발생시킬 수 있었다.
+
+```java
+@EntityGraph(attributePaths = {
+        "gameEntity",
+        "reportUser",
+        "targetUser"
+})
+Page<ReportEntity> findAllByReportStatusOrderByReportedDateTimeDesc(
+        ReportStatus reportStatus,
+        Pageable pageable
+);
+```
+
+`reviewedBy`는 DTO에서 사용하지 않으므로 Fetch 대상에서 제외했다. 서로 다른 경기·신고자·대상자를 연결한 신고 20건을 조회했을 때 관리자 검증, 목록, COUNT로 SELECT 3회를 유지했다.
+
+초기 적용 전 측정은 빈 페이지에서 수행돼 유효한 기준선으로 사용하지 않았다. 따라서 신고 목록은 실측 감소율을 제시하지 않고, DTO 접근 경로 분석과 개선 후 쿼리 수 고정 검증으로 범위를 한정한다.
+
+---
+
+## 6. 관리자 블랙리스트 목록
+
+`BlackListResponse` 변환은 제재 대상 사용자의 이메일과 닉네임을 읽는다. 반면 `reportEntity`와 `bannedBy`는 식별자만 읽으므로 Fetch 범위에서 제외했다.
+
+```java
+@EntityGraph(attributePaths = "userEntity")
+Page<BlackListEntity> findAllByExpiresAtAfterOrderByBannedDateTimeDesc(
+        LocalDateTime now,
+        Pageable pageable
+);
+
+@EntityGraph(attributePaths = "userEntity")
+Page<BlackListEntity> findAllByExpiresAtLessThanEqualOrderByBannedDateTimeDesc(
+        LocalDateTime now,
+        Pageable pageable
+);
+```
+
+| 항목 | 개선 전 | 개선 후 |
+|---|---:|---:|
+| 페이지 크기 | 20 | 20 |
+| SELECT | 23 | 3 |
+| 항목별 사용자 SELECT | 20 | 0 |
+
+활성·만료 목록이 서로 다른 파생 쿼리를 사용하므로 두 메서드 모두 동일한 `EntityGraph`를 적용했다.
+
+---
+
+## 7. 페이지네이션과 Fetch 범위
+
+이번 변경은 컬렉션 연관관계를 Fetch Join하지 않는다. 목록의 기준 엔티티에서 단건으로 참조하는 `ToOne` 연관관계만 함께 조회하므로 다음 특성을 유지한다.
+
+- 본문 결과 행이 연관 엔티티 수만큼 증가하지 않는다.
+- DB에서 `offset`과 `limit`를 적용하는 기존 페이지네이션을 유지한다.
+- COUNT 쿼리에 불필요한 Fetch Join을 추가하지 않는다.
+- 엔티티의 전역 FetchType은 `LAZY`로 유지한다.
+
+---
+
+## 8. 검증 결과
+
+| 대상 목록 | 개선 전 | 개선 후 | 판정 |
+|---|---:|---:|---|
+| 내 예정·지난 경기 100건 | 103 | 3 | N+1 제거 |
+| 경기 참가자 20건 | 24 | 4 | N+1 제거 |
+| 관리자 신고 20건 | 유효한 기준선 미확보 | 3 | 잠재 N+1 방지 |
+| 관리자 블랙리스트 20건 | 23 | 3 | N+1 제거 |
+
+경기 참가자와 블랙리스트는 페이지 항목 수만큼 추가되던 SELECT가 0회로 줄었다. 내 경기 목록은 요청당 SELECT가 103회에서 3회로 줄었고, 최대 200 RPS 스트레스 구간의 dropped iteration 4,445건이 0건으로 감소했다.
+
+---
+
+## 9. 트레이드오프와 후속 과제
+
+`EntityGraph`는 파생 쿼리를 유지하면서 N+1을 제거할 수 있지만 응답 필드가 변경되면 Fetch 범위와 DTO 접근 경로를 함께 재검토해야 한다. 연관관계를 과도하게 포함하면 JOIN 행 크기와 DB·네트워크 전송량이 늘어날 수 있다.
+
+후속으로 다음을 검토한다.
+
+1. 페이지 크기가 증가해도 쿼리 수가 상수인지 통합 테스트로 고정한다.
+2. 응답에 필요한 컬럼이 더 줄어들면 DTO Projection을 비교한다.
+3. 컬렉션 Fetch Join이 필요해지면 2단계 ID 조회, Batch Fetch 또는 쿼리 분리를 먼저 검토한다.
+4. 신고 목록은 적용 전 유효 기준선을 추가로 확보해 실측 감소폭을 보완한다.
+
+---
+
+## 10. 성과
+
+- 목록 DTO의 연관관계 접근 경로를 기준으로 Fetch 범위를 최소화했다.
+- 경기 참가자 20건의 SELECT를 24회에서 4회로 줄였다.
+- 블랙리스트 20건의 SELECT를 23회에서 3회로 줄였다.
+- 신고 20건 조회에서 세 개의 필요한 연관관계를 함께 조회하고 SELECT 3회를 유지했다.
+- 페이지네이션과 전역 `LAZY` 정책을 유지하면서 조회 메서드별 N+1을 제거했다.
+- 내 경기 목록의 기존 스트레스 테스트에서 200 RPS 처리와 dropped iteration 0건을 확인했다.
+
+로딩 전략 선택 근거는 [Fetch Join과 EntityGraph 선택 ADR](../../adr/performance/n-plus-one-loading-strategy.md)에 별도로 기록한다.

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,11 +1,17 @@
 # Performance tests
 
-이 디렉터리는 경기 목록 API의 성능 개선 과정을 재현하기 위한 자료를 관리한다.
+이 디렉터리는 경기 목록 인덱스, 경기 참가 동시성, 목록 조회 N+1 개선 과정을 재현하기 위한 실행 스크립트와 측정 결과를 관리한다.
 
-## 대상 API
+## 성능 검증 대상 API
 
 ```http
 GET /api/v1/games?page=0&size=10
+GET /api/v1/mypage/games/upcoming?page=0&size=100
+GET /api/v1/mypage/games/completed?page=0&size=100
+POST /api/v1/games/{gameId}/participations
+GET /api/v1/games/{gameId}/participants?page=0&size=20
+GET /api/v1/admin/reports?status=PENDING&page=0&size=20
+GET /api/v1/admin/blacklists?status=ACTIVE&page=0&size=20
 ```
 
 ## 디렉터리 구조
@@ -134,7 +140,27 @@ CREATE INDEX idx_game_list_latest
 - [최종 검증 결과](./results/game-list-filter/after-latest-index/summary.md)
 - [설계 결정 기록](../docs/adr/game/game-list-latest-index.md)
 
-## 측정 원칙
+## 목록 조회 N+1 개선
+
+응답 DTO 변환 과정에서 `LAZY` 연관관계의 일반 필드에 접근하면 페이지 항목 수에 비례해 추가 SELECT가 발생했다. 커스텀 QueryDSL 조회에는 Fetch Join을, Spring Data JPA 파생 쿼리에는 `EntityGraph`를 적용해 필요한 `ToOne` 연관관계만 본문 쿼리에서 함께 조회했다.
+
+| 대상 목록 | 검증 크기 | 개선 전 SELECT | 개선 후 SELECT | 결과 |
+|---|---:|---:|---:|---|
+| 내 예정·지난 경기 | 100건 | 103회 | 3회 | 97.09% 감소 |
+| 경기 참가자 | 20건 | 24회 | 4회 | 83.33% 감소 |
+| 관리자 블랙리스트 | 20건 | 23회 | 3회 | 86.96% 감소 |
+| 관리자 신고 | 20건 | 유효한 기준선 미확보 | 3회 | 쿼리 수 상수 유지 |
+
+경기 참가자와 블랙리스트 목록은 서로 다른 사용자 20명을 조회해 페이지 크기만큼 추가 SELECT가 발생하는 것을 재현했다. 신고 목록은 DTO가 `gameEntity`, `reportUser`, `targetUser`의 일반 필드를 읽는 세 개의 지연 로딩 경로를 분석했고, 서로 다른 연관 데이터 20건을 조회했을 때 SELECT 3회로 유지되는 것을 확인했다.
+
+모든 Fetch 대상은 `ManyToOne` 또는 식별자 기반의 단건 연관관계이다. 컬렉션 Fetch Join을 사용하지 않아 결과 행 증폭과 메모리 페이지네이션 문제를 피했고, COUNT 쿼리는 본문 조회와 분리해 전체 건수 정확성을 유지했다.
+
+- [내 경기 목록 개선 전 기준선](./results/my-game-list-n-plus-one/before/summary.md)
+- [내 경기 목록 개선 후 검증](./results/my-game-list-n-plus-one/after/summary.md)
+- [N+1 로딩 전략 결정 기록](../docs/adr/performance/n-plus-one-loading-strategy.md)
+- [목록 조회 N+1 리팩터링](../docs/refactoring/performance/list-query-n-plus-one-refactoring.md)
+
+## 경기 목록 인덱스 측정 원칙
 
 1. 인덱스 적용 전후에 같은 데이터와 같은 Hibernate 바인딩 값을 사용한다.
 2. 목록 SQL과 COUNT SQL을 별도로 측정한다.

--- a/src/main/java/com/example/basketballmatching/blacklist/repository/BlackListRepository.java
+++ b/src/main/java/com/example/basketballmatching/blacklist/repository/BlackListRepository.java
@@ -3,6 +3,7 @@ package com.example.basketballmatching.blacklist.repository;
 import com.example.basketballmatching.blacklist.domain.BlackListEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -17,10 +18,12 @@ public interface BlackListRepository extends JpaRepository<BlackListEntity, Long
 
     boolean existsByUserEntity_EmailAndExpiresAtAfter(String email, LocalDateTime now);
 
+    @EntityGraph(attributePaths = "userEntity")
     Page<BlackListEntity> findAllByExpiresAtAfterOrderByBannedDateTimeDesc(
             LocalDateTime now, Pageable pageable
     );
 
+    @EntityGraph(attributePaths = "userEntity")
     Page<BlackListEntity> findAllByExpiresAtLessThanEqualOrderByBannedDateTimeDesc(LocalDateTime now, Pageable pageable);
 
 }

--- a/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
+++ b/src/main/java/com/example/basketballmatching/game/repository/ParticipantGameRepository.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.game.domain.ParticipantGameEntity;
 import com.example.basketballmatching.game.type.ParticipantGameStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Optional;
 
 public interface ParticipantGameRepository extends JpaRepository<ParticipantGameEntity, Long> {
 
-    boolean existsByUserEntity_UserIdAndGameEntity_GameId(Long userId, Long gameId);
 
     boolean existsByGameEntity_GameIdAndUserEntity_UserIdAndParticipantGameStatus(
             Long gameId, Long userId, ParticipantGameStatus status
@@ -24,8 +24,7 @@ public interface ParticipantGameRepository extends JpaRepository<ParticipantGame
     Optional<ParticipantGameEntity> findByGameEntity_GameIdAndUserEntity_UserId(Long gameId, Long userId);
 
 
-    List<ParticipantGameEntity> findByUserEntity_UserIdAndParticipantGameStatusIn(Long userId, List<ParticipantGameStatus> statuses);
-
+    @EntityGraph(attributePaths = "userEntity")
     Page<ParticipantGameEntity> findByGameEntity_GameIdAndParticipantGameStatus(Long gameId, ParticipantGameStatus status, Pageable pageable);
 
 

--- a/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/basketballmatching/report/repository/ReportRepository.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.report.domain.ReportEntity;
 import com.example.basketballmatching.report.type.ReportStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
@@ -13,6 +14,11 @@ public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
     );
 
 
+    @EntityGraph(attributePaths = {
+            "gameEntity",
+            "reportUser",
+            "targetUser"
+    })
     Page<ReportEntity> findAllByReportStatusOrderByReportedDateTimeDesc(
             ReportStatus reportStatus, Pageable pageable
     );


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS

- 경기 참가자 목록 DTO 변환 과정에서 `userEntity`를 지연 로딩해 페이지 크기만큼 추가 SELECT가 발생
  - 참가자 20건 조회 시 SELECT 24회
- 관리자 블랙리스트 목록에서 제재 대상 사용자의 정보를 항목별로 조회
  - 블랙리스트 20건 조회 시 SELECT 23회
- 관리자 신고 목록에서 경기, 신고자, 신고 대상 연관관계에 대한 잠재적인 N+1 발생 가능성 존재
- 목록 조회별 로딩 전략과 N+1 개선 결과가 프로젝트 문서에 반영되지 않음
- `ParticipantGameRepository`에 사용되지 않는 조회 메서드가 남아 있었음

### 🚀 TO-BE

- Spring Data JPA 파생 쿼리를 유지하면서 필요한 연관관계만 조회하도록 `EntityGraph` 적용
  - 경기 참가자 목록: `userEntity`
  - 관리자 신고 목록: `gameEntity`, `reportUser`, `targetUser`
  - 관리자 블랙리스트 목록: `userEntity`
- 전역 `LAZY` 정책과 DB 페이지네이션을 유지하면서 요청당 쿼리 수를 상수로 고정
- 경기 참가자 20건 조회 SELECT를 `24회 → 4회`로 개선
- 관리자 블랙리스트 20건 조회 SELECT를 `23회 → 3회`로 개선
- 관리자 신고 20건 조회에서 SELECT 3회 유지 확인
  - 적용 전 데이터가 없는 측정은 유효한 기준선에서 제외
- 사용되지 않는 `ParticipantGameRepository` 조회 메서드 제거
- Fetch Join과 `EntityGraph` 선택 기준 및 N+1 개선 결과 문서화
  - 성능 테스트 README
  - 프로젝트 README
  - N+1 로딩 전략 ADR
  - 목록 조회 N+1 리팩터링 문서

---

## ✅ 체크리스트

- [x] 코드 빌드 및 테스트 통과
- [x] 주요 기능 동작 확인 (API 테스트, 통합 테스트 등)
- [x] 관련 문서(README, API 명세) 업데이트
- [x] 성능/보안/예외 처리 검토 완료

---